### PR TITLE
Fix discover services on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.6
+* Fix a Windows issue where characteristics of certain services would not be discovered
+* Improve readme
+
 ## 0.9.5
 * Windows support has graduated from beta to stable
 * Support filtering by manufacturer data

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: universal_ble
 description: A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE) plugin for Flutter
-version: 0.9.5
+version: 0.9.6
 homepage: https://navideck.com
 repository: https://github.com/Navideck/universal_ble
 issue_tracker: https://github.com/Navideck/universal_ble/issues

--- a/windows/src/universal_ble_plugin.h
+++ b/windows/src/universal_ble_plugin.h
@@ -111,7 +111,7 @@ namespace universal_ble
         winrt::fire_and_forget ConnectAsync(uint64_t bluetoothAddress);
         void BluetoothLEDevice_ConnectionStatusChanged(BluetoothLEDevice sender, IInspectable args);
         void CleanConnection(uint64_t bluetoothAddress);
-        winrt::fire_and_forget DiscoverServicesAsync(BluetoothDeviceAgent &bluetoothDeviceAgent, std::function<void(ErrorOr<flutter::EncodableList> reply)>);
+        void DiscoverServicesAsync(BluetoothDeviceAgent &bluetoothDeviceAgent, std::function<void(ErrorOr<flutter::EncodableList> reply)>);
         winrt::fire_and_forget SetNotifiableAsync(BluetoothDeviceAgent &bluetoothDeviceAgent, const std::string &service,
                                                   const std::string &characteristic, GattClientCharacteristicConfigurationDescriptorValue descriptorValue);
         void GattCharacteristic_ValueChanged(GattCharacteristic sender, GattValueChangedEventArgs args);


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Changed `DiscoverServicesAsync` method to improve performance and code readability:
  - Transitioned from asynchronous to synchronous execution.
  - Directly accessed GATT services and characteristics from a cached map, enhancing efficiency.
  - Simplified the parsing of characteristic properties, reducing code complexity.
- Updated method signature in the header file to match the implementation changes.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>universal_ble_plugin.cpp</strong><dd><code>Optimize Service Discovery and Characteristic Properties Parsing</code></dd></summary>
<hr>

windows/src/universal_ble_plugin.cpp
<li>Changed <code>DiscoverServicesAsync</code> from <code>winrt::fire_and_forget</code> to <code>void</code>.<br> <li> Optimized service discovery by utilizing <br><code>bluetoothDeviceAgent.gatt_map_</code> directly.<br> <li> Streamlined characteristic properties parsing and removed redundant <br>code.


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/32/files#diff-c744a38517e9dcb9177126ffd1392b9decc2b53e55772d4270f4387a4f4c9357">+40/-54</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble_plugin.h</strong><dd><code>Update DiscoverServicesAsync Signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

windows/src/universal_ble_plugin.h
<li>Updated <code>DiscoverServicesAsync</code> signature to reflect the change from <br><code>winrt::fire_and_forget</code> to <code>void</code>.


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/32/files#diff-5e53d816e18b3a55d63090396aac40ab0c2159f0bf24d5ae5687d003c22c809f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

