### PR TITLE
Add queue per device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.12
+* Add .perDevice queue
+* Improve code level documentation
+
 ## 0.9.11
 * Add device name prefix filtering
 

--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ UniversalBle.connect(deviceId);
 // Disconnect from a device
 UniversalBle.disconnect(deviceId);
 
-// Get notified for connection state changes
+// Get connection state updates
 UniversalBle.onConnectionChanged = (String deviceId, BleConnectionState state) {
-  print('OnConnectionChanged $deviceId, $state');
+  debugPrint('OnConnectionChanged $deviceId, $state');
 }
 ```
 
@@ -168,7 +168,7 @@ UniversalBle.setNotifiable(deviceId, serviceId, characteristicId, BleInputProper
 
 // Get characteristic updates in `onValueChanged`
 UniversalBle.onValueChanged = (String deviceId, String characteristicId, Uint8List value) {
-  print('onValueChanged $deviceId, $characteristicId, ${hex.encode(value)}');
+  debugPrint('onValueChanged $deviceId, $characteristicId, ${hex.encode(value)}');
 }
 
 // Unsubscribe from a characteristic
@@ -210,11 +210,31 @@ UniversalBle.enableBluetooth();
 
 ## Command Queue
 
-By default, all commands are executed in a queue, with each command waiting for the previous one to finish. This is because some platforms (e.g. Android) may fail to send consecutive commands without a delay between them. Therefore, it is a good idea to leave the queue enabled.
+By default, all commands are executed in a global queue (`QueueType.global`), with each command waiting for the previous one to finish.
+
+If you want to parallelize commands between multiple devices, you can set:
+
+```dart
+// Create a separate queue for each device. 
+UniversalBle.queueType = QueueType.perDevice;
+```
+
+You can also disable the queue completely and parallelize all commands, even for the same device, by using:
 
 ```dart
 // Disable queue
-UniversalBle.queuesCommands = false;
+UniversalBle.queueType = QueueType.none;
+```
+
+Keep in mind that some platforms (e.g. Android) may not handle well devices that fail to process consecutive commands without a minimum interval. Therefore, it is not advised to set `queueType` to `none`.
+
+You can get queue updates by setting:
+
+```dart
+// Get queue state updates
+UniversalBle.onQueueUpdate = (String id, int remainingItems) {
+  debugPrint("Queue: $id Remaining: $remainingItems");
+};
 ```
 
 ## Timeout

--- a/example/lib/home/home.dart
+++ b/example/lib/home/home.dart
@@ -22,7 +22,7 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   final _scanResults = <BleScanResult>[];
   bool _isScanning = false;
-  bool _isQueueEnabled = true;
+  QueueType _queueType = QueueType.global;
 
   AvailabilityState? bleAvailabilityState;
   final List<String> _services = [
@@ -45,7 +45,7 @@ class _MyAppState extends State<MyApp> {
     }
 
     /// Setup queue and timeout
-    UniversalBle.queuesCommands = _isQueueEnabled;
+    UniversalBle.queuesCommands = _queueType;
     UniversalBle.timeout = const Duration(seconds: 10);
 
     UniversalBle.onAvailabilityChange = (state) {
@@ -68,6 +68,10 @@ class _MyAppState extends State<MyApp> {
       }
       setState(() {});
     };
+
+    // UniversalBle.onQueueUpdate = (String id, int remainingItems) {
+    //   debugPrint("Queue: $id RemainingItems: $remainingItems");
+    // };
   }
 
   Future<void> startScan() async {
@@ -184,11 +188,15 @@ class _MyAppState extends State<MyApp> {
                     },
                   ),
                 PlatformButton(
-                  text: _isQueueEnabled ? 'Disable Queue' : 'Enable Queue',
+                  text: 'Queue: ${_queueType.name.toUpperCase()}',
                   onPressed: () {
                     setState(() {
-                      _isQueueEnabled = !_isQueueEnabled;
-                      UniversalBle.queuesCommands = _isQueueEnabled;
+                      _queueType = switch (_queueType) {
+                        QueueType.global => QueueType.perDevice,
+                        QueueType.perDevice => QueueType.none,
+                        QueueType.none => QueueType.global,
+                      };
+                      UniversalBle.queuesCommands = _queueType;
                     });
                   },
                 ),

--- a/example/lib/home/home.dart
+++ b/example/lib/home/home.dart
@@ -45,7 +45,7 @@ class _MyAppState extends State<MyApp> {
     }
 
     /// Setup queue and timeout
-    UniversalBle.queuesCommands = _queueType;
+    UniversalBle.queueType = _queueType;
     UniversalBle.timeout = const Duration(seconds: 10);
 
     UniversalBle.onAvailabilityChange = (state) {
@@ -196,7 +196,7 @@ class _MyAppState extends State<MyApp> {
                         QueueType.perDevice => QueueType.none,
                         QueueType.none => QueueType.global,
                       };
-                      UniversalBle.queuesCommands = _queueType;
+                      UniversalBle.queueType = _queueType;
                     });
                   },
                 ),

--- a/lib/src/ble_command_queue.dart
+++ b/lib/src/ble_command_queue.dart
@@ -1,7 +1,7 @@
 import 'package:universal_ble/src/queue.dart';
 import 'package:universal_ble/universal_ble.dart';
 
-/// Execute Commands in queue, and manage queue per device
+/// Execute commands in queue and manage queue per device
 class BleCommandQueue {
   QueueType queueType = QueueType.global;
   Duration? timeout = const Duration(seconds: 10);

--- a/lib/src/models/model_exports.dart
+++ b/lib/src/models/model_exports.dart
@@ -1,3 +1,4 @@
+export 'package:universal_ble/src/models/queue_type.dart';
 export 'package:universal_ble/src/models/uuid.dart';
 export 'package:universal_ble/src/models/scan_filter.dart';
 export 'package:universal_ble/src/models/ble_property.dart';
@@ -5,3 +6,5 @@ export 'package:universal_ble/src/models/ble_service.dart';
 export 'package:universal_ble/src/models/availability_state.dart';
 export 'package:universal_ble/src/models/ble_connection_state.dart';
 export 'package:universal_ble/src/models/ble_scan_result.dart';
+
+

--- a/lib/src/models/queue_type.dart
+++ b/lib/src/models/queue_type.dart
@@ -1,0 +1,5 @@
+enum QueueType {
+  none,
+  perDevice,
+  global,
+}

--- a/lib/src/queue.dart
+++ b/lib/src/queue.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+
+/// Original Author: Ryan Knell (https://github.com/rknell/dart_queue)
+
+/// Queue to execute Futures in order.
+/// It awaits each future before executing the next one.
+class Queue {
+  final Set<int> _activeItems = {};
+  int _lastProcessId = 0;
+  bool _isCancelled = false;
+  final List<_QueuedFuture> _nextCycle = [];
+  Function(int)? onRemainingItemsUpdate;
+
+  Future<T> add<T>(Future<T> Function() closure, {Duration? timeout}) {
+    if (_isCancelled) throw Exception('Queue Cancelled');
+    final completer = Completer<T>();
+    _nextCycle.add(_QueuedFuture<T>(closure, completer, timeout));
+    _updateRemainingItems();
+    if (_activeItems.isEmpty) _queueUpNext();
+    return completer.future;
+  }
+
+  void dispose() {
+    for (final item in _nextCycle) {
+      item.completer.completeError(Exception('Queue Cancelled'));
+    }
+    _nextCycle.removeWhere((item) => item.completer.isCompleted);
+    _isCancelled = true;
+  }
+
+  void _queueUpNext() {
+    if (_nextCycle.isNotEmpty && !_isCancelled && _activeItems.length <= 1) {
+      final processId = _lastProcessId;
+      _activeItems.add(processId);
+      final item = _nextCycle.first;
+      _lastProcessId++;
+      _nextCycle.remove(item);
+      item.onComplete = () async {
+        _activeItems.remove(processId);
+        _updateRemainingItems();
+        _queueUpNext();
+      };
+      unawaited(item.execute());
+    }
+  }
+
+  void _updateRemainingItems() {
+    int remainingQueueItems = _nextCycle.length + _activeItems.length;
+    onRemainingItemsUpdate?.call(remainingQueueItems);
+  }
+}
+
+class _QueuedFuture<T> {
+  final Completer completer;
+  final Future<T> Function() closure;
+  Function? onComplete;
+  final Duration? timeout;
+
+  _QueuedFuture(this.closure, this.completer, this.timeout, {this.onComplete});
+
+  Future<void> execute() async {
+    try {
+      T result;
+      if (timeout != null) {
+        result = await closure().timeout(timeout!);
+      } else {
+        result = await closure();
+      }
+      if (result != null) {
+        completer.complete(result);
+      } else {
+        completer.complete(null);
+      }
+      await Future.microtask(() {});
+    } catch (e, stack) {
+      completer.completeError(e, stack);
+    } finally {
+      if (onComplete != null) onComplete?.call();
+    }
+  }
+}

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -16,7 +16,8 @@ class UniversalBle {
   static void setInstance(UniversalBlePlatform instance) =>
       _platform = instance;
 
-  /// Set global timeout for all commands, default timeout is 10 seconds
+  /// Set global timeout for all commands.
+  /// Default timeout is 10 seconds
   static set timeout(Duration? duration) {
     _bleCommandQueue.timeout = duration;
   }

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -4,7 +4,6 @@ import 'package:flutter/foundation.dart';
 import 'package:universal_ble/src/ble_command_queue.dart';
 import 'package:universal_ble/src/universal_ble_linux/universal_ble_linux.dart';
 import 'package:universal_ble/src/universal_ble_pigeon/universal_ble_pigeon_channel.dart';
-import 'package:universal_ble/src/universal_ble_platform_interface.dart';
 import 'package:universal_ble/src/universal_ble_web/universal_ble_web.dart';
 import 'package:universal_ble/universal_ble.dart';
 
@@ -22,26 +21,29 @@ class UniversalBle {
     _bleCommandQueue.timeout = duration;
   }
 
-  /// Setup global queue for all commands, by default queue is global
-  /// [QueueType.none] will not execute commands in queue
+  /// Set how commands will be executed. By default, all commands are executed in a global queue (`QueueType.global`),
+  /// with each command waiting for the previous one to finish.
+  /// 
   /// [QueueType.global] will execute commands of all devices in a single queue
-  /// [QueueType.perDevice] will execute command of each device in a separate queue
-  static set queuesCommands(QueueType queueType) {
+  /// [QueueType.perDevice] will execute command of each device in separate queues
+  /// [QueueType.none] will execute all commands in parallel
+  static set queueType(QueueType queueType) {
     _bleCommandQueue.queueType = queueType;
     UniversalBlePlatform.logInfo('Queue ${queueType.name}');
   }
 
-  /// To get Bluetooth state availability
-  /// To get updates, set [onAvailabilityChange] listener
+  /// Get Bluetooth availability state 
+  /// To be notified of updates, set [onAvailabilityChange] listener
   static Future<AvailabilityState> getBluetoothAvailabilityState() async {
     return await _bleCommandQueue.executeCommand(
       () => _platform.getBluetoothAvailabilityState(),
     );
   }
 
-  /// To Start scan, get scan results in [onScanResult] listener
-  /// might throw errors if Bluetooth is not available
-  /// `webRequestOptions` supported on Web only
+  /// Start scan.
+  /// Scan results will arrive in [onScanResult] listener
+  /// It might throw errors if Bluetooth is not available
+  /// `webRequestOptions` is supported on Web only
   static Future<void> startScan({
     ScanFilter? scanFilter,
   }) async {
@@ -51,8 +53,9 @@ class UniversalBle {
     );
   }
 
-  /// To Stop scan, set [onScanResult] listener to `null` if you don't need it anymore
-  /// might throw errors if Bluetooth is not available
+  /// Stop scan.
+  /// Set [onScanResult] listener to `null` if you don't need it anymore
+  /// It might throw errors if Bluetooth is not available
   static Future<void> stopScan() async {
     return await _bleCommandQueue.executeCommand(
       () => _platform.stopScan(),
@@ -60,10 +63,11 @@ class UniversalBle {
     );
   }
 
-  /// To connect to a device, get connection state in [onConnectionChanged] listener
-  /// preferred to stop scan before connecting
-  /// might throw errors if device is not connectable
-  /// `connectionTimeout` supported on Web only
+  /// Connect to a device.
+  /// Get notified of connection state changes in [onConnectionChanged] listener
+  /// It is advised to stop scanning before connecting
+  /// It might throw errors if device is not connectable
+  /// `connectionTimeout` is supported on Web only
   static Future<void> connect(
     String deviceId, {
     Duration? connectionTimeout,
@@ -74,7 +78,8 @@ class UniversalBle {
     );
   }
 
-  /// To disconnect from a device, get connection state in [onConnectionChanged] listener
+  /// Disconnect from a device.
+  /// Get notified of connection state changes in [onConnectionChanged] listener
   static Future<void> disconnect(String deviceId) async {
     return await _bleCommandQueue.executeCommand(
       () => _platform.disconnect(deviceId),
@@ -82,7 +87,7 @@ class UniversalBle {
     );
   }
 
-  /// To discover services of a device
+  /// Discover services of a device
   static Future<List<BleService>> discoverServices(String deviceId) async {
     return await _bleCommandQueue.executeCommand(
       () => _platform.discoverServices(deviceId),
@@ -90,7 +95,9 @@ class UniversalBle {
     );
   }
 
-  /// To set a characteristic notifiable, set `bleInputProperty` to [BleInputProperty.notification] or [BleInputProperty.indication], get updates in [onValueChanged] listener
+  /// Set a characteristic notifiable.
+  /// Set `bleInputProperty` to [BleInputProperty.notification] or [BleInputProperty.indication]
+  /// Updates will arrive in [onValueChanged] listener
   /// To stop listening to a characteristic, set `bleInputProperty` to [BleInputProperty.disabled]
   static Future<void> setNotifiable(
     String deviceId,
@@ -109,8 +116,8 @@ class UniversalBle {
     );
   }
 
-  /// To read a characteristic value
-  /// on iOS and MacOS, this command will also trigger [onValueChanged] listener
+  /// Read a characteristic value
+  /// On iOS and MacOS this command will also trigger [onValueChanged] listener
   static Future<Uint8List> readValue(
     String deviceId,
     String service,
@@ -122,7 +129,7 @@ class UniversalBle {
     );
   }
 
-  /// To write a characteristic value
+  /// Write a characteristic value
   /// To write a characteristic value with response, set `bleOutputProperty` to [BleOutputProperty.withResponse]
   static Future<void> writeValue(
     String deviceId,
@@ -143,7 +150,8 @@ class UniversalBle {
     );
   }
 
-  /// `requestMtu` not supported on `Linux` and `Web
+  /// Request MTU value
+  /// `requestMtu` is not supported on `Linux` and `Web
   static Future<int> requestMtu(String deviceId, int expectedMtu) async {
     return await _bleCommandQueue.executeCommand(
       () => _platform.requestMtu(deviceId, expectedMtu),
@@ -151,7 +159,8 @@ class UniversalBle {
     );
   }
 
-  /// Pair commands are not supported on `iOS`, `MacOS` and `Web`
+  /// Check if a device is paired
+  /// Pair commands are not supported on `Apple` and `Web`
   static Future<bool> isPaired(String deviceId) async {
     return await _bleCommandQueue.executeCommand(
       () => _platform.isPaired(deviceId),
@@ -159,8 +168,8 @@ class UniversalBle {
     );
   }
 
-  /// To trigger pair request
-  /// might throw errors if device is already paired
+  /// Trigger pair request
+  /// It might throw an error if device is already paired
   static Future<void> pair(String deviceId) async {
     return await _bleCommandQueue.executeCommand(
       () => _platform.pair(deviceId),
@@ -168,8 +177,8 @@ class UniversalBle {
     );
   }
 
-  /// To trigger unPair request
-  /// might throw errors if device is not paired
+  /// Unpair a device
+  /// It might throw an error if device is not paired
   static Future<void> unPair(String deviceId) async {
     return await _bleCommandQueue.executeCommand(
       () => _platform.unPair(deviceId),
@@ -177,10 +186,10 @@ class UniversalBle {
     );
   }
 
-  /// To get connected devices to the system (connected by any app)
-  /// use [withServices] to filter devices by services
-  /// on `iOS`, `MacOS` [withServices] is required to get connected devices, else [1800] service will be used as default filter
-  /// on `Android`, `Linux` and `Windows`, if [withServices] is used, then internally all services will be discovered for each device first (either by connecting or by using cached services)
+  /// Get connected devices to the system (connected by any app)
+  /// Use [withServices] to filter devices by services
+  /// On `Apple`, [withServices] is required to get connected devices, else [1800] service will be used as default filter
+  /// On `Android`, `Linux` and `Windows`, if [withServices] is used, then internally all services will be discovered for each device first (either by connecting or by using cached services)
   /// Not supported on `Web`
   static Future<List<BleScanResult>> getConnectedDevices({
     List<String>? withServices,
@@ -190,7 +199,8 @@ class UniversalBle {
     );
   }
 
-  /// Enabling Bluetooth, might throw errors if Bluetooth is not available
+  /// Enable Bluetooth
+  /// It might throw errors if Bluetooth is not available
   /// Not supported on `Web` and `Apple`
   static Future<bool> enableBluetooth() async {
     return await _bleCommandQueue.executeCommand(
@@ -198,7 +208,7 @@ class UniversalBle {
     );
   }
 
-  /// To get Bluetooth state availability
+  /// Get Bluetooth state availability
   static set onAvailabilityChange(OnAvailabilityChange? onAvailabilityChange) {
     _platform.onAvailabilityChange = onAvailabilityChange;
     if (onAvailabilityChange != null) {
@@ -208,23 +218,23 @@ class UniversalBle {
     }
   }
 
-  /// To get updates of remaining items of a queue
+  /// Get updates of remaining items of a queue
   static set onQueueUpdate(OnQueueUpdate? onQueueUpdate) =>
       _bleCommandQueue.onQueueUpdate = onQueueUpdate;
 
-  /// To get scan results
+  /// Get scan results
   static set onScanResult(OnScanResult? onScanResult) =>
       _platform.onScanResult = onScanResult;
 
-  /// To get connection state changes
+  /// Get connection state changes
   static set onConnectionChanged(OnConnectionChanged? onConnectionChanged) =>
       _platform.onConnectionChanged = onConnectionChanged;
 
-  /// To get characteristic value updates, set `bleInputProperty` in [setNotifiable] to [BleInputProperty.notification] or [BleInputProperty.indication]
+  /// Get characteristic value updates, set `bleInputProperty` in [setNotifiable] to [BleInputProperty.notification] or [BleInputProperty.indication]
   static set onValueChanged(OnValueChanged? onValueChanged) =>
       _platform.onValueChanged = onValueChanged;
 
-  /// To get pair state changes,
+  /// Get pair state changes,
   static set onPairingStateChange(OnPairingStateChange pairingStateChange) =>
       _platform.onPairingStateChange = pairingStateChange;
 

--- a/lib/src/universal_ble_platform_interface.dart
+++ b/lib/src/universal_ble_platform_interface.dart
@@ -84,3 +84,5 @@ typedef OnAvailabilityChange = void Function(AvailabilityState state);
 
 typedef OnPairingStateChange = void Function(
     String deviceId, bool isPaired, String? error);
+
+typedef OnQueueUpdate = void Function(String id, int remainingQueueItems);

--- a/lib/universal_ble.dart
+++ b/lib/universal_ble.dart
@@ -1,6 +1,5 @@
 library universal_ble;
 
-export 'package:universal_ble/src/ble_command_queue.dart';
 export 'package:universal_ble/src/universal_ble_platform_interface.dart';
 export 'package:universal_ble/src/universal_ble.dart';
 export 'package:universal_ble/src/models/model_exports.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: universal_ble
 description: A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE) plugin for Flutter
-version: 0.9.11
+version: 0.9.12
 homepage: https://navideck.com
 repository: https://github.com/Navideck/universal_ble
 issue_tracker: https://github.com/Navideck/universal_ble/issues


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Introduced `QueueType` enum to manage different queue types: none, perDevice, global.
- Refactored command queue implementation to support multiple queue types.
- Updated UI components to reflect the current queue type.
- Improved documentation with examples for setting queue type and handling queue updates.
- Updated version to 0.9.12 and added changelog entry.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>home.dart</strong><dd><code>Add queue type management and update UI accordingly.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example/lib/home/home.dart
<li>Replaced <code>_isQueueEnabled</code> with <code>_queueType</code> to manage different queue <br>types.<br> <li> Updated UI button to reflect the current queue type.<br> <li> Modified queue setup to use <code>QueueType</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/48/files#diff-da1b5bdcb6f7b90bf5ad0c250e3af4c06567c23d1ebe6135325b8d30241a3838">+13/-5</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ble_command_queue.dart</strong><dd><code>Refactor command queue to support multiple queue types.</code>&nbsp; &nbsp; </dd></summary>
<hr>

lib/src/ble_command_queue.dart
<li>Refactored to use <code>Queue</code> class for command execution.<br> <li> Added support for different queue types: global, perDevice, none.<br> <li> Managed queues for individual devices.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/48/files#diff-138d252ab7b0ff99064abd1138bbcf0d9ef5f88d5992c456b8b4200ccd8bf53f">+39/-69</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>model_exports.dart</strong><dd><code>Export QueueType model.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/models/model_exports.dart
- Exported `queue_type.dart`.



</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/48/files#diff-441e2767a2d6313395d11691abfd4b7f62830a247982babee81cc8e5ac617c07">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>queue_type.dart</strong><dd><code>Define QueueType enum.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/models/queue_type.dart
- Added `QueueType` enum with values: none, perDevice, global.



</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/48/files#diff-83e211260261f64bccd426053229a72fab7230023596031a63d1f983fc507a81">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>queue.dart</strong><dd><code>Implement Queue class for command management.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/queue.dart
<li>Introduced <code>Queue</code> class to manage command execution.<br> <li> Implemented queue management with timeout and cancellation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/48/files#diff-6ef8ad996419cc0b8611a29b58892f4cbf31890eb58f33b8ef4cb3462997960f">+81/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble.dart</strong><dd><code>Integrate BleCommandQueue and support queue types.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/universal_ble.dart
<li>Refactored to use <code>BleCommandQueue</code> for command execution.<br> <li> Added support for setting queue type and handling queue updates.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/48/files#diff-0299ec0dda75c972b21ca1a2d8ac5fc87bc4dc3f354c49c7995bcb3d18054304">+88/-85</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble_platform_interface.dart</strong><dd><code>Add OnQueueUpdate typedef.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/universal_ble_platform_interface.dart
- Added `OnQueueUpdate` typedef for queue update callbacks.



</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/48/files#diff-127e48afab502be75a7cc9a9d97749f8a34e499dc343bff386b3da7ddd0ea4b3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble.dart</strong><dd><code>Update exports in universal_ble.dart.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/universal_ble.dart
- Removed export of `ble_command_queue.dart`.



</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/48/files#diff-12cb3102dd3140efab18f7a61b0c7b7ed3168f86762fa3c0e354056892ba62aa">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Documentation
</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog for version 0.9.12.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md
<li>Added entry for version 0.9.12 with new queue types and documentation <br>improvements.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/48/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README with new queue types and examples.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md
<li>Updated documentation to reflect new queue types and usage.<br> <li> Added examples for setting queue type and handling queue updates.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/48/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+25/-5</a>&nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes
</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>pubspec.yaml</strong><dd><code>Update version to 0.9.12.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pubspec.yaml
- Bumped version to 0.9.12.



</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/48/files#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

