### PR TITLE
Fix windows crash when no bluetooth adapter available

### DIFF
--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -500,11 +500,19 @@ namespace universal_ble
 
   winrt::fire_and_forget UniversalBlePlugin::InitializeAsync()
   {
-    auto bluetoothAdapter = co_await BluetoothAdapter::GetDefaultAsync();
-    bluetoothRadio = co_await bluetoothAdapter.GetRadioAsync();
-    if (bluetoothRadio)
+    auto radios = co_await Radio::GetRadiosAsync();
+    for (auto &&radio : radios)
     {
-      radioStateChangedRevoker = bluetoothRadio.StateChanged(winrt::auto_revoke, {this, &UniversalBlePlugin::Radio_StateChanged});
+      if (radio.Kind() == RadioKind::Bluetooth)
+      {
+        bluetoothRadio = radio;
+        radioStateChangedRevoker = bluetoothRadio.StateChanged(winrt::auto_revoke, {this, &UniversalBlePlugin::Radio_StateChanged});
+        break;
+      }
+    }
+    if (!bluetoothRadio)
+    {
+      std::cout << "Bluetooth is not available" << std::endl;
     }
   }
 


### PR DESCRIPTION
## **Type**
bug_fix


___

## **Description**
- Improved Bluetooth radio detection to iterate through all available radios, fixing a crash when no Bluetooth adapter is present.
- Added a message output to the console if Bluetooth is not available, enhancing debuggability and user feedback.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>universal_ble_plugin.cpp</strong><dd><code>Improved Bluetooth Radio Detection and Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

windows/src/universal_ble_plugin.cpp
<li>Replaced direct Bluetooth adapter retrieval with a loop checking all <br>radios for a Bluetooth kind.<br> <li> Added a console output if no Bluetooth radio is available.


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/20/files#diff-c744a38517e9dcb9177126ffd1392b9decc2b53e55772d4270f4387a4f4c9357">+12/-4</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

