### PR TITLE
Set CBCentralManagerScanOptionAllowDuplicatesKey to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Add .perDevice queue
 * Improve code level documentation
 * Support "ProvidePin" pairing on Windows 10/11
+* Get RRSI updates on Apple platforms
 
 ## 0.9.11
 * Add device name prefix filtering

--- a/darwin/Classes/UniversalBlePlugin.swift
+++ b/darwin/Classes/UniversalBlePlugin.swift
@@ -73,7 +73,8 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
     // Save scanFilter for later user
     scanFilter = filter
 
-    manager.scanForPeripherals(withServices: withServices)
+    let options = [CBCentralManagerScanOptionAllowDuplicatesKey: true]
+    manager.scanForPeripherals(withServices: withServices, options: options)
   }
 
   func stopScan() throws {


### PR DESCRIPTION
### **User description**
Fixes https://github.com/Navideck/universal_ble/issues/47


___

### **PR Type**
enhancement


___

### **Description**
- Added an `options` dictionary to enable duplicate peripheral discovery during BLE scanning by setting `CBCentralManagerScanOptionAllowDuplicatesKey` to `true`.
- Updated the `scanForPeripherals` method to include the new `options` parameter.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UniversalBlePlugin.swift</strong><dd><code>Enable duplicate peripheral discovery in BLE scanning</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

darwin/Classes/UniversalBlePlugin.swift
<li>Added <code>options</code> dictionary with <br><code>CBCentralManagerScanOptionAllowDuplicatesKey</code> set to <code>true</code>.<br> <li> Updated <code>scanForPeripherals</code> method to include the new <code>options</code> <br>parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/51/files#diff-87832239a271a17152d0bd5fd33a705cd1398bda21bfdfff19934f405c09965f">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

