### PR TITLE
Implement pairing on Apple

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
     "BTLE",
     "BTNHIGHLIGHT",
     "bytevc",
+    "cccd",
     "connnection",
     "Cupertino",
     "DFACE",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## 0.12.0
 * BREAKING CHANGE: `unPair` is now `unpair`
+* Add isPaired support on Apple
+* `connect` will now return the connection result
 * Add `PlatformConfig` property in `StartScan`
 * Add `WebConfig` property in `PlatformConfig`
 * Fix notifications for characteristics without cccd on Android
-* Add isPaired support on Apple
+* Add `connectionStream` API to get connection updates as stream
 
 ## 0.11.1
 * Trim spaces in UUIDs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fix Android disconnection events sometimes missed
 * Improve cleanup after disconnection on Apple and Android
 * Support pairing on Apple
+* Improve code level documentation
 
 ## 0.10.0
 * BREAKING CHANGE: `ScanResult` is now `BleDevice`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Improve Android error handling
 * Fix Android disconnection events sometimes missed
 * Improve cleanup after disconnection on Apple and Android
+* Support pairing on Apple
 
 ## 0.10.0
 * BREAKING CHANGE: `ScanResult` is now `BleDevice`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-## 0.11.2
+## 0.12.0
+* BREAKING CHANGE: `unPair` is now `unpair`
 * Add `PlatformConfig` property in `StartScan`
 * Add `WebConfig` property in `PlatformConfig`
-* Fix notification for characteristics without cccd
+* Fix notifications for characteristics without cccd on Android
+* Add isPaired support on Apple
 
 ## 0.11.1
 * Trim spaces in UUIDs
@@ -11,6 +13,8 @@
 ## 0.11.0
 * Unify UUID format across all platforms, 128-bit lowercase
 * Add BleUuidParser utility methods for UUID parsing
+
+## 0.10.1
 * Improve Android error handling
 * Fix Android disconnection events sometimes missed
 * Improve cleanup after disconnection on Apple and Android

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE
 | readValue            |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ✔️  |
 | writeValue           |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ✔️  |
 | setNotifiable        |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ✔️  |
-| pair/unPair          |   ✔️    | ❌  |  ❌   |   ✔️    |      ✔️      | ❌  |
+| pair                 |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ❌  |
+| unPair               |   ✔️    | ❌  |  ❌   |   ✔️    |      ✔️      | ❌  |
 | onPairingStateChange |   ✔️    | ❌  |  ❌   |   ✔️    |      ✔️      | ❌  |
 | enableBluetooth      |   ✔️    | ❌  |  ❌   |   ✔️    |      ✔️      | ❌  |
 | onAvailabilityChange |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ✔️  |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE
 | writeValue           |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ✔️  |
 | setNotifiable        |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ✔️  |
 | pair                 |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ❌  |
-| unPair               |   ✔️    | ❌  |  ❌   |   ✔️    |      ✔️      | ❌  |
+| unpair               |   ✔️    | ❌  |  ❌   |   ✔️    |      ✔️      | ❌  |
+| isPaired             |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ?  |
+| getBluetoothAvailabilityState                 |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ❌  |
 | onPairingStateChange |   ✔️    | ❌  |  ❌   |   ✔️    |      ✔️      | ❌  |
 | enableBluetooth      |   ✔️    | ❌  |  ❌   |   ✔️    |      ✔️      | ❌  |
 | onAvailabilityChange |   ✔️    | ✔️  |  ✔️   |   ✔️    |      ✔️      | ✔️  |
@@ -202,7 +204,7 @@ UniversalBle.onPairingStateChange = (String deviceId, bool isPaired, String? err
 }
 
 // Unpair
-UniversalBle.unPair(deviceId);
+UniversalBle.unpair(deviceId);
 
 // Check current pairing state
 bool isPaired = UniversalBle.isPaired(deviceId);

--- a/example/lib/data/capabilities.dart
+++ b/example/lib/data/capabilities.dart
@@ -9,7 +9,7 @@ class Capabilities {
 
   static bool supportsConnectedDevicesApi = !Platform.isWeb;
 
-  static bool supportsPairingApi = !Platform.isWeb && !Platform.isCupertino;
+  static bool supportsPairingApi = !Platform.isWeb;
 
   static bool supportsRequestMtuApi = !Platform.isWeb;
 }

--- a/example/lib/data/mock_universal_ble.dart
+++ b/example/lib/data/mock_universal_ble.dart
@@ -27,19 +27,19 @@ class MockUniversalBle extends UniversalBlePlatform {
     ScanFilter? scanFilter,
     PlatformConfig? platformConfig,
   }) async =>
-      onScanResult?.call(_mockBleDevice);
+      updateScanResult(_mockBleDevice);
 
   @override
   Future<void> stopScan() async {}
 
   @override
   Future<void> connect(String deviceId, {Duration? connectionTimeout}) async {
-    onConnectionChange?.call(deviceId, true);
+    updateConnection(deviceId, true);
   }
 
   @override
   Future<void> disconnect(String deviceId) async {
-    onConnectionChange?.call(deviceId, false);
+    updateConnection(deviceId, false);
   }
 
   @override
@@ -99,12 +99,12 @@ class MockUniversalBle extends UniversalBlePlatform {
 
   @override
   Future<void> pair(String deviceId) async {
-    onPairingStateChange?.call(deviceId, true, null);
+    updatePairingState(deviceId, true, null);
   }
 
   @override
   Future<void> unpair(String deviceId) async {
-    onPairingStateChange?.call(deviceId, false, null);
+    updatePairingState(deviceId, false, null);
   }
 
   @override

--- a/example/lib/data/mock_universal_ble.dart
+++ b/example/lib/data/mock_universal_ble.dart
@@ -103,7 +103,7 @@ class MockUniversalBle extends UniversalBlePlatform {
   }
 
   @override
-  Future<void> unPair(String deviceId) async {
+  Future<void> unpair(String deviceId) async {
     onPairingStateChange?.call(deviceId, false, null);
   }
 

--- a/example/lib/home/home.dart
+++ b/example/lib/home/home.dart
@@ -192,7 +192,7 @@ class _MyAppState extends State<MyApp> {
                     },
                   ),
                 PlatformButton(
-                  text: 'Queue: ${_queueType.name.toUpperCase()}',
+                  text: 'Queue: ${_queueType.name}',
                   onPressed: () {
                     setState(() {
                       _queueType = switch (_queueType) {

--- a/example/lib/peripheral_details/peripheral_detail_page.dart
+++ b/example/lib/peripheral_details/peripheral_detail_page.dart
@@ -414,7 +414,14 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
                             PlatformButton(
                               onPressed: () async {
                                 bool? isPaired = await UniversalBle.isPaired(
-                                    widget.deviceId);
+                                  widget.deviceId,
+                                  bleCommand: BleCommand(
+                                    service:
+                                        "8000dd00-dd00-ffff-ffff-ffffffffffff",
+                                    characteristic:
+                                        "0000dd21-0000-1000-8000-00805f9b34fb",
+                                  ),
+                                );
                                 _addLog('IsPaired', isPaired);
                               },
                               text: 'IsPaired',

--- a/example/lib/peripheral_details/peripheral_detail_page.dart
+++ b/example/lib/peripheral_details/peripheral_detail_page.dart
@@ -84,11 +84,11 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
 
   void _handlePairingStateChange(
       String deviceId, bool isPaired, String? error) {
-    print('OnPairStateChange $deviceId, $isPaired');
+    print('isPaired $deviceId, $isPaired');
     if (error != null && error.isNotEmpty) {
       _addLog("PairStateChangeError", "(Paired: $isPaired): $error ");
     } else {
-      _addLog("PairStateChange", isPaired);
+      _addLog("PairStateChange - isPaired", isPaired);
     }
   }
 
@@ -254,7 +254,10 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
                               enabled: !isConnected,
                               onPressed: () async {
                                 try {
-                                  await UniversalBle.connect(widget.deviceId);
+                                  bool connected = await UniversalBle.connect(
+                                    widget.deviceId,
+                                  );
+                                  _addLog("ConnectionResult", connected);
                                 } catch (e) {
                                   _addLog('ConnectError', e);
                                 }
@@ -407,7 +410,15 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
                             ),
                             PlatformButton(
                               onPressed: () async {
-                                await UniversalBle.pair(widget.deviceId);
+                                await UniversalBle.pair(
+                                  widget.deviceId,
+                                  // pairingCommand: BleCommand(
+                                  //   service:
+                                  //       "",
+                                  //   characteristic:
+                                  //       "",
+                                  // ),
+                                );
                               },
                               text: 'Pair',
                             ),
@@ -415,12 +426,12 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
                               onPressed: () async {
                                 bool? isPaired = await UniversalBle.isPaired(
                                   widget.deviceId,
-                                  bleCommand: BleCommand(
-                                    service:
-                                        "8000dd00-dd00-ffff-ffff-ffffffffffff",
-                                    characteristic:
-                                        "0000dd21-0000-1000-8000-00805f9b34fb",
-                                  ),
+                                  // pairingCheckCommand: BleCommand(
+                                  //   service:
+                                  //       "",
+                                  //   characteristic:
+                                  //       "",
+                                  // ),
                                 );
                                 _addLog('IsPaired', isPaired);
                               },

--- a/example/lib/peripheral_details/peripheral_detail_page.dart
+++ b/example/lib/peripheral_details/peripheral_detail_page.dart
@@ -421,9 +421,9 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
                             ),
                             PlatformButton(
                               onPressed: () async {
-                                await UniversalBle.unPair(widget.deviceId);
+                                await UniversalBle.unpair(widget.deviceId);
                               },
-                              text: 'UnPair',
+                              text: 'Unpair',
                             ),
                           ],
                         ),

--- a/example/lib/peripheral_details/peripheral_detail_page.dart
+++ b/example/lib/peripheral_details/peripheral_detail_page.dart
@@ -405,29 +405,26 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
                                   BleInputProperty.disabled),
                               text: 'Unsubscribe',
                             ),
-                            if (Capabilities.supportsPairingApi)
-                              PlatformButton(
-                                onPressed: () async {
-                                  await UniversalBle.pair(widget.deviceId);
-                                },
-                                text: 'Pair',
-                              ),
-                            if (Capabilities.supportsPairingApi)
-                              PlatformButton(
-                                onPressed: () async {
-                                  bool? isPaired = await UniversalBle.isPaired(
-                                      widget.deviceId);
-                                  _addLog('IsPaired', isPaired);
-                                },
-                                text: 'IsPaired',
-                              ),
-                            if (Capabilities.supportsPairingApi)
-                              PlatformButton(
-                                onPressed: () async {
-                                  await UniversalBle.unPair(widget.deviceId);
-                                },
-                                text: 'UnPair',
-                              ),
+                            PlatformButton(
+                              onPressed: () async {
+                                await UniversalBle.pair(widget.deviceId);
+                              },
+                              text: 'Pair',
+                            ),
+                            PlatformButton(
+                              onPressed: () async {
+                                bool? isPaired = await UniversalBle.isPaired(
+                                    widget.deviceId);
+                                _addLog('IsPaired', isPaired);
+                              },
+                              text: 'IsPaired',
+                            ),
+                            PlatformButton(
+                              onPressed: () async {
+                                await UniversalBle.unPair(widget.deviceId);
+                              },
+                              text: 'UnPair',
+                            ),
                           ],
                         ),
                       ),

--- a/example/macos/Runner/AppDelegate.swift
+++ b/example/macos/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -402,7 +402,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.11.1"
+    version: "0.12.0"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/models/ble_command.dart
+++ b/lib/src/models/ble_command.dart
@@ -1,0 +1,13 @@
+import 'dart:typed_data';
+
+class BleCommand {
+  String service;
+  String characteristic;
+  Uint8List? writeValue;
+
+  BleCommand({
+    required this.service,
+    required this.characteristic,
+    this.writeValue,
+  });
+}

--- a/lib/src/models/model_exports.dart
+++ b/lib/src/models/model_exports.dart
@@ -7,3 +7,5 @@ export 'package:universal_ble/src/models/ble_service.dart';
 export 'package:universal_ble/src/models/availability_state.dart';
 export 'package:universal_ble/src/models/ble_connection_state.dart';
 export 'package:universal_ble/src/models/ble_device.dart';
+export 'package:universal_ble/src/models/ble_command.dart';
+

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -180,8 +180,10 @@ class UniversalBle {
     );
   }
 
-  /// Trigger pair request
-  /// It might throw an error if device is already paired
+  /// Pair a device.
+  /// It might throw an error if device is already paired.
+  /// On Apple, it only works on devices with encrypted `read` characteristics.
+  /// On Apple, it throws an error if the device is not already connected.
   static Future<void> pair(String deviceId) async {
     return await _bleCommandQueue.queueCommand(
       () => _platform.pair(deviceId),

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -9,17 +9,17 @@ import 'package:universal_ble/src/universal_ble_web/universal_ble_web.dart';
 import 'package:universal_ble/universal_ble.dart';
 
 class UniversalBle {
-  /// Get platform specific implementation
+  /// Get platform specific implementation.
   static UniversalBlePlatform _platform = _defaultPlatform();
   static final BleCommandQueue _bleCommandQueue = BleCommandQueue();
 
-  /// Set custom platform specific implementation (e.g. for testing)
+  /// Set custom platform specific implementation (e.g. for testing).
   static void setInstance(UniversalBlePlatform instance) =>
       _platform = instance;
 
   /// Set global timeout for all commands.
-  /// Default timeout is 10 seconds
-  /// Set to null to disable
+  /// Default timeout is 10 seconds.
+  /// Set to null to disable.
   static set timeout(Duration? duration) {
     _bleCommandQueue.timeout = duration;
   }
@@ -27,16 +27,16 @@ class UniversalBle {
   /// Set how commands will be executed. By default, all commands are executed in a global queue (`QueueType.global`),
   /// with each command waiting for the previous one to finish.
   ///
-  /// [QueueType.global] will execute commands of all devices in a single queue
-  /// [QueueType.perDevice] will execute command of each device in separate queues
-  /// [QueueType.none] will execute all commands in parallel
+  /// [QueueType.global] will execute commands of all devices in a single queue.
+  /// [QueueType.perDevice] will execute command of each device in separate queues.
+  /// [QueueType.none] will execute all commands in parallel.
   static set queueType(QueueType queueType) {
     _bleCommandQueue.queueType = queueType;
     UniversalBlePlatform.logInfo('Queue ${queueType.name}');
   }
 
-  /// Get Bluetooth availability state
-  /// To be notified of updates, set [onAvailabilityChange] listener
+  /// Get Bluetooth availability state.
+  /// To be notified of updates, set [onAvailabilityChange] listener.
   static Future<AvailabilityState> getBluetoothAvailabilityState() async {
     return await _bleCommandQueue.queueCommand(
       () => _platform.getBluetoothAvailabilityState(),
@@ -44,9 +44,9 @@ class UniversalBle {
   }
 
   /// Start scan.
-  /// Scan results will arrive in [onScanResult] listener
-  /// It might throw errors if Bluetooth is not available
-  /// `webRequestOptions` is supported on Web only
+  /// Scan results will arrive in [onScanResult] listener.
+  /// It might throw errors if Bluetooth is not available.
+  /// `webRequestOptions` is supported on Web only.
   static Future<void> startScan({
     ScanFilter? scanFilter,
     PlatformConfig? platformConfig,
@@ -61,8 +61,8 @@ class UniversalBle {
   }
 
   /// Stop scan.
-  /// Set [onScanResult] listener to `null` if you don't need it anymore
-  /// It might throw errors if Bluetooth is not available
+  /// Set [onScanResult] listener to `null` if you don't need it anymore.
+  /// It might throw errors if Bluetooth is not available.
   static Future<void> stopScan() async {
     return await _bleCommandQueue.queueCommand(
       () => _platform.stopScan(),
@@ -71,10 +71,10 @@ class UniversalBle {
   }
 
   /// Connect to a device.
-  /// Get notified of connection state changes in [onConnectionChange] listener
-  /// It is advised to stop scanning before connecting
-  /// It might throw errors if device is not connectable
-  /// `connectionTimeout` is supported on Web only
+  /// Get notified of connection state changes in [onConnectionChange] listener.
+  /// It is advised to stop scanning before connecting.
+  /// It might throw errors if device is not connectable.
+  /// `connectionTimeout` is supported on Web only.
   static Future<void> connect(
     String deviceId, {
     Duration? connectionTimeout,
@@ -86,7 +86,7 @@ class UniversalBle {
   }
 
   /// Disconnect from a device.
-  /// Get notified of connection state changes in [onConnectionChange] listener
+  /// Get notified of connection state changes in [onConnectionChange] listener.
   static Future<void> disconnect(String deviceId) async {
     return await _bleCommandQueue.queueCommand(
       () => _platform.disconnect(deviceId),
@@ -94,7 +94,7 @@ class UniversalBle {
     );
   }
 
-  /// Discover services of a device
+  /// Discover services of a device.
   static Future<List<BleService>> discoverServices(String deviceId) async {
     return await _bleCommandQueue.queueCommand(
       () => _platform.discoverServices(deviceId),
@@ -103,9 +103,9 @@ class UniversalBle {
   }
 
   /// Set a characteristic notifiable.
-  /// Set `bleInputProperty` to [BleInputProperty.notification] or [BleInputProperty.indication]
-  /// Updates will arrive in [onValueChange] listener
-  /// To stop listening to a characteristic, set `bleInputProperty` to [BleInputProperty.disabled]
+  /// Set `bleInputProperty` to [BleInputProperty.notification] or [BleInputProperty.indication].
+  /// Updates will arrive in [onValueChange] listener.
+  /// To stop listening to a characteristic, set `bleInputProperty` to [BleInputProperty.disabled].
   static Future<void> setNotifiable(
     String deviceId,
     String service,
@@ -123,8 +123,8 @@ class UniversalBle {
     );
   }
 
-  /// Read a characteristic value
-  /// On iOS and MacOS this command will also trigger [onValueChange] listener
+  /// Read a characteristic value.
+  /// On iOS and MacOS this command will also trigger [onValueChange] listener.
   static Future<Uint8List> readValue(
     String deviceId,
     String service,
@@ -140,8 +140,8 @@ class UniversalBle {
     );
   }
 
-  /// Write a characteristic value
-  /// To write a characteristic value with response, set `bleOutputProperty` to [BleOutputProperty.withResponse]
+  /// Write a characteristic value.
+  /// To write a characteristic value with response, set `bleOutputProperty` to [BleOutputProperty.withResponse].
   static Future<void> writeValue(
     String deviceId,
     String service,
@@ -161,8 +161,8 @@ class UniversalBle {
     );
   }
 
-  /// Request MTU value
-  /// `requestMtu` is not supported on `Linux` and `Web
+  /// Request MTU value.
+  /// `requestMtu` is not supported on `Linux` and `Web.
   static Future<int> requestMtu(String deviceId, int expectedMtu) async {
     return await _bleCommandQueue.queueCommand(
       () => _platform.requestMtu(deviceId, expectedMtu),
@@ -170,8 +170,8 @@ class UniversalBle {
     );
   }
 
-  /// Check if a device is paired
-  /// Returns null on `Apple` and `Web`
+  /// Check if a device is paired.
+  /// Returns null on `Apple` and `Web`.
   static Future<bool?> isPaired(String deviceId) async {
     if (kIsWeb || Platform.isIOS || Platform.isMacOS) return null;
     return await _bleCommandQueue.queueCommand(
@@ -191,8 +191,8 @@ class UniversalBle {
     );
   }
 
-  /// Unpair a device
-  /// It might throw an error if device is not paired
+  /// Unpair a device.
+  /// It might throw an error if device is not paired.
   static Future<void> unPair(String deviceId) async {
     return await _bleCommandQueue.queueCommand(
       () => _platform.unPair(deviceId),
@@ -200,11 +200,11 @@ class UniversalBle {
     );
   }
 
-  /// Get connected devices to the system (connected by any app)
-  /// Use [withServices] to filter devices by services
-  /// On `Apple`, [withServices] is required to get connected devices, else [1800] service will be used as default filter
-  /// On `Android`, `Linux` and `Windows`, if [withServices] is used, then internally all services will be discovered for each device first (either by connecting or by using cached services)
-  /// Not supported on `Web`
+  /// Get connected devices to the system (connected by any app).
+  /// Use [withServices] to filter devices by services.
+  /// On `Apple`, [withServices] is required to get connected devices, else [1800] service will be used as default filter.
+  /// On `Android`, `Linux` and `Windows`, if [withServices] is used, then internally all services will be discovered for each device first (either by connecting or by using cached services).
+  /// Not supported on `Web`.
   static Future<List<BleDevice>> getSystemDevices({
     List<String>? withServices,
   }) async {
@@ -222,9 +222,9 @@ class UniversalBle {
     );
   }
 
-  /// Enable Bluetooth
-  /// It might throw errors if Bluetooth is not available
-  /// Not supported on `Web` and `Apple`
+  /// Enable Bluetooth.
+  /// It might throw errors if Bluetooth is not available.
+  /// Not supported on `Web` and `Apple`.
   static Future<bool> enableBluetooth() async {
     return await _bleCommandQueue.queueCommand(
       () => _platform.enableBluetooth(),
@@ -241,7 +241,7 @@ class UniversalBle {
   static bool receivesAdvertisements(String deviceId) =>
       _platform.receivesAdvertisements(deviceId);
 
-  /// Get Bluetooth state availability
+  /// Get Bluetooth state availability.
   static set onAvailabilityChange(OnAvailabilityChange? onAvailabilityChange) {
     _platform.onAvailabilityChange = onAvailabilityChange;
     if (onAvailabilityChange != null) {
@@ -251,23 +251,23 @@ class UniversalBle {
     }
   }
 
-  /// Get updates of remaining items of a queue
+  /// Get updates of remaining items of a queue.
   static set onQueueUpdate(OnQueueUpdate? onQueueUpdate) =>
       _bleCommandQueue.onQueueUpdate = onQueueUpdate;
 
-  /// Get scan results
+  /// Get scan results.
   static set onScanResult(OnScanResult? bleDevice) =>
       _platform.onScanResult = bleDevice;
 
-  /// Get connection state changes
+  /// Get connection state changes.
   static set onConnectionChange(OnConnectionChange? onConnectionChange) =>
       _platform.onConnectionChange = onConnectionChange;
 
-  /// Get characteristic value updates, set `bleInputProperty` in [setNotifiable] to [BleInputProperty.notification] or [BleInputProperty.indication]
+  /// Get characteristic value updates, set `bleInputProperty` in [setNotifiable] to [BleInputProperty.notification] or [BleInputProperty.indication].
   static set onValueChange(OnValueChange? onValueChange) =>
       _platform.onValueChange = onValueChange;
 
-  /// Get pair state changes,
+  /// Get pair state changes.
   static set onPairingStateChange(OnPairingStateChange pairingStateChange) =>
       _platform.onPairingStateChange = pairingStateChange;
 

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -193,9 +193,9 @@ class UniversalBle {
 
   /// Unpair a device.
   /// It might throw an error if device is not paired.
-  static Future<void> unPair(String deviceId) async {
+  static Future<void> unpair(String deviceId) async {
     return await _bleCommandQueue.queueCommand(
-      () => _platform.unPair(deviceId),
+      () => _platform.unpair(deviceId),
       deviceId: deviceId,
     );
   }

--- a/lib/src/universal_ble_linux/universal_ble_linux.dart
+++ b/lib/src/universal_ble_linux/universal_ble_linux.dart
@@ -101,7 +101,7 @@ class UniversalBleLinux extends UniversalBlePlatform {
   Future<void> connect(String deviceId, {Duration? connectionTimeout}) async {
     final device = _findDeviceById(deviceId);
     if (device.connected) {
-      onConnectionChange?.call(deviceId, true);
+      updateConnection(deviceId, true);
       return;
     }
     await device.connect();
@@ -111,7 +111,7 @@ class UniversalBleLinux extends UniversalBlePlatform {
   Future<void> disconnect(String deviceId) async {
     final device = _findDeviceById(deviceId);
     if (!device.connected) {
-      onConnectionChange?.call(deviceId, false);
+      updateConnection(deviceId, false);
       return;
     }
     await device.disconnect();
@@ -273,7 +273,7 @@ class UniversalBleLinux extends UniversalBlePlatform {
   Future<void> pair(String deviceId) async {
     BlueZDevice device = _findDeviceById(deviceId);
     device.pair().onError((error, _) {
-      onPairingStateChange?.call(deviceId, false, error.toString());
+      updatePairingState(deviceId, false, error.toString());
     });
   }
 
@@ -356,7 +356,7 @@ class UniversalBleLinux extends UniversalBlePlatform {
         for (final property in properties) {
           switch (property) {
             case BluezProperty.powered:
-              onAvailabilityChange?.call(_availabilityState);
+              updateAvailability(_availabilityState);
               break;
             case BluezProperty.discoverable:
             case BluezProperty.discovering:
@@ -374,7 +374,7 @@ class UniversalBleLinux extends UniversalBlePlatform {
       _client.deviceAdded.listen(_onDeviceAdd);
       _client.deviceRemoved.listen(_onDeviceRemoved);
 
-      onAvailabilityChange?.call(_availabilityState);
+      updateAvailability(_availabilityState);
       isInitialized = true;
       _initializationCompleter?.complete();
       _initializationCompleter = null;
@@ -433,13 +433,13 @@ class UniversalBleLinux extends UniversalBlePlatform {
             updateScanResult(device.toBleDevice());
             break;
           case BluezProperty.connected:
-            onConnectionChange?.call(device.address, device.connected);
+            updateConnection(device.address, device.connected);
             break;
           case BluezProperty.manufacturerData:
             updateScanResult(device.toBleDevice());
             break;
           case BluezProperty.paired:
-            onPairingStateChange?.call(device.address, device.paired, null);
+            updatePairingState(device.address, device.paired, null);
             break;
           // Ignored these properties updates
           case BluezProperty.bonded:

--- a/lib/src/universal_ble_linux/universal_ble_linux.dart
+++ b/lib/src/universal_ble_linux/universal_ble_linux.dart
@@ -278,7 +278,7 @@ class UniversalBleLinux extends UniversalBlePlatform {
   }
 
   @override
-  Future<void> unPair(String deviceId) async {
+  Future<void> unpair(String deviceId) async {
     BlueZDevice device = _findDeviceById(deviceId);
     if (device.paired) {
       // await device.cancelPairing();

--- a/lib/src/universal_ble_pigeon/universal_ble_pigeon_channel.dart
+++ b/lib/src/universal_ble_pigeon/universal_ble_pigeon_channel.dart
@@ -108,7 +108,7 @@ class UniversalBlePigeonChannel extends UniversalBlePlatform {
   Future<void> pair(String deviceId) => _channel.pair(deviceId);
 
   @override
-  Future<void> unPair(String deviceId) => _channel.unPair(deviceId);
+  Future<void> unpair(String deviceId) => _channel.unPair(deviceId);
 
   @override
   Future<List<BleDevice>> getSystemDevices(

--- a/lib/src/universal_ble_pigeon/universal_ble_pigeon_channel.dart
+++ b/lib/src/universal_ble_pigeon/universal_ble_pigeon_channel.dart
@@ -126,16 +126,11 @@ class UniversalBlePigeonChannel extends UniversalBlePlatform {
   /// To set listeners
   void _setupListeners() {
     UniversalBleCallbackChannel.setUp(_UniversalBleCallbackHandler(
-      scanResult: (BleDevice bleDevice) => updateScanResult(bleDevice),
-      availabilityChange: (AvailabilityState state) =>
-          onAvailabilityChange?.call(state),
-      connectionChanged: (String deviceId, bool connected) =>
-          onConnectionChange?.call(deviceId, connected),
-      valueChanged:
-          (String deviceId, String characteristicId, Uint8List value) =>
-              updateCharacteristicValue(deviceId, characteristicId, value),
-      pairStateChange: (String deviceId, bool isPaired, String? error) =>
-          onPairingStateChange?.call(deviceId, isPaired, error),
+      scanResult: updateScanResult,
+      availabilityChange: updateAvailability,
+      connectionChanged: updateConnection,
+      valueChanged: updateCharacteristicValue,
+      pairStateChange: updatePairingState,
     ));
   }
 }

--- a/lib/src/universal_ble_platform_interface.dart
+++ b/lib/src/universal_ble_platform_interface.dart
@@ -43,7 +43,7 @@ abstract class UniversalBlePlatform {
 
   Future<void> pair(String deviceId);
 
-  Future<void> unPair(String deviceId);
+  Future<void> unpair(String deviceId);
 
   Future<BleConnectionState> getConnectionState(String deviceId);
 

--- a/lib/src/universal_ble_platform_interface.dart
+++ b/lib/src/universal_ble_platform_interface.dart
@@ -1,9 +1,11 @@
+import 'dart:async';
 import 'dart:developer';
 import 'dart:typed_data';
 import 'package:universal_ble/universal_ble.dart';
 
 abstract class UniversalBlePlatform {
   ScanFilter? _scanFilter;
+  StreamController? _connectionStreamController;
 
   Future<AvailabilityState> getBluetoothAvailabilityState();
 
@@ -51,6 +53,15 @@ abstract class UniversalBlePlatform {
     List<String>? withServices,
   );
 
+  bool receivesAdvertisements(String deviceId) => true;
+
+  Stream<bool> connectionStream(String deviceId) {
+    _setupConnectionStreamIfRequired();
+    return _connectionStreamController!.stream
+        .where((event) => event.deviceId == deviceId)
+        .map((event) => event.isConnected);
+  }
+
   void updateScanResult(BleDevice bleDevice) {
     // Filter by name
     ScanFilter? scanFilter = _scanFilter;
@@ -62,7 +73,11 @@ abstract class UniversalBlePlatform {
     onScanResult?.call(bleDevice);
   }
 
-  bool receivesAdvertisements(String deviceId) => true;
+  void updateConnection(String deviceId, bool isConnected) {
+    onConnectionChange?.call(deviceId, isConnected);
+    _connectionStreamController
+        ?.add((deviceId: deviceId, isConnected: isConnected));
+  }
 
   void updateCharacteristicValue(
       String deviceId, String characteristicId, Uint8List value) {
@@ -70,15 +85,39 @@ abstract class UniversalBlePlatform {
         deviceId, BleUuidParser.string(characteristicId), value);
   }
 
-  OnAvailabilityChange? onAvailabilityChange;
+  void updateAvailability(AvailabilityState state) {
+    onAvailabilityChange?.call(state);
+  }
+
+  void updatePairingState(String deviceId, bool isPaired, String? error) {
+    onPairingStateChange?.call(deviceId, isPaired, error);
+  }
+
+  // Do not use these directly to push updates
   OnScanResult? onScanResult;
   OnConnectionChange? onConnectionChange;
   OnValueChange? onValueChange;
+  OnAvailabilityChange? onAvailabilityChange;
   OnPairingStateChange? onPairingStateChange;
 
   static void logInfo(String message, {bool isError = false}) {
     if (isError) message = '\x1B[31m$message\x1B[31m';
     log(message, name: 'UniversalBle');
+  }
+
+  /// Creates an auto disposable streamController
+  void _setupConnectionStreamIfRequired() {
+    if (_connectionStreamController != null) return;
+
+    _connectionStreamController =
+        StreamController<({String deviceId, bool isConnected})>.broadcast();
+
+    // Auto dispose if no more subscribers
+    _connectionStreamController?.onCancel = () {
+      // logInfo('Disposing Connection Stream');
+      _connectionStreamController?.close();
+      _connectionStreamController = null;
+    };
   }
 }
 

--- a/lib/src/universal_ble_web/universal_ble_web.dart
+++ b/lib/src/universal_ble_web/universal_ble_web.dart
@@ -246,7 +246,7 @@ class UniversalBleWeb extends UniversalBlePlatform {
   }
 
   @override
-  Future<void> unPair(String deviceId) {
+  Future<void> unpair(String deviceId) {
     throw UnimplementedError();
   }
 

--- a/lib/src/universal_ble_web/universal_ble_web.dart
+++ b/lib/src/universal_ble_web/universal_ble_web.dart
@@ -45,14 +45,14 @@ class UniversalBleWeb extends UniversalBlePlatform {
 
     _connectedDeviceStreamList[deviceId] = device.connected.listen((event) {
       if (!event) _cleanConnection(deviceId);
-      onConnectionChange?.call(deviceId, event);
+      updateConnection(deviceId, event);
     });
   }
 
   @override
   Future<void> disconnect(String deviceId) async {
     _cleanConnection(deviceId);
-    onConnectionChange?.call(deviceId, false);
+    updateConnection(deviceId, false);
     _getDeviceById(deviceId)?.disconnect();
   }
 
@@ -270,7 +270,7 @@ class UniversalBleWeb extends UniversalBlePlatform {
         } else if (isAvailable) {
           newState = AvailabilityState.poweredOn;
         }
-        onAvailabilityChange?.call(newState);
+        updateAvailability(newState);
       },
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: universal_ble
 description: A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE) plugin for Flutter
-version: 0.11.1
+version: 0.12.0
 homepage: https://navideck.com
 repository: https://github.com/Navideck/universal_ble
 issue_tracker: https://github.com/Navideck/universal_ble/issues


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Enabled pairing API support for Cupertino platform by removing conditional checks.
- Always display pairing buttons in the peripheral detail page regardless of platform.
- Improved code level documentation by adding dots for better readability.
- Implemented pairing logic for Apple devices, including error handling and logging for debugging.
- Updated the changelog to include version 0.10.1 with new features and improvements.
- Updated the README to reflect new pairing and unpairing support details.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>capabilities.dart</strong><dd><code>Enable pairing API support for Cupertino platform</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example/lib/data/capabilities.dart

- Removed the Cupertino platform check for `supportsPairingApi`.



</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/59/files#diff-7ca6520bc280035eff1bdb0363b0b949f72f65c95304f9ffa0c1f2046dca4ffb">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>peripheral_detail_page.dart</strong><dd><code>Always display pairing buttons regardless of platform</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example/lib/peripheral_details/peripheral_detail_page.dart

<li>Removed conditional checks for <code>supportsPairingApi</code> before displaying <br>pairing buttons.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/59/files#diff-d27c53e1f72b2e62946d82111ebe75b0ddf554cabd123d995bd8cc6d91f7d34b">+20/-23</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>UniversalBlePlugin.swift</strong><dd><code>Implement pairing logic and improve debugging for Apple devices</code></dd></summary>
<hr>

darwin/Classes/UniversalBlePlugin.swift

<li>Implemented pairing logic for Apple devices.<br> <li> Added logging for debugging in <code>didUpdateValueFor</code>.<br> <li> Improved error handling in characteristic read futures.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/59/files#diff-87832239a271a17152d0bd5fd33a705cd1398bda21bfdfff19934f405c09965f">+27/-13</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>universal_ble.dart</strong><dd><code>Improve documentation and enhance pairing on Apple devices</code></dd></summary>
<hr>

lib/src/universal_ble.dart

<li>Added dots to code level documentation for better readability.<br> <li> Updated <code>pair</code> method to work on Apple devices with encrypted <code>read</code> <br>characteristics.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/59/files#diff-0299ec0dda75c972b21ca1a2d8ac5fc87bc4dc3f354c49c7995bcb3d18054304">+54/-52</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog for version 0.10.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Added version 0.10.1 with support for pairing on Apple and improved <br>documentation.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/59/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README with new pairing support details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Updated the pairing and unpairing support matrix to reflect new <br>changes.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/59/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

