### PR TITLE
Receive advertisement events on web

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,35 @@
                 "--dart-define",
                 "MOCK=true",
             ]
+        },
+        {
+            "name": "example_web",
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart",
+            "program": "lib/main.dart",
+            "args": [
+                "-d",
+                "web-server",
+                "--web-hostname=127.0.0.1",
+                "--web-port=8080"
+            ],
+            "preLaunchTask": "open_chrome"
+        },
+    ],
+    "tasks": [
+        {
+            "label": "open_chrome",
+            "type": "shell",
+            "command": "open",
+            "args": [
+                "-na",
+                "Google Chrome",
+                "--args",
+                "--user-data-dir=/tmp/temporary-chrome-profile-dir",
+                "--disable-web-security",
+                "--disable-site-isolation-trials"
+            ],
         }
-    ]
+    ],
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.11.1
 * Trim spaces in UUIDs
+* Receive advertisement events on web
+* Improve cleanup after disconnection on web
 
 ## 0.11.0
 * Unify UUID format across all platforms, 128-bit lowercase

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ You can optionally set filters when scanning.
 
 ##### With Services
 
-When setting this parameter, the scan results will only include devices that advertize any of the specified services. This is the primary filter. All devices are first filtered by services, then further filtered by other criteria. This parameter is mandatory on [web](#web) if you want to access those services.
+When setting this parameter, the scan results will only include devices that advertise any of the specified services. This is the primary filter. All devices are first filtered by services, then further filtered by other criteria. This parameter is mandatory on [web](#web) if you want to access those services.
 
 ```dart
 List<String> withServices;
@@ -328,7 +328,7 @@ When publishing on Windows you need to declare the following [capabilities](http
 
 ### Web
 
-On web, the `withServices` parameter in the ScanFilter is used as [optional_services](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice#optionalservices) as well as a services filter. On web you have to set this parameter to ensure that you can access the specified services after connecting to the device. You can leave it empty for the rest of the platforms if your device does not advertize services.
+On web, the `withServices` parameter in the ScanFilter is used as [optional_services](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice#optionalservices) as well as a services filter. On web you have to set this parameter to ensure that you can access the specified services after connecting to the device. You can leave it empty for the rest of the platforms if your device does not advertise services.
 
 ```dart
 ScanFilter(

--- a/example/lib/home/home.dart
+++ b/example/lib/home/home.dart
@@ -72,17 +72,7 @@ class _MyAppState extends State<MyApp> {
 
   Future<void> startScan() async {
     await UniversalBle.startScan(
-      scanFilter: ScanFilter(
-        withManufacturerData: [
-          ManufacturerDataFilter(
-            companyIdentifier: 0x012D,
-          )
-        ],
-        withServices: [
-          '180a',
-          '180f',
-        ],
-      ),
+      scanFilter: scanFilter,
     );
   }
 

--- a/example/lib/home/home.dart
+++ b/example/lib/home/home.dart
@@ -1,5 +1,7 @@
 // ignore_for_file: use_build_context_synchronously
 
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
 import 'package:universal_ble/universal_ble.dart';
 import 'package:universal_ble_example/data/capabilities.dart';
@@ -50,8 +52,7 @@ class _MyAppState extends State<MyApp> {
     };
 
     UniversalBle.onScanResult = (result) {
-      // debugPrint("BleDevice: ${result.name}  ${result.services}");
-      // debugPrint("${result.name} ${result.manufacturerData}");
+      log(result.toString());
       int index = _bleDevices.indexWhere((e) => e.deviceId == result.deviceId);
       if (index == -1) {
         _bleDevices.add(result);
@@ -71,7 +72,17 @@ class _MyAppState extends State<MyApp> {
 
   Future<void> startScan() async {
     await UniversalBle.startScan(
-      scanFilter: scanFilter,
+      scanFilter: ScanFilter(
+        withManufacturerData: [
+          ManufacturerDataFilter(
+            companyIdentifier: 0x012D,
+          )
+        ],
+        withServices: [
+          '180a',
+          '180f',
+        ],
+      ),
     );
   }
 

--- a/example/lib/home/widgets/scan_filter_widget.dart
+++ b/example/lib/home/widgets/scan_filter_widget.dart
@@ -74,6 +74,7 @@ class _ScanFilterWidgetState extends State<ScanFilterWidget> {
           ScanFilter(
             withServices: serviceUUids,
             withNamePrefix: namePrefixes,
+            withManufacturerData: manufacturerDataFilters,
           ),
         );
         ScaffoldMessenger.of(context).showSnackBar(

--- a/example/lib/peripheral_details/peripheral_detail_page.dart
+++ b/example/lib/peripheral_details/peripheral_detail_page.dart
@@ -93,16 +93,20 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
   }
 
   Future<void> _discoverServices() async {
-    var services = await UniversalBle.discoverServices(widget.deviceId);
-    print('${services.length} services discovered');
-    discoveredServices.clear();
-    setState(() {
-      discoveredServices = services;
-    });
+    try {
+      var services = await UniversalBle.discoverServices(widget.deviceId);
+      print('${services.length} services discovered');
+      discoveredServices.clear();
+      setState(() {
+        discoveredServices = services;
+      });
 
-    if (kIsWeb) {
-      _addLog("DiscoverServices",
-          '${services.length} services discovered,\nNote: Only services added in ScanFilter will be discovered');
+      if (kIsWeb) {
+        _addLog("DiscoverServices",
+            '${services.length} services discovered,\nNote: Only services added in ScanFilter will be discovered');
+      }
+    } catch (e) {
+      _addLog("DiscoverServicesError", e);
     }
   }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -402,7 +402,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.11.0"
+    version: "0.11.1"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/models/ble_device.dart
+++ b/lib/src/models/ble_device.dart
@@ -18,10 +18,10 @@ class BleDevice {
   Future<BleConnectionState> get connectionState =>
       UniversalBle.getConnectionState(deviceId);
 
-  /// On Web, it returns true if the web browser supports [watchAdvertisements].
+  /// On web, it returns true if the web browser supports receiving advertisements from this device.
   /// The rest of the platforms will always return true.
-  bool get canWatchAdvertisements =>
-      UniversalBle.canWatchAdvertisements(deviceId);
+  bool get receivesAdvertisements =>
+      UniversalBle.receivesAdvertisements(deviceId);
 
   BleDevice({
     required this.deviceId,

--- a/lib/src/models/ble_device.dart
+++ b/lib/src/models/ble_device.dart
@@ -12,14 +12,14 @@ class BleDevice {
   Uint8List? manufacturerDataHead;
   Uint8List? manufacturerData;
 
-  /// Returns connection state of device,
-  /// All platforms will return `Connected/Disconnected` states
-  /// `Android` and `Apple` can also return `Connecting/Disconnecting` states
+  /// Returns connection state of the device.
+  /// All platforms will return `Connected/Disconnected` states.
+  /// `Android` and `Apple` can also return `Connecting/Disconnecting` states.
   Future<BleConnectionState> get connectionState =>
       UniversalBle.getConnectionState(deviceId);
 
-  /// returns true if the current browser supports the [watchAdvertisements] on `Web`,
-  /// rest of the platforms will always return true
+  /// On Web, it returns true if the web browser supports [watchAdvertisements].
+  /// The rest of the platforms will always return true.
   bool get canWatchAdvertisements =>
       UniversalBle.canWatchAdvertisements(deviceId);
 

--- a/lib/src/models/ble_device.dart
+++ b/lib/src/models/ble_device.dart
@@ -18,6 +18,11 @@ class BleDevice {
   Future<BleConnectionState> get connectionState =>
       UniversalBle.getConnectionState(deviceId);
 
+  /// returns true if the current browser supports the [watchAdvertisements] on `Web`,
+  /// rest of the platforms will always return true
+  bool get canWatchAdvertisements =>
+      UniversalBle.canWatchAdvertisements(deviceId);
+
   BleDevice({
     required this.deviceId,
     required this.name,

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -225,12 +225,15 @@ class UniversalBle {
     );
   }
 
-  /// On Web, it returns true if the web browser supports [watchAdvertisements]. The rest of the platforms will always return true.
-  /// If [canWatchAdvertisements] returns true on `Web`, then you will get scanResult updates of the selected device.
-  /// Not every browser supports this API yet. It is hidden behind the `chrome://flags/#enable-experimental-web-platform-features` flag.
-  /// Even if the device technically has the method, sometimes it won't update ScanResults even though the device may be sending them.
-  static bool canWatchAdvertisements(String deviceId) =>
-      _platform.canWatchAdvertisements(deviceId);
+  /// [receivesAdvertisements] returns true on web if the browser supports receiving advertisements from a certain `deviceId`.
+  /// The rest of the platforms will always return true.
+  /// If true, then you will be getting scanResult updates for this device.
+  ///
+  /// For this feature to work, you need to enable the `chrome://flags/#enable-experimental-web-platform-features` flag.
+  /// Not every browser supports this API yet.
+  /// Even if the browser supports it, sometimes it won't fire any advertisement events even though the device may be sending them.
+  static bool receivesAdvertisements(String deviceId) =>
+      _platform.receivesAdvertisements(deviceId);
 
   /// Get Bluetooth state availability
   static set onAvailabilityChange(OnAvailabilityChange? onAvailabilityChange) {

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -225,6 +225,13 @@ class UniversalBle {
     );
   }
 
+  /// Check to see if the current browser supports the [watchAdvertisements] on `Web`, Rest of the platforms will always return true
+  /// if [canWatchAdvertisements] returns true on `Web`, then you will get scanResult updates of selected device
+  /// Not every browser supports this API yet. this is hidden behind chrome://flags/#enable-experimental-web-platform-features flag.
+  /// Even if the device technically has the method, sometimes it won't update ScanResults even though the device may be sending them
+  static bool canWatchAdvertisements(String deviceId) =>
+      _platform.canWatchAdvertisements(deviceId);
+
   /// Get Bluetooth state availability
   static set onAvailabilityChange(OnAvailabilityChange? onAvailabilityChange) {
     _platform.onAvailabilityChange = onAvailabilityChange;

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -207,9 +207,9 @@ class UniversalBle {
     );
   }
 
-  /// Returns connection state of device,
-  /// All platforms will return `Connected/Disconnected` states
-  /// `Android` and `Apple` can also return `Connecting/Disconnecting` states
+  /// Returns connection state of the device.
+  /// All platforms will return `Connected/Disconnected` states.
+  /// `Android` and `Apple` can also return `Connecting/Disconnecting` states.
   static Future<BleConnectionState> getConnectionState(String deviceId) async {
     return await _bleCommandQueue.queueCommand(
       () => _platform.getConnectionState(deviceId),
@@ -225,10 +225,10 @@ class UniversalBle {
     );
   }
 
-  /// Check to see if the current browser supports the [watchAdvertisements] on `Web`, Rest of the platforms will always return true
-  /// if [canWatchAdvertisements] returns true on `Web`, then you will get scanResult updates of selected device
-  /// Not every browser supports this API yet. this is hidden behind chrome://flags/#enable-experimental-web-platform-features flag.
-  /// Even if the device technically has the method, sometimes it won't update ScanResults even though the device may be sending them
+  /// On Web, it returns true if the web browser supports [watchAdvertisements]. The rest of the platforms will always return true.
+  /// If [canWatchAdvertisements] returns true on `Web`, then you will get scanResult updates of the selected device.
+  /// Not every browser supports this API yet. It is hidden behind the `chrome://flags/#enable-experimental-web-platform-features` flag.
+  /// Even if the device technically has the method, sometimes it won't update ScanResults even though the device may be sending them.
   static bool canWatchAdvertisements(String deviceId) =>
       _platform.canWatchAdvertisements(deviceId);
 

--- a/lib/src/universal_ble_platform_interface.dart
+++ b/lib/src/universal_ble_platform_interface.dart
@@ -62,6 +62,8 @@ abstract class UniversalBlePlatform {
     onScanResult?.call(bleDevice);
   }
 
+  bool canWatchAdvertisements(String deviceId) => true;
+
   /// `onValueChange` interceptor to parse the native uuids to 128 bit uuid, to keep consistency
   void updateCharacteristicValue(
       String deviceId, String characteristicId, Uint8List value) {

--- a/lib/src/universal_ble_platform_interface.dart
+++ b/lib/src/universal_ble_platform_interface.dart
@@ -50,7 +50,6 @@ abstract class UniversalBlePlatform {
     List<String>? withServices,
   );
 
-  /// `onScanResult` interceptor to filter by name
   void updateScanResult(BleDevice bleDevice) {
     // Filter by name
     ScanFilter? scanFilter = _scanFilter;
@@ -62,9 +61,8 @@ abstract class UniversalBlePlatform {
     onScanResult?.call(bleDevice);
   }
 
-  bool canWatchAdvertisements(String deviceId) => true;
+  bool receivesAdvertisements(String deviceId) => true;
 
-  /// `onValueChange` interceptor to parse the native uuids to 128 bit uuid, to keep consistency
   void updateCharacteristicValue(
       String deviceId, String characteristicId, Uint8List value) {
     onValueChange?.call(

--- a/lib/src/universal_ble_web/universal_ble_web.dart
+++ b/lib/src/universal_ble_web/universal_ble_web.dart
@@ -145,33 +145,22 @@ class UniversalBleWeb extends UniversalBlePlatform {
           !device.hasWatchAdvertisements()) return;
 
       if (_deviceAdvertisementStreamList[device.id] != null) {
-        UniversalBlePlatform.logInfo(
-          "Resetting Advertisement watcher for ${device.id}",
-        );
         _deviceAdvertisementStreamList[device.id]?.cancel();
         await device.unwatchAdvertisements();
-      } else {
-        UniversalBlePlatform.logInfo(
-          "Setting Advertisement watcher for ${device.id}",
-        );
       }
 
-      _deviceAdvertisementStreamList[device.id] = device.advertisements.listen(
-        (event) {
-          updateScanResult(
-            device.toBleScanResult(
-              rssi: event.rssi,
-              manufacturerDataMap: event.manufacturerData,
-              services: event.uuids,
-            ),
-          );
-        },
-      );
+      _deviceAdvertisementStreamList[device.id] =
+          device.advertisements.listen((event) {
+        updateScanResult(
+          device.toBleScanResult(
+            rssi: event.rssi,
+            manufacturerDataMap: event.manufacturerData,
+            services: event.uuids,
+          ),
+        );
+      });
 
       await device.watchAdvertisements();
-      UniversalBlePlatform.logInfo(
-        "AdvertisementWatcherStarted: ${device.id}",
-      );
     } catch (e) {
       UniversalBlePlatform.logInfo(
         "WebWatchAdvertisementError: $e",

--- a/lib/src/universal_ble_web/universal_ble_web.dart
+++ b/lib/src/universal_ble_web/universal_ble_web.dart
@@ -139,7 +139,7 @@ class UniversalBleWeb extends UniversalBlePlatform {
   }
 
   @override
-  bool canWatchAdvertisements(String deviceId) =>
+  bool receivesAdvertisements(String deviceId) =>
       _getDeviceById(deviceId)?.hasWatchAdvertisements() ?? false;
 
   /// This will work only if `chrome://flags/#enable-experimental-web-platform-features` is enabled

--- a/lib/src/universal_ble_web/universal_ble_web.dart
+++ b/lib/src/universal_ble_web/universal_ble_web.dart
@@ -138,11 +138,14 @@ class UniversalBleWeb extends UniversalBlePlatform {
     _watchDeviceAdvertisements(device);
   }
 
+  @override
+  bool canWatchAdvertisements(String deviceId) =>
+      _getDeviceById(deviceId)?.hasWatchAdvertisements() ?? false;
+
   /// This will work only if `chrome://flags/#enable-experimental-web-platform-features` is enabled
   Future<void> _watchDeviceAdvertisements(BluetoothDevice device) async {
     try {
-      if (!FlutterWebBluetooth.instance.hasRequestLEScan ||
-          !device.hasWatchAdvertisements()) return;
+      if (!device.hasWatchAdvertisements()) return;
 
       if (_deviceAdvertisementStreamList[device.id] != null) {
         _deviceAdvertisementStreamList[device.id]?.cancel();
@@ -159,7 +162,7 @@ class UniversalBleWeb extends UniversalBlePlatform {
           ),
         );
       });
-
+      device.advertisementsUseMemory = true;
       await device.watchAdvertisements();
     } catch (e) {
       UniversalBlePlatform.logInfo(


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation, Bug fix


___

### **Description**
- Improved logging for BLE scan results by replacing `debugPrint` with `log`.
- Added `withManufacturerData` filter to scan filter widget.
- Added error handling for service discovery in peripheral detail page.
- Added `receivesAdvertisements` property to `BleDevice` and method to `UniversalBle`.
- Improved advertisement handling and cleanup on web.
- Added new launch configuration for web development in VSCode.
- Updated changelog for new features and improvements.
- Fixed typos and clarified usage of `withServices` parameter on web in README.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>home.dart</strong><dd><code>Improve logging for BLE scan results.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example/lib/home/home.dart

<li>Added <code>dart:developer</code> import.<br> <li> Replaced <code>debugPrint</code> with <code>log</code> for scan results.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/63/files#diff-da1b5bdcb6f7b90bf5ad0c250e3af4c06567c23d1ebe6135325b8d30241a3838">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>scan_filter_widget.dart</strong><dd><code>Add manufacturer data filter to scan widget.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example/lib/home/widgets/scan_filter_widget.dart

- Added `withManufacturerData` filter to scan filter widget.



</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/63/files#diff-2e16cc2ffa0178b5fb2a9624cc78b337dc2a524ec59fe58a2f05fc616b6e94c7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ble_device.dart</strong><dd><code>Add receivesAdvertisements property to BleDevice.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/models/ble_device.dart

<li>Added <code>receivesAdvertisements</code> property to <code>BleDevice</code>.<br> <li> Improved documentation for connection state.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/63/files#diff-ee570ae7012a23746736f11e460a03cc3f91a7a215ea081a588a145ac0931247">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble.dart</strong><dd><code>Add receivesAdvertisements method to UniversalBle.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/universal_ble.dart

<li>Added <code>receivesAdvertisements</code> method.<br> <li> Improved documentation for connection state.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/63/files#diff-0299ec0dda75c972b21ca1a2d8ac5fc87bc4dc3f354c49c7995bcb3d18054304">+13/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble_platform_interface.dart</strong><dd><code>Add receivesAdvertisements method to platform interface.</code>&nbsp; </dd></summary>
<hr>

lib/src/universal_ble_platform_interface.dart

- Added `receivesAdvertisements` method to platform interface.



</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/63/files#diff-127e48afab502be75a7cc9a9d97749f8a34e499dc343bff386b3da7ddd0ea4b3">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble_web.dart</strong><dd><code>Improve advertisement handling on web.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/universal_ble_web/universal_ble_web.dart

<li>Added <code>receivesAdvertisements</code> method for web.<br> <li> Improved advertisement watching and cleanup.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/63/files#diff-dc72e700f7c098e3f4e71b5d1f38c8514d3007af606d0fd15b1e5f0ecbd580cd">+61/-44</a>&nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>peripheral_detail_page.dart</strong><dd><code>Add error handling for service discovery.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example/lib/peripheral_details/peripheral_detail_page.dart

<li>Wrapped service discovery in a try-catch block.<br> <li> Added error logging for service discovery.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/63/files#diff-d27c53e1f72b2e62946d82111ebe75b0ddf554cabd123d995bd8cc6d91f7d34b">+13/-9</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>launch.json</strong><dd><code>Add launch configuration for web development.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.vscode/launch.json

<li>Added new launch configuration for web.<br> <li> Added task to open Chrome with specific arguments.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/63/files#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945">+30/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog for new features and improvements.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Added entries for receiving advertisement events on web.<br> <li> Added entries for improved cleanup after disconnection on web.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/63/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Fix typos and clarify web usage in README.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Fixed typos in documentation.<br> <li> Clarified usage of <code>withServices</code> parameter on web.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/63/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

