### PR TITLE
Remove dependency on collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 * Fix Windows scan filter
 * Improve service discovery on Linux
 * Use asynchronous callbacks for SetNotifiable
+* Remove dependency on `convert`
+* Remove dependency on `collection`
+* Update Android example app Gradle
 
 ## 0.9.9
 * Improve service discovery on Apple

--- a/lib/src/universal_ble_linux/universal_ble_linux.dart
+++ b/lib/src/universal_ble_linux/universal_ble_linux.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:bluez/bluez.dart';
-import 'package:collection/collection.dart';
 import 'package:flutter/services.dart';
 import 'package:universal_ble/src/models/model_exports.dart';
 import 'package:universal_ble/src/universal_ble_platform_interface.dart';
@@ -148,9 +147,11 @@ class UniversalBleLinux extends UniversalBlePlatform {
       String deviceId, String service, String characteristic) {
     final device = _findDeviceById(deviceId);
     final s = device.gattServices
-        .firstWhereOrNull((s) => s.uuid.toString() == service);
-    final c = s?.characteristics
-        .firstWhereOrNull((c) => c.uuid.toString() == characteristic);
+        .cast<BlueZGattService?>()
+        .firstWhere((s) => s?.uuid.toString() == service, orElse: () => null);
+    final c = s?.characteristics.cast<BlueZGattCharacteristic?>().firstWhere(
+        (c) => c?.uuid.toString() == characteristic,
+        orElse: () => null);
 
     if (c == null) {
       throw Exception('Unknown characteristic:$characteristic');
@@ -306,8 +307,9 @@ class UniversalBleLinux extends UniversalBlePlatform {
 
   BlueZDevice _findDeviceById(String deviceId) {
     final device = _devices[deviceId] ??
-        _client.devices
-            .firstWhereOrNull((device) => device.address == deviceId);
+        _client.devices.cast<BlueZDevice?>().firstWhere(
+            (device) => device?.address == deviceId,
+            orElse: () => null);
     if (device == null) {
       throw Exception('Unknown deviceId:$deviceId');
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.6
-  collection: ^1.17.2
   flutter_web_bluetooth: ^0.2.2
   bluez: ^0.8.2
 


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Removed the import of the `collection` package to reduce dependencies and potentially improve performance.
- Refactored the `_getCharacteristic` and `_findDeviceById` methods to use native Dart list handling (`cast` and `firstWhere`) instead of relying on the `collection` package's `firstWhereOrNull`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>universal_ble_linux.dart</strong><dd><code>Remove `collection` dependency and refactor method implementations</code></dd></summary>
<hr>

lib/src/universal_ble_linux/universal_ble_linux.dart
<li>Removed dependency on <code>collection</code> package by deleting its import.<br> <li> Updated <code>_getCharacteristic</code> and <code>_findDeviceById</code> methods to use <code>cast</code> and <br><code>firstWhere</code> with <code>orElse</code> instead of <code>firstWhereOrNull</code>.


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/43/files#diff-bd61ea0530e3e409336cd7d8a6d93c00911618355a9bf99fd1cf3d92cb6a02d9">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

