### PR TITLE
Improve manufacturer data discovery on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.8
+* Improve manufacturer data discovery on Windows
+* Example app improvements
+
 ## 0.9.7
 * Fix characteristic keying on linux allowing receiving data from multiple BLE devices at the same time
 

--- a/example/lib/home/widgets/scanned_item_widget.dart
+++ b/example/lib/home/widgets/scanned_item_widget.dart
@@ -22,13 +22,13 @@ class ScannedItemWidget extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(scanResult.deviceId),
-              // Show manufacturer data only on web and desktop
               Visibility(
-                visible: (Platform.isWeb || Platform.isDesktop) &&
-                    scanResult.manufacturerData?.isNotEmpty == true,
+                visible: scanResult.manufacturerData?.isNotEmpty == true,
                 child: Text(
-                  ManufacturerData.fromData(scanResult.manufacturerData!)
-                      .toString(),
+                  Platform.isWeb || Platform.isDesktop
+                      ? ManufacturerData.fromData(scanResult.manufacturerData!)
+                          .toString()
+                      : 'ManufacturerCompanyId: ${ManufacturerData.fromData(scanResult.manufacturerData!).companyIdRadix16}',
                 ),
               ),
               Visibility(

--- a/example/lib/peripheral_details/peripheral_detail_page.dart
+++ b/example/lib/peripheral_details/peripheral_detail_page.dart
@@ -56,7 +56,7 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
 
   void _addLog(String type, dynamic data) {
     setState(() {
-      _logs.add('$type : ${data.toString()}');
+      _logs.add('$type: ${data.toString()}');
     });
   }
 
@@ -85,7 +85,7 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
   void _handlePairingStateChange(
       String deviceId, bool isPaired, String? error) {
     print('OnPairStateChange $deviceId, $isPaired');
-    if (error != null) {
+    if (error != null && error.isNotEmpty) {
       _addLog("PairStateChangeError", "(Paired: $isPaired): $error ");
     } else {
       _addLog("PairStateChange", isPaired);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: universal_ble
 description: A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE) plugin for Flutter
-version: 0.9.7
+version: 0.9.8
 homepage: https://navideck.com
 repository: https://github.com/Navideck/universal_ble
 issue_tracker: https://github.com/Navideck/universal_ble/issues

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -411,6 +411,7 @@ namespace universal_ble
       auto customPairing = deviceInformation.Pairing().Custom();
       winrt::event_token token = customPairing.PairingRequested([this](const Enumeration::DeviceInformationCustomPairing &sender, const Enumeration::DevicePairingRequestedEventArgs &eventArgs)
                                                                 {
+                                                                  std::cout << "PairLog: Pairing requested" << std::endl;
                                                                 // eventArgs.AcceptWithPasswordCredential(nullptr, nullptr);
                                                                 // eventArgs.Pin();
                                                                 // Accept all pairing request
@@ -420,7 +421,7 @@ namespace universal_ble
       std::cout << "PairLog: Trying to pair" << std::endl;
       auto async_c = customPairing.PairAsync(
           Enumeration::DevicePairingKinds::ConfirmOnly,
-          Enumeration::DevicePairingProtectionLevel::None);
+          Enumeration::DevicePairingProtectionLevel::Encryption);
       async_c.Completed([this, customPairing, token, device_id](IAsyncOperation<DevicePairingResult> const &sender, AsyncStatus const args)
                         {
                           auto result = sender.GetResults();

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -420,8 +420,7 @@ namespace universal_ble
       // DevicePairingProtectionLevel =>  Default, None, Encryption, EncryptionAndAuthentication
       std::cout << "PairLog: Trying to pair" << std::endl;
       auto async_c = customPairing.PairAsync(
-          Enumeration::DevicePairingKinds::ConfirmOnly,
-          Enumeration::DevicePairingProtectionLevel::Encryption);
+          Enumeration::DevicePairingKinds::ConfirmOnly);
       async_c.Completed([this, customPairing, token, device_id](IAsyncOperation<DevicePairingResult> const &sender, AsyncStatus const args)
                         {
                           auto result = sender.GetResults();

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -549,7 +549,7 @@ namespace universal_ble
 
   // Send device to callback channel
   // if device is already discovered in deviceWatcher then merge the scan result
-  void UniversalBlePlugin::pushUniversalScanResult(UniversalBleScanResult scanResult)
+  void UniversalBlePlugin::pushUniversalScanResult(UniversalBleScanResult scanResult, bool isConnectable)
   {
     auto it = scanResults.find(scanResult.device_id());
     if (it != scanResults.end())
@@ -590,8 +590,11 @@ namespace universal_ble
       scanResults.insert(std::make_pair(scanResult.device_id(), scanResult));
     }
 
-    uiThreadHandler_.Post([scanResult]
-                          { callbackChannel->OnScanResult(scanResult, SuccessCallback, ErrorCallback); });
+    if (isConnectable)
+    {
+      uiThreadHandler_.Post([scanResult]
+                            { callbackChannel->OnScanResult(scanResult, SuccessCallback, ErrorCallback); });
+    }
   }
 
   void UniversalBlePlugin::setupDeviceWatcher()
@@ -690,7 +693,7 @@ namespace universal_ble
         universalScanResult.set_rssi(rssi);
       }
 
-      pushUniversalScanResult(universalScanResult);
+      pushUniversalScanResult(universalScanResult, true);
     }
   }
 
@@ -699,10 +702,6 @@ namespace universal_ble
   {
     try
     {
-      // Avoid devices if they are not connectable
-      if (!args.IsConnectable())
-        return;
-
       // Apply ManufacturerData filter
       if (!manufacturerScanFilter.empty())
       {
@@ -717,6 +716,7 @@ namespace universal_ble
       auto deviceId = _mac_address_to_str(args.BluetoothAddress());
       auto universalScanResult = UniversalBleScanResult(deviceId);
       std::string name = winrt::to_string(args.Advertisement().LocalName());
+      auto manufacturerData = parseManufacturerDataHead(args.Advertisement(), deviceId);
 
       auto dataSection = args.Advertisement().DataSections();
       for (auto &&data : dataSection)
@@ -737,8 +737,9 @@ namespace universal_ble
       if (!name.empty())
         universalScanResult.set_name(name);
 
-      auto manufacturerData = parseManufacturerDataHead(args.Advertisement(), deviceId);
-      universalScanResult.set_manufacturer_data_head(manufacturerData);
+      if (!manufacturerData.empty())
+        universalScanResult.set_manufacturer_data_head(manufacturerData);
+
       universalScanResult.set_rssi(args.RawSignalStrengthInDBm());
 
       // Add services
@@ -765,7 +766,7 @@ namespace universal_ble
           universalScanResult.set_name(winrt::to_string(deviceInfo.Name()));
       }
 
-      pushUniversalScanResult(universalScanResult);
+      pushUniversalScanResult(universalScanResult, args.IsConnectable());
     }
     catch (...)
     {

--- a/windows/src/universal_ble_plugin.h
+++ b/windows/src/universal_ble_plugin.h
@@ -101,7 +101,7 @@ namespace universal_ble
 
         void setupDeviceWatcher();
         void disposeDeviceWatcher();
-        void pushUniversalScanResult(UniversalBleScanResult scanResult,bool isConnectable);
+        void pushUniversalScanResult(UniversalBleScanResult scanResult, bool isConnectable);
         void BluetoothLEWatcher_Received(BluetoothLEAdvertisementWatcher sender, BluetoothLEAdvertisementReceivedEventArgs args);
         void onDeviceInfoReceived(DeviceInformation deviceInfo);
 

--- a/windows/src/universal_ble_plugin.h
+++ b/windows/src/universal_ble_plugin.h
@@ -101,7 +101,7 @@ namespace universal_ble
 
         void setupDeviceWatcher();
         void disposeDeviceWatcher();
-        void pushUniversalScanResult(UniversalBleScanResult scanResult);
+        void pushUniversalScanResult(UniversalBleScanResult scanResult,bool isConnectable);
         void BluetoothLEWatcher_Received(BluetoothLEAdvertisementWatcher sender, BluetoothLEAdvertisementReceivedEventArgs args);
         void onDeviceInfoReceived(DeviceInformation deviceInfo);
 


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Added a new parameter `isConnectable` to the `pushUniversalScanResult` function to enhance filtering of BLE devices based on their connectability.
- Updated calls to `pushUniversalScanResult` throughout the code to pass the `isConnectable` flag, improving the management of BLE device discovery.
- Modified the `BluetoothLEWatcher_Received` method to include parsing and conditional handling of manufacturer data based on device connectability.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>universal_ble_plugin.cpp</strong><dd><code>Enhance BLE Scan Result Handling with Connectability Check</code></dd></summary>
<hr>

windows/src/universal_ble_plugin.cpp
<li>Added a new parameter <code>isConnectable</code> to <code>pushUniversalScanResult</code> to <br>filter non-connectable devices.<br> <li> Modified the function call to <code>pushUniversalScanResult</code> to include the <br><code>isConnectable</code> parameter.<br> <li> Updated the <code>BluetoothLEWatcher_Received</code> method to process manufacturer <br>data and conditionally push scan results based on connectability.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/38/files#diff-c744a38517e9dcb9177126ffd1392b9decc2b53e55772d4270f4387a4f4c9357">+12/-11</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble_plugin.h</strong><dd><code>Update Function Signature for Connectability Enhancement</code>&nbsp; </dd></summary>
<hr>

windows/src/universal_ble_plugin.h
<li>Updated the declaration of <code>pushUniversalScanResult</code> to include the new <br><code>isConnectable</code> parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/38/files#diff-5e53d816e18b3a55d63090396aac40ab0c2159f0bf24d5ae5687d003c22c809f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

