### PR TITLE
Fix Android notification for characteristics without CCCD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.11.2
 * Add `PlatformConfig` property in `StartScan`
 * Add `WebConfig` property in `PlatformConfig`
+* Fix notification for characteristics without cccd
 
 ## 0.11.1
 * Trim spaces in UUIDs

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -252,7 +252,7 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
             }
 
             if (descriptor != null) {
-                // Some devices does no need their CCCD to update
+                // Some devices do not need CCCD to update
                 @Suppress("DEPRECATION")
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     if (gatt.writeDescriptor(descriptor, value) != BluetoothStatusCodes.SUCCESS) {

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -231,45 +231,65 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
     ) {
         try {
             val gatt = deviceId.toBluetoothGatt()
-            val gattCharacteristic = gatt.getCharacteristic(service, characteristic)
-                ?: throw FlutterError(
-                    "IllegalArgument",
-                    "Unknown characteristic: $characteristic",
-                    null
-                )
+            val gattCharacteristic: BluetoothGattCharacteristic? =
+                gatt.getCharacteristic(service, characteristic)
 
-            if (gatt.setNotifiable(gattCharacteristic, bleInputProperty)) {
-                subscriptionResultFutureList.add(
-                    SubscriptionResultFuture(
-                        gatt.device.address,
-                        gattCharacteristic.uuid.toString(),
-                        gattCharacteristic.service.uuid.toString(),
-                        callback
-                    )
-                )
+            if (gattCharacteristic == null) {
+                callback(subscriptionFailedError("characteristic not found"))
+                return
+            }
+
+            val descriptor: BluetoothGattDescriptor? =
+                gattCharacteristic.getDescriptor(ccdCharacteristic)
+
+            val bleInputPropertyEnum: BleInputProperty =
+                BleInputProperty.values().first { it.value == bleInputProperty }
+
+            val (value, enable) = when (bleInputPropertyEnum) {
+                BleInputProperty.Notification -> BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE to true
+                BleInputProperty.Indication -> BluetoothGattDescriptor.ENABLE_INDICATION_VALUE to true
+                else -> BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE to false
+            }
+
+            if (descriptor != null) {
+                // Some devices does no need their CCCD to update
+                @Suppress("DEPRECATION")
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    if (gatt.writeDescriptor(descriptor, value) != BluetoothStatusCodes.SUCCESS) {
+                        callback(subscriptionFailedError("Failed to update descriptor"))
+                        return
+                    }
+                } else {
+                    descriptor.value = value
+                    if (!gatt.writeDescriptor(descriptor)) {
+                        callback(subscriptionFailedError("Failed to update descriptor"))
+                        return
+                    }
+                }
             } else {
-                callback(
-                    Result.failure(
-                        FlutterError(
-                            "Failed",
-                            "Failed to update subscription state",
-                            null
+                Log.d("UniversalBle", "CCCD Descriptor not found")
+            }
+
+            if (gatt.setCharacteristicNotification(gattCharacteristic, enable)) {
+                if (descriptor != null) {
+                    subscriptionResultFutureList.add(
+                        SubscriptionResultFuture(
+                            gatt.device.address,
+                            gattCharacteristic.uuid.toString(),
+                            gattCharacteristic.service.uuid.toString(),
+                            callback
                         )
                     )
-                )
+                } else {
+                    callback(Result.success(Unit))
+                }
+            } else {
+                callback(subscriptionFailedError())
             }
         } catch (e: FlutterError) {
             callback(Result.failure(e))
         } catch (e: Exception) {
-            callback(
-                Result.failure(
-                    FlutterError(
-                        "Failed",
-                        "Failed to update subscription state",
-                        e.toString()
-                    )
-                )
-            )
+            callback(subscriptionFailedError(e.toString()))
         }
     }
 
@@ -820,7 +840,7 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
         status: Int,
     ) {
         super.onDescriptorWrite(gatt, descriptor, status)
-        if (descriptor?.uuid.toString() == ccdCharacteristic) {
+        if (descriptor?.uuid.toString() == ccdCharacteristic.toString()) {
             val char: String? = descriptor?.characteristic?.uuid?.toString()
             val service: String? = descriptor?.characteristic?.service?.uuid?.toString()
             val deviceId: String? = gatt?.device?.address;

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -187,18 +187,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -235,18 +235,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -307,10 +307,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -384,10 +384,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -415,10 +415,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.4"
   webdriver:
     dependency: transitive
     description:


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added a null check for `BluetoothGattDescriptor` to handle cases where the descriptor is not found.
- Updated the logic to ensure that devices which do not require their CCCD to update are handled correctly.
- Improved error logging to provide more information when descriptor write operations fail.
- Ensured backward compatibility by using deprecated methods conditionally based on the Android version.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UniversalBleHelper.kt</strong><dd><code>Fix notification setup for characteristics without CCCD</code>&nbsp; &nbsp; </dd></summary>
<hr>

android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt

<li>Added null check for <code>BluetoothGattDescriptor</code>.<br> <li> Updated logic to handle devices without CCCD.<br> <li> Improved error logging for descriptor write failures.<br> <li> Ensured backward compatibility with deprecated methods.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/72/files#diff-07528325c9af8065d3fe07cc2436350a5db4dde75378b96e4801cdc7675b128a">+19/-7</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

