### PR TITLE
Improve web support

### DIFF
--- a/example/lib/peripheral_details/peripheral_detail_page.dart
+++ b/example/lib/peripheral_details/peripheral_detail_page.dart
@@ -152,7 +152,8 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
         selectedCharacteristic!.service.uuid,
         selectedCharacteristic!.characteristic.uuid,
         value,
-        isValidProperty([CharacteristicProperty.writeWithoutResponse])
+        _hasSelectedCharacteristicProperty(
+                [CharacteristicProperty.writeWithoutResponse])
             ? BleOutputProperty.withoutResponse
             : BleOutputProperty.withResponse,
       );
@@ -187,17 +188,6 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
     } catch (e) {
       _addLog('NotifyError', e);
     }
-  }
-
-  bool isValidProperty(List<CharacteristicProperty> properties) {
-    for (CharacteristicProperty property in properties) {
-      if (selectedCharacteristic?.characteristic.properties
-              .contains(property) ??
-          false) {
-        return true;
-      }
-    }
-    return false;
   }
 
   @override
@@ -309,7 +299,7 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
                               ),
                             ),
 
-                      if (isValidProperty([
+                      if (_hasSelectedCharacteristicProperty([
                         CharacteristicProperty.write,
                         CharacteristicProperty.writeWithoutResponse
                       ]))
@@ -377,7 +367,7 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
                             PlatformButton(
                               enabled: isConnected &&
                                   discoveredServices.isNotEmpty &&
-                                  isValidProperty([
+                                  _hasSelectedCharacteristicProperty([
                                     CharacteristicProperty.read,
                                   ]),
                               onPressed: _readValue,
@@ -386,7 +376,7 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
                             PlatformButton(
                               enabled: isConnected &&
                                   discoveredServices.isNotEmpty &&
-                                  isValidProperty([
+                                  _hasSelectedCharacteristicProperty([
                                     CharacteristicProperty.write,
                                     CharacteristicProperty.writeWithoutResponse
                                   ]),
@@ -396,7 +386,7 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
                             PlatformButton(
                               enabled: isConnected &&
                                   discoveredServices.isNotEmpty &&
-                                  isValidProperty([
+                                  _hasSelectedCharacteristicProperty([
                                     CharacteristicProperty.notify,
                                     CharacteristicProperty.indicate
                                   ]),
@@ -407,7 +397,7 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
                             PlatformButton(
                               enabled: isConnected &&
                                   discoveredServices.isNotEmpty &&
-                                  isValidProperty([
+                                  _hasSelectedCharacteristicProperty([
                                     CharacteristicProperty.notify,
                                     CharacteristicProperty.indicate
                                   ]),
@@ -478,4 +468,11 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
       }),
     );
   }
+
+  bool _hasSelectedCharacteristicProperty(
+          List<CharacteristicProperty> properties) =>
+      properties.any((property) =>
+          selectedCharacteristic?.characteristic.properties
+              .contains(property) ??
+          false);
 }

--- a/example/lib/peripheral_details/peripheral_detail_page.dart
+++ b/example/lib/peripheral_details/peripheral_detail_page.dart
@@ -152,7 +152,9 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
         selectedCharacteristic!.service.uuid,
         selectedCharacteristic!.characteristic.uuid,
         value,
-        BleOutputProperty.withResponse,
+        isValidProperty([CharacteristicProperty.writeWithoutResponse])
+            ? BleOutputProperty.withoutResponse
+            : BleOutputProperty.withResponse,
       );
       _addLog('Write', value);
     } catch (e) {

--- a/lib/src/universal_ble_web/universal_ble_web.dart
+++ b/lib/src/universal_ble_web/universal_ble_web.dart
@@ -304,7 +304,9 @@ class UniversalBleWeb extends UniversalBlePlatform {
 
   BluetoothDevice? _getDeviceById(String id) => _bluetoothDeviceList[id];
 
-  /// Cache all services and its characteristics, and use that for further communication, clears cache on disconnection
+  /// Get services and their characteristics.
+  /// Services and characteristics are cached.
+  /// Clears cache on disconnection.
   Future<List<_UniversalWebBluetoothService>> _getServices(
     String deviceId,
   ) async {

--- a/lib/src/universal_ble_web/universal_ble_web.dart
+++ b/lib/src/universal_ble_web/universal_ble_web.dart
@@ -58,7 +58,7 @@ class UniversalBleWeb extends UniversalBlePlatform {
 
   @override
   Future<List<BleService>> discoverServices(String deviceId) async =>
-      (await _getServices(deviceId)).map((e) => e.bleService).toList();
+      (await _getServices(deviceId)).map((e) => e._bleService).toList();
 
   @override
   Future<AvailabilityState> getBluetoothAvailabilityState() async {
@@ -471,7 +471,7 @@ class _UniversalWebBluetoothService {
     return null;
   }
 
-  BleService get bleService => BleService(
+  BleService get _bleService => BleService(
         service.uuid,
         characteristics.map((e) {
           return BleCharacteristic(e.uuid, [

--- a/lib/src/universal_ble_web/universal_ble_web.dart
+++ b/lib/src/universal_ble_web/universal_ble_web.dart
@@ -18,6 +18,7 @@ class UniversalBleWeb extends UniversalBlePlatform {
   final Map<String, StreamSubscription> _deviceAdvertisementStreamList = {};
   final Map<String, StreamSubscription> _connectedDeviceStreamList = {};
   final Map<String, StreamSubscription> _characteristicStreamList = {};
+  final Map<String, List<_UniversalWebBluetoothService>> _serviceCache = {};
 
   @override
   Future<BleConnectionState> getConnectionState(String deviceId) async {
@@ -56,47 +57,8 @@ class UniversalBleWeb extends UniversalBlePlatform {
   }
 
   @override
-  Future<List<BleService>> discoverServices(String deviceId) async {
-    final device = _getDeviceById(deviceId);
-    final services = await device?.discoverServices();
-    if (services == null) return [];
-    var discoveredServices = <BleService>[];
-    for (var service in services) {
-      final characteristics = await service.getCharacteristics();
-      List<BleCharacteristic> bleCharacteristics = [];
-      for (BluetoothCharacteristic characteristic in characteristics) {
-        List<CharacteristicProperty> properties = [];
-        if (characteristic.properties.broadcast) {
-          properties.add(CharacteristicProperty.broadcast);
-        }
-        if (characteristic.properties.read) {
-          properties.add(CharacteristicProperty.read);
-        }
-        if (characteristic.properties.writeWithoutResponse) {
-          properties.add(CharacteristicProperty.writeWithoutResponse);
-        }
-        if (characteristic.properties.write) {
-          properties.add(CharacteristicProperty.write);
-        }
-        if (characteristic.properties.notify) {
-          properties.add(CharacteristicProperty.notify);
-        }
-        if (characteristic.properties.indicate) {
-          properties.add(CharacteristicProperty.indicate);
-        }
-        if (characteristic.properties.authenticatedSignedWrites) {
-          properties.add(CharacteristicProperty.authenticatedSignedWrites);
-        }
-        bleCharacteristics.add(
-          BleCharacteristic(characteristic.uuid.toString(), properties),
-        );
-      }
-      discoveredServices.add(
-        BleService(service.uuid.toString(), bleCharacteristics),
-      );
-    }
-    return discoveredServices;
-  }
+  Future<List<BleService>> discoverServices(String deviceId) async =>
+      (await _getServices(deviceId)).map((e) => e.bleService).toList();
 
   @override
   Future<AvailabilityState> getBluetoothAvailabilityState() async {
@@ -118,6 +80,7 @@ class UniversalBleWeb extends UniversalBlePlatform {
     ScanFilter? scanFilter,
     PlatformConfig? platformConfig,
   }) async {
+    FlutterWebBluetooth.instance.isAvailable;
     BluetoothDevice device = await FlutterWebBluetooth.instance.requestDevice(
       _getRequestOptionBuilder(scanFilter, platformConfig?.web),
     );
@@ -322,6 +285,7 @@ class UniversalBleWeb extends UniversalBlePlatform {
       return key.contains(deviceId);
     });
     _disposeAdvertisementWatcher(deviceId);
+    _serviceCache.remove(deviceId);
     // _bluetoothDeviceList.removeWhere((element) => element.id == deviceId);
   }
 
@@ -330,19 +294,30 @@ class UniversalBleWeb extends UniversalBlePlatform {
     required String serviceId,
     required String characteristicId,
   }) async {
-    final device = _getDeviceById(deviceId);
-    List<BluetoothService> services = await device?.discoverServices() ?? [];
-    BluetoothService? service;
-    for (BluetoothService bleService in services) {
-      if (bleService.uuid.toString() == serviceId.toString()) {
-        service = bleService;
-        break;
+    for (var service in await _getServices(deviceId)) {
+      if (BleUuidParser.compareStrings(service.uuid, serviceId)) {
+        return service.getCharacteristic(characteristicId);
       }
     }
-    return await service?.getCharacteristic(characteristicId.toString());
+    return null;
   }
 
   BluetoothDevice? _getDeviceById(String id) => _bluetoothDeviceList[id];
+
+  /// Cache all services and its characteristics, and use that for further communication, clears cache on disconnection
+  Future<List<_UniversalWebBluetoothService>> _getServices(
+    String deviceId,
+  ) async {
+    BluetoothDevice? device = _getDeviceById(deviceId);
+    if (device == null) return [];
+    var services = _serviceCache[deviceId] ?? [];
+    if (services.isNotEmpty) return services;
+    for (var service in await device.discoverServices()) {
+      services.add(await _UniversalWebBluetoothService.fromService(service));
+    }
+    _serviceCache[deviceId] = services;
+    return services;
+  }
 
   void _disposeAdvertisementWatcher([String? deviceId]) {
     _deviceAdvertisementStreamList.removeWhere((key, value) {
@@ -462,4 +437,52 @@ extension _UnmodifiableMapViewExtension on UnmodifiableMapView<int, ByteData> {
     List<int> bytes = byteData.buffer.asUint8List();
     return Uint8List.fromList(bytes + manufacturerDataValue);
   }
+}
+
+class _UniversalWebBluetoothService {
+  late String uuid;
+  BluetoothService service;
+  List<BluetoothCharacteristic> characteristics;
+
+  _UniversalWebBluetoothService({
+    required this.service,
+    required this.characteristics,
+  }) {
+    uuid = service.uuid;
+  }
+
+  static Future<_UniversalWebBluetoothService> fromService(
+    BluetoothService service,
+  ) async {
+    return _UniversalWebBluetoothService(
+      service: service,
+      characteristics: await service.getCharacteristics(),
+    );
+  }
+
+  BluetoothCharacteristic? getCharacteristic(String characteristicId) {
+    for (var characteristic in characteristics) {
+      if (BleUuidParser.compareStrings(characteristic.uuid, characteristicId)) {
+        return characteristic;
+      }
+    }
+    return null;
+  }
+
+  BleService get bleService => BleService(
+        service.uuid,
+        characteristics.map((e) {
+          return BleCharacteristic(e.uuid, [
+            if (e.properties.broadcast) CharacteristicProperty.broadcast,
+            if (e.properties.read) CharacteristicProperty.read,
+            if (e.properties.write) CharacteristicProperty.write,
+            if (e.properties.writeWithoutResponse)
+              CharacteristicProperty.writeWithoutResponse,
+            if (e.properties.notify) CharacteristicProperty.notify,
+            if (e.properties.indicate) CharacteristicProperty.indicate,
+            if (e.properties.authenticatedSignedWrites)
+              CharacteristicProperty.authenticatedSignedWrites,
+          ]);
+        }).toList(),
+      );
 }


### PR DESCRIPTION
### **User description**
Support IOS [Bluefy](https://apps.apple.com/de/app/bluefy-web-ble-browser/id1492822055) browser
Support [web_view_ble](https://pub.dev/packages/web_view_ble)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added a conditional check for `BleOutputProperty` in `peripheral_detail_page.dart` to handle write operations more effectively.
- Introduced a service cache in `universal_ble_web.dart` to improve performance and refactored related methods to utilize this cache.
- Created `_UniversalWebBluetoothService` class to encapsulate service and characteristic management.
- Improved error handling and code readability.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>peripheral_detail_page.dart</strong><dd><code>Add conditional check for BleOutputProperty in write operation</code></dd></summary>
<hr>

example/lib/peripheral_details/peripheral_detail_page.dart

<li>Added a conditional check for <code>BleOutputProperty</code> based on <br>characteristic properties.<br> <li> Improved error handling for write operations.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/66/files#diff-d27c53e1f72b2e62946d82111ebe75b0ddf554cabd123d995bd8cc6d91f7d34b">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble_web.dart</strong><dd><code>Implement service caching and refactor BLE service discovery</code></dd></summary>
<hr>

lib/src/universal_ble_web/universal_ble_web.dart

<li>Added a service cache to improve performance.<br> <li> Refactored <code>discoverServices</code> method to use the new service cache.<br> <li> Updated <code>_getBleCharacteristic</code> to use cached services.<br> <li> Introduced <code>_UniversalWebBluetoothService</code> class for better service <br>management.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/66/files#diff-dc72e700f7c098e3f4e71b5d1f38c8514d3007af606d0fd15b1e5f0ecbd580cd">+72/-49</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

