### PR TITLE
Update readme and improve logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.9.5
+* Windows support has graduated from beta to stable
+* Support filtering by manufacturer data
+* Unify web's optionalServices API with filtering API
+* Implement requestMtu in Linux 
+* Fix wrong manufacturer data in Windows release builds
+* Improve logging
+
 ## 0.9.4
 * Fix Windows crash when no Bluetooth adapter is present
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE
 
 ### API Support Matrix
 
-| API                  | Android | iOS | macOS | Windows (beta) | Linux (beta) | Web |
+| API                  | Android | iOS | macOS | Windows | Linux (beta) | Web |
 | :------------------- | :-----: | :-: | :---: | :------------: | :----------: | :-: |
 | startScan/stopScan   |   ✔️    | ✔️  |  ✔️   |       ✔️       |      ✔️      | ✔️  |
 | connect/disconnect   |   ✔️    | ✔️  |  ✔️   |       ✔️       |      ✔️      | ✔️  |

--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@ A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE
 ### API Support Matrix
 
 | API                  | Android | iOS | macOS | Windows | Linux (beta) | Web |
-| :------------------- | :-----: | :-: | :---: | :------------: | :----------: | :-: |
-| startScan/stopScan   |   ✔️    | ✔️  |  ✔️   |       ✔️       |      ✔️      | ✔️  |
-| connect/disconnect   |   ✔️    | ✔️  |  ✔️   |       ✔️       |      ✔️      | ✔️  |
-| getConnectedDevices  |   ✔️    | ✔️  |  ✔️   |       ✔️       |      ✔️      | ❌  |
-| discoverServices     |   ✔️    | ✔️  |  ✔️   |       ✔️       |      ✔️      | ✔️  |
-| readValue            |   ✔️    | ✔️  |  ✔️   |       ✔️       |      ✔️      | ✔️  |
-| writeValue           |   ✔️    | ✔️  |  ✔️   |       ✔️       |      ✔️      | ✔️  |
-| setNotifiable        |   ✔️    | ✔️  |  ✔️   |       ✔️       |      ✔️      | ✔️  |
-| pair/unPair          |   ✔️    | ❌  |  ❌   |       ✔️       |      ✔️      | ❌  |
-| onPairingStateChange |   ✔️    | ❌  |  ❌   |       ✔️       |      ✔️      | ❌  |
-| enableBluetooth      |   ✔️    | ❌  |  ❌   |       ✔️       |      ✔️      | ❌  |
-| onAvailabilityChange |   ✔️    | ✔️  |  ✔️   |       ✔️       |      ✔️      | ✔️  |
-| requestMtu           |   ✔️    | ✔️  |  ✔️   |       ✔️       |      ✔️      | ❌  |
+| :------------------- | :-----: | :-: | :---: | :-----: | :----------: | :-: |
+| startScan/stopScan   |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ✔️  |
+| connect/disconnect   |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ✔️  |
+| getConnectedDevices  |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ❌  |
+| discoverServices     |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ✔️  |
+| readValue            |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ✔️  |
+| writeValue           |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ✔️  |
+| setNotifiable        |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ✔️  |
+| pair/unPair          |   ✔️    | ❌  |  ❌   |   ✔️    |      ✔️      | ❌  |
+| onPairingStateChange |   ✔️    | ❌  |  ❌   |   ✔️    |      ✔️      | ❌  |
+| enableBluetooth      |   ✔️    | ❌  |  ❌   |   ✔️    |      ✔️      | ❌  |
+| onAvailabilityChange |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ✔️  |
+| requestMtu           |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ❌  |
 
 ## Getting Started
 
@@ -51,8 +51,6 @@ import 'package:universal_ble/universal_ble.dart';
 
 ### Scanning
 
-Before initiating a scan, ensure that Bluetooth is available. You can monitor the status of Bluetooth availability by referring to the [Bluetooth Availability](#bluetooth-availability) section.
-
 ```dart
 // Set a scan result handler
 UniversalBle.onScanResult = (scanResult) {
@@ -64,7 +62,10 @@ UniversalBle.startScan();
 
 // Or optionally add a scan filter
 UniversalBle.startScan(
-  scanFilter: ScanFilter()
+  scanFilter: ScanFilter(
+    withServices: ["SERVICE_UUID"],
+    withManufacturerData: ["ManufacturerDataFilters"]
+  )
 );
 
 // Stop scanning
@@ -228,6 +229,24 @@ Add the `Bluetooth` capability to the macOS app from Xcode.
 
 When publishing on Windows you need to declare the following [capabilities](https://learn.microsoft.com/en-us/windows/uwp/packaging/app-capability-declarations): `bluetooth, radios`
 
+Before initiating a scan, ensure that Bluetooth is available. You can monitor the status of Bluetooth availability by referring to the [Bluetooth Availability](#bluetooth-availability) section.
+
+```dart
+AvailabilityState state = await UniversalBle.getBluetoothAvailabilityState()
+// Start scan only if Bluetooth is powered on
+if (state != AvailabilityState.poweredOn) {
+  UniversalBle.startScan();
+}
+
+// Or listen to bluetooth availability change
+UniversalBle.onAvailabilityChange = (state) {
+  // Handle if already scanning, or other cases
+  if (state == AvailabilityState.poweredOn) {
+    UniversalBle.startScan();
+  }
+};
+```
+
 ## Customizing Platform Implementation of UniversalBle
 
 ```dart
@@ -237,8 +256,4 @@ class UniversalBleMock extends UniversalBlePlatform {
 }
 
 UniversalBle.setInstance(UniversalBleMock());
-```
-
-```
-
 ```

--- a/README.md
+++ b/README.md
@@ -106,9 +106,7 @@ You can optionally set filters when scanning.
 
 ##### With Services
 
-When setting this parameter, the scan results will only include devices that advertize any of the specified services. This is the primary filter. All devices are first filtered by services, then further filtered by other criteria.
-
-On web, the `withServices` parameter is used as [optional_services](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice#optionalservices) as well as a services filter. You have to set this parameter on web to ensure that you can access the specified services after connecting to the device.
+When setting this parameter, the scan results will only include devices that advertize any of the specified services. This is the primary filter. All devices are first filtered by services, then further filtered by other criteria. This parameter is mandatory on [web](#web) if you want to access those services.
 
 ```dart
 List<String> withServices;
@@ -250,6 +248,16 @@ Add the `Bluetooth` capability to the macOS app from Xcode.
 ### Windows
 
 When publishing on Windows you need to declare the following [capabilities](https://learn.microsoft.com/en-us/windows/uwp/packaging/app-capability-declarations): `bluetooth, radios`
+
+### Web
+
+On web, the `withServices` parameter in the ScanFilter is used as [optional_services](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice#optionalservices) as well as a services filter. On web you have to set this parameter to ensure that you can access the specified services after connecting to the device. You can leave it empty for the rest of the platforms if your device does not advertize services.
+
+```dart
+ScanFilter(
+      withServices: kIsWeb ?  ["SERVICE_UUID"] : [],
+)
+```
 
 ## Customizing Platform Implementation of UniversalBle
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ UniversalBle.startScan();
 UniversalBle.startScan(
   scanFilter: ScanFilter(
     withServices: ["SERVICE_UUID"],
-    withManufacturerData: ["ManufacturerDataFilters"]
+    withManufacturerData: ["MANUFACTURER_DATA"]
   )
 );
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ import 'package:universal_ble/universal_ble.dart';
 
 ### Scanning
 
+Before initiating a scan, ensure that Bluetooth is available. You can monitor the status of Bluetooth availability by referring to the [Bluetooth Availability](#bluetooth-availability) section.
+
 ```dart
 // Set a scan result handler
 UniversalBle.onScanResult = (scanResult) {
@@ -62,9 +64,7 @@ UniversalBle.startScan();
 
 // Or optionally add a scan filter
 UniversalBle.startScan(
-  scanFilter: ScanFilter(
-      withServices: ["SERVICE_UUID"],
-  )
+  scanFilter: ScanFilter()
 );
 
 // Stop scanning
@@ -77,6 +77,26 @@ You can list those devices using `getConnectedDevices()`. You still need to expl
 ```dart
 // You can set `withServices` to narrow down the results
 await UniversalBle.getConnectedDevices(withServices: []);
+```
+
+## Scan Filters
+
+### withServices:
+
+This is the primary filter. All devices are first filtered by services, then further filtered by other criteria.
+
+On Web, the `withServices` property is used as [optional_services](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice#optionalservices) as well as a services filter. It is recommended to use this property on the web to ensure that you can use the specified services after connecting to the device.
+
+```dart
+List<String> withServices;
+```
+
+### withManufacturerData
+
+Use the `withManufacturerData` property to filter devices by manufacturer data. When you pass a list of `ManufacturerDataFilter` objects to this property, the scan results will only include devices that contain any of the specified manufacturer data.
+
+```dart
+List<ManufacturerDataFilter> withManufacturerData;
 ```
 
 ### Connecting
@@ -208,18 +228,6 @@ Add the `Bluetooth` capability to the macOS app from Xcode.
 
 When publishing on Windows you need to declare the following [capabilities](https://learn.microsoft.com/en-us/windows/uwp/packaging/app-capability-declarations): `bluetooth, radios`
 
-### Web
-`
-On web, you have to add filters and specify optional services when scanning for devices. The parameter is ignored on other platforms.
-
-```dart
-UniversalBle.startScan(
-  webRequestOptions: WebRequestOptionsBuilder.acceptAllDevices(
-    optionalServices: ["SERVICE_UUID"],
-  ),
-);
-```
-
 ## Customizing Platform Implementation of UniversalBle
 
 ```dart
@@ -229,4 +237,8 @@ class UniversalBleMock extends UniversalBlePlatform {
 }
 
 UniversalBle.setInstance(UniversalBleMock());
+```
+
+```
+
 ```

--- a/README.md
+++ b/README.md
@@ -72,6 +72,26 @@ UniversalBle.startScan(
 UniversalBle.stopScan();
 ```
 
+Before initiating a scan, ensure that Bluetooth is available:
+```dart
+AvailabilityState state = await UniversalBle.getBluetoothAvailabilityState()
+// Start scan only if Bluetooth is powered on
+if (state != AvailabilityState.poweredOn) {
+  UniversalBle.startScan();
+}
+
+// Or listen to bluetooth availability changes
+UniversalBle.onAvailabilityChange = (state) {
+  if (state == AvailabilityState.poweredOn) {
+    UniversalBle.startScan();
+  }
+};
+```
+
+See the [Bluetooth Availability](#bluetooth-availability) section for more.
+
+#### Connected Devices
+
 Already connected devices, either through previous sessions or connected through system settings, won't show up as scan results.
 You can list those devices using `getConnectedDevices()`. You still need to explicitly connect before using them.
 
@@ -80,11 +100,13 @@ You can list those devices using `getConnectedDevices()`. You still need to expl
 await UniversalBle.getConnectedDevices(withServices: []);
 ```
 
-## Scan Filters
+#### Scan Filter
 
-### withServices
+You can optionally set filters when scanning.
 
-This is the primary filter. All devices are first filtered by services, then further filtered by other criteria.
+##### With Services
+
+When setting this parameter, the scan results will only include devices that advertize any of the specified services. This is the primary filter. All devices are first filtered by services, then further filtered by other criteria.
 
 On web, the `withServices` parameter is used as [optional_services](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice#optionalservices) as well as a services filter. You have to set this parameter on web to ensure that you can access the specified services after connecting to the device.
 
@@ -92,7 +114,7 @@ On web, the `withServices` parameter is used as [optional_services](https://deve
 List<String> withServices;
 ```
 
-### withManufacturerData
+##### With ManufacturerData
 
 Use the `withManufacturerData` parameter to filter devices by manufacturer data. When you pass a list of `ManufacturerDataFilter` objects to this parameter, the scan results will only include devices that contain any of the specified manufacturer data.
 
@@ -228,24 +250,6 @@ Add the `Bluetooth` capability to the macOS app from Xcode.
 ### Windows
 
 When publishing on Windows you need to declare the following [capabilities](https://learn.microsoft.com/en-us/windows/uwp/packaging/app-capability-declarations): `bluetooth, radios`
-
-Before initiating a scan, ensure that Bluetooth is available. You can monitor the status of Bluetooth availability by referring to the [Bluetooth Availability](#bluetooth-availability) section.
-
-```dart
-AvailabilityState state = await UniversalBle.getBluetoothAvailabilityState()
-// Start scan only if Bluetooth is powered on
-if (state != AvailabilityState.poweredOn) {
-  UniversalBle.startScan();
-}
-
-// Or listen to bluetooth availability change
-UniversalBle.onAvailabilityChange = (state) {
-  // Handle if already scanning, or other cases
-  if (state == AvailabilityState.poweredOn) {
-    UniversalBle.startScan();
-  }
-};
-```
 
 ## Customizing Platform Implementation of UniversalBle
 

--- a/example/lib/home/home.dart
+++ b/example/lib/home/home.dart
@@ -75,18 +75,12 @@ class _MyAppState extends State<MyApp> {
       scanFilter: ScanFilter(
         withServices: kIsWeb ? _services : [],
         withManufacturerData: [
-          ManufacturerDataFilter(
-            companyIdentifier: 0x012D,
-            data: Uint8List.fromList(
-              [0x03, 0x00, 0x64, 0x00],
-            ),
-          ),
-          ManufacturerDataFilter(
-            companyIdentifier: 0x012D,
-            data: Uint8List.fromList(
-              [0x03, 0x00, 0x65, 0x00],
-            ),
-          ),
+          // ManufacturerDataFilter(
+          //   companyIdentifier: 0x012D,
+          //   data: Uint8List.fromList(
+          //     [0x03, 0x00, 0x64, 0x00],
+          //   ),
+          // ),
         ],
       ),
     );

--- a/lib/src/universal_ble_web/universal_ble_web.dart
+++ b/lib/src/universal_ble_web/universal_ble_web.dart
@@ -113,7 +113,7 @@ class UniversalBleWeb extends UniversalBlePlatform {
   }) async {
     if (scanFilter == null || scanFilter.withServices.isEmpty) {
       UniversalBlePlatform.logInfo(
-        "Error: services list empty. On web you have to specify services in the ScanFilter in order to be able to access those after connecting",
+        "Service list empty: on web you have to specify services in the ScanFilter in order to be able to access those after connecting",
         isError: true,
       );
     }

--- a/lib/src/universal_ble_web/universal_ble_web.dart
+++ b/lib/src/universal_ble_web/universal_ble_web.dart
@@ -111,6 +111,13 @@ class UniversalBleWeb extends UniversalBlePlatform {
   Future<void> startScan({
     ScanFilter? scanFilter,
   }) async {
+    if (scanFilter == null || scanFilter.withServices.isEmpty) {
+      UniversalBlePlatform.logInfo(
+        "It is recommended to use ScanFilter.withServices on the web to ensure the specified services can be used after connecting",
+        isError: true,
+      );
+    }
+
     BluetoothDevice device = await FlutterWebBluetooth.instance.requestDevice(
       scanFilter?.toRequestOptionsBuilder() ??
           RequestOptionsBuilder.acceptAllDevices(),

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -16,7 +16,7 @@ FetchContent_Declare(nuget
 find_program(NUGET nuget)
 
 if(NOT NUGET)
-  message("Nuget.exe not found, trying to download or use cached version.")
+  # message("Nuget.exe not found, trying to download or use cached version.")
   FetchContent_MakeAvailable(nuget)
   set(NUGET ${nuget_SOURCE_DIR}/nuget.exe)
 endif()


### PR DESCRIPTION
## **Type**
enhancement, documentation


___

## **Description**
- Simplified the Bluetooth scan filter by commenting out `ManufacturerDataFilter` usage.
- Added a warning log for web scans without `ScanFilter` or empty `withServices`.
- Updated README with new sections on ensuring Bluetooth availability and detailed Scan Filters usage.
- Removed outdated web scanning instructions from README.
- Silenced the warning message for missing Nuget.exe in CMakeLists.txt for Windows.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>home.dart</strong><dd><code>Simplify Bluetooth Scan Filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example/lib/home/home.dart
<li>Commented out <code>ManufacturerDataFilter</code> usage in the Bluetooth scan <br>filter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/28/files#diff-da1b5bdcb6f7b90bf5ad0c250e3af4c06567c23d1ebe6135325b8d30241a3838">+6/-12</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble_web.dart</strong><dd><code>Improve ScanFilter Validation and Logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/universal_ble_web/universal_ble_web.dart
<li>Added a log warning when <code>ScanFilter</code> is null or <code>withServices</code> is empty <br>during a scan on the web.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/28/files#diff-dc72e700f7c098e3f4e71b5d1f38c8514d3007af606d0fd15b1e5f0ecbd580cd">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CMakeLists.txt</strong><dd><code>Silence Missing Nuget.exe Warning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

windows/CMakeLists.txt
<li>Commented out the message for missing Nuget.exe, opting for silent <br>handling.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/28/files#diff-67b8036ebec555bc48b9ed2fdf146e80ebfea01c32d9daec8d3aa70a70ec1b1f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README with Improved Scanning Instructions and Scan Filters </code><br><code>Section</code></dd></summary>
<hr>

README.md
<li>Added instructions on ensuring Bluetooth availability before scanning.<br> <li> Simplified the example for adding a scan filter.<br> <li> Added a new section on Scan Filters, explaining <code>withServices</code> and <br><code>withManufacturerData</code>.<br> <li> Removed outdated web-specific instructions for scanning.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/28/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+27/-15</a>&nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

