### PR TITLE
Improve error handling and disconnection events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.10.1
+* Improve Android error handling
+* Fix: Android disconnection events were sometimes missed
+* Improve cleanup after disconnection on Apple and Android
+
 ## 0.10.0
 * BREAKING CHANGE: `ScanResult` is now `BleDevice`
 * BREAKING CHANGE: `getConnectedDevices` is now `getSystemDevices`

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt
@@ -298,14 +298,14 @@ fun Short.toByteArray(byteOrder: ByteOrder = ByteOrder.LITTLE_ENDIAN): ByteArray
 fun unknownCharacteristicError(char: String) =
     FlutterError("IllegalArgument", "Unknown error", null)
 
-// Future result classes
-class BleCharacteristicFuture(
-    val deviceId: String,
-    val characteristicId: String,
-    val serviceId: String,
-    val result: (Result<ByteArray>) -> Unit,
+
+val DeviceDisconnectedError: FlutterError = FlutterError(
+    "DeviceDisconnected",
+    "Device Disconnected",
+    null
 )
 
+// Future result classes
 class DiscoverServicesFuture(
     val deviceId: String,
     val result: (Result<List<UniversalBleService>>) -> Unit,
@@ -316,6 +316,13 @@ class MtuResultFuture(
     val result: (Result<Long>) -> Unit,
 )
 
+class ReadResultFuture(
+    val deviceId: String,
+    val characteristicId: String,
+    val serviceId: String,
+    val result: (Result<ByteArray>) -> Unit,
+)
+
 class WriteResultFuture(
     val deviceId: String,
     val characteristicId: String,
@@ -323,7 +330,7 @@ class WriteResultFuture(
     val result: (Result<Unit>) -> Unit,
 )
 
-class CharacteristicSubscriptionFuture(
+class SubscriptionResultFuture(
     val deviceId: String,
     val characteristicId: String,
     val serviceId: String,

--- a/darwin/Classes/UniversalBlePlugin.swift
+++ b/darwin/Classes/UniversalBlePlugin.swift
@@ -121,6 +121,24 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
       }
       return false
     }
+    characteristicWriteFutures.removeAll { future in
+      if future.deviceId == deviceId {
+        future.result(
+          Result.failure(FlutterError(code: "DeviceDisconnected", message: "Device Disconnected", details: nil))
+        )
+        return true
+      }
+      return false
+    }
+    characteristicNotifyFutures.removeAll { future in
+      if future.deviceId == deviceId {
+        future.result(
+          Result.failure(FlutterError(code: "DeviceDisconnected", message: "Device Disconnected", details: nil))
+        )
+        return true
+      }
+      return false
+    }
     discoverServicesFutures.removeAll { future in
       if future.deviceId == deviceId {
         future.result(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: universal_ble
 description: A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE) plugin for Flutter
-version: 0.10.0
+version: 0.10.1
 homepage: https://navideck.com
 repository: https://github.com/Navideck/universal_ble
 issue_tracker: https://github.com/Navideck/universal_ble/issues


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added `DeviceDisconnectedError` for better error handling in Android.
- Improved cleanup logic on disconnection for both Android and Apple.
- Renamed several future result classes for clarity.
- Added error handling for `requestMtu` and `discoverServices` methods in Android.
- Updated changelog and version number to 0.10.1.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UniversalBleHelper.kt</strong><dd><code>Improve error handling and future result classes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt

<li>Added <code>DeviceDisconnectedError</code> for better error handling.<br> <li> Renamed <code>BleCharacteristicFuture</code> to <code>ReadResultFuture</code>.<br> <li> Added <code>ReadResultFuture</code> class.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/60/files#diff-07528325c9af8065d3fe07cc2436350a5db4dde75378b96e4801cdc7675b128a">+14/-7</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>UniversalBlePlugin.kt</strong><dd><code>Enhance error handling and disconnection cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt

<li>Added error handling for <code>requestMtu</code> and <code>discoverServices</code>.<br> <li> Improved cleanup logic on disconnection.<br> <li> Renamed <code>CharacteristicSubscriptionFuture</code> to <code>SubscriptionResultFuture</code>.<br> <li> Added detailed logging for connection state changes.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/60/files#diff-9bf8297311d93083e68b98b07fd87ec8038bf693833cef20b676ac88a4aa837e">+71/-51</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>UniversalBlePlugin.swift</strong><dd><code>Improve disconnection cleanup on Apple</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

darwin/Classes/UniversalBlePlugin.swift

<li>Improved cleanup after disconnection by removing futures and returning <br>errors.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/60/files#diff-87832239a271a17152d0bd5fd33a705cd1398bda21bfdfff19934f405c09965f">+18/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog for version 0.10.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Updated changelog for version 0.10.1 with details on improvements and <br>fixes.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/60/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pubspec.yaml</strong><dd><code>Bump version to 0.10.1</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pubspec.yaml

- Bumped version to 0.10.1.



</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/60/files#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

