### PR TITLE
Improve windows and linux error handling

### DIFF
--- a/example/lib/home/home.dart
+++ b/example/lib/home/home.dart
@@ -62,7 +62,7 @@ class _MyAppState extends State<MyApp> {
     };
 
     UniversalBle.onScanResult = (result) {
-      debugPrint("${result.name} ${result.manufacturerData}");
+      // debugPrint("${result.name} ${result.manufacturerData}");
       int index = _scanResults.indexWhere((e) => e.deviceId == result.deviceId);
       if (index == -1) {
         _scanResults.add(result);

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -386,7 +386,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.9.1"
+    version: "0.9.2"
   vector_math:
     dependency: transitive
     description:

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -783,7 +783,7 @@ namespace universal_ble
     {
       int errorCode = err.code();
       std::cout << "WriteValueLog: " << winrt::to_string(err.message()) << " ErrorCode: " << std::to_string(errorCode) << std::endl;
-      result(FlutterError("WriteFailed", winrt::to_string(err.message())));
+      result(FlutterError(std::to_string(errorCode), winrt::to_string(err.message())));
     }
     catch (const std::exception &err)
     {

--- a/windows/src/universal_ble_plugin.h
+++ b/windows/src/universal_ble_plugin.h
@@ -120,6 +120,9 @@ namespace universal_ble
         winrt::fire_and_forget GetConnectedDevicesAsync(std::vector<std::string> with_services,
                                                         std::function<void(ErrorOr<flutter::EncodableList> reply)> result);
         winrt::fire_and_forget IsPairedAsync(std::string device_id, std::function<void(ErrorOr<bool> reply)> result);
+        winrt::fire_and_forget WriteAsync(GattCharacteristic characteristic, GattWriteOption writeOption,
+                                          const std::vector<uint8_t> &value,
+                                          std::function<void(std::optional<FlutterError> reply)> result);
 
         // UniversalBlePlatformChannel implementation.
         void GetBluetoothAvailabilityState(std::function<void(ErrorOr<int64_t> reply)> result) override;


### PR DESCRIPTION
## **Type**
bug_fix, enhancement


___

## **Description**
- Introduced a new `WriteAsync` method in the Windows plugin for better error handling and modern asynchronous programming with C++ coroutines.
- Enhanced error handling across Windows and Linux plugins to include specific error codes and messages.
- Reduced verbosity of debug logs in the example app by commenting out a debug print statement.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>universal_ble_plugin.cpp</strong><dd><code>Refactor Write Operations and Improve Error Handling in Windows Plugin</code></dd></summary>
<hr>

windows/src/universal_ble_plugin.cpp
<li>Refactored WriteValueAsync call into a new WriteAsync method using <br>modern C++ coroutines for better error handling.<br> <li> Improved error logging within WriteAsync to include specific error <br>codes.<br> <li> Enhanced GetConnectedDevicesAsync method with try-catch blocks for <br>robust error handling.


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/12/files#diff-c744a38517e9dcb9177126ffd1392b9decc2b53e55772d4270f4387a4f4c9357">+76/-44</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble_linux.dart</strong><dd><code>Implement Error Handling in Linux BLE Operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/universal_ble_linux/universal_ble_linux.dart
<li>Added error handling in readValue and writeValue methods to throw <br>PlatformException on failure.<br> <li> Implemented errorCode extension on BlueZFailedException to parse error <br>codes from exception messages.


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/12/files#diff-bd61ea0530e3e409336cd7d8a6d93c00911618355a9bf99fd1cf3d92cb6a02d9">+48/-13</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble_plugin.h</strong><dd><code>Declare New WriteAsync Method for Windows Plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

windows/src/universal_ble_plugin.h
- Declared the new WriteAsync method in the plugin header file.


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/12/files#diff-5e53d816e18b3a55d63090396aac40ab0c2159f0bf24d5ae5687d003c22c809f">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>home.dart</strong><dd><code>Reduce Debug Log Verbosity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example/lib/home/home.dart
- Commented out a debug print statement in the onScanResult callback.


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/12/files#diff-da1b5bdcb6f7b90bf5ad0c250e3af4c06567c23d1ebe6135325b8d30241a3838">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
