### PR TITLE
Remove error from onPairingStateChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 0.12.0
 * BREAKING CHANGE: `unPair` is now `unpair`
+* BREAKING CHANGE: `onPairingStateChange` does not return error anymore
 * Add `pair()`, `isPaired` and `onPairingStateChange` support for Apple and web
 * `connect()` and `pair()` now return a bool result
-* BREAKING CHANGE: `onPairingStateChange` does not return error anymore
 * Add `PlatformConfig` property in `StartScan`
 * Add `WebConfig` property in `PlatformConfig`
 * Fix notifications for characteristics without cccd on Android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * BREAKING CHANGE: `unPair` is now `unpair`
 * Add `pair()`, `isPaired` and `onPairingStateChange` support for Apple and web
 * `connect()` and `pair()` now return a bool result
+* BREAKING CHANGE: `onPairingStateChange` does not return error anymore
 * Add `PlatformConfig` property in `StartScan`
 * Add `WebConfig` property in `PlatformConfig`
 * Fix notifications for characteristics without cccd on Android

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ bool? isPaired = await UniversalBle.pair(deviceId); // Returns true if successfu
 UniversalBle.pair(deviceId, pairingCommand: BleCommand(service:"SERVICE", characteristic:"ENCRYPTED_CHARACTERISTIC",));
 
 // Receive pairing state changes
-UniversalBle.onPairingStateChange = (String deviceId, bool isPaired, String? error) {
+UniversalBle.onPairingStateChange = (String deviceId, bool isPaired) {
   // Handle pairing state change
 }
 

--- a/example/lib/data/mock_universal_ble.dart
+++ b/example/lib/data/mock_universal_ble.dart
@@ -103,13 +103,13 @@ class MockUniversalBle extends UniversalBlePlatform {
 
   @override
   Future<bool> pair(String deviceId) async {
-    updatePairingState(deviceId, true, null);
+    updatePairingState(deviceId, true);
     return true;
   }
 
   @override
   Future<void> unpair(String deviceId) async {
-    updatePairingState(deviceId, false, null);
+    updatePairingState(deviceId, false);
   }
 
   @override

--- a/example/lib/peripheral_details/peripheral_detail_page.dart
+++ b/example/lib/peripheral_details/peripheral_detail_page.dart
@@ -81,14 +81,9 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
     _addLog("Value", data);
   }
 
-  void _handlePairingStateChange(
-      String deviceId, bool isPaired, String? error) {
+  void _handlePairingStateChange(String deviceId, bool isPaired) {
     print('isPaired $deviceId, $isPaired');
-    if (error != null && error.isNotEmpty) {
-      _addLog("PairingStateChangeError", "(Paired: $isPaired): $error ");
-    } else {
-      _addLog("PairingStateChange - isPaired", isPaired);
-    }
+    _addLog("PairingStateChange - isPaired", isPaired);
   }
 
   Future<void> _discoverServices() async {

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -325,7 +325,7 @@ class UniversalBle {
         bool commandResult =
             await _executeBleCommand(deviceId, services, bleCommand);
         if (updateCallbackValue) {
-          _platform.updatePairingState(deviceId, commandResult, null);
+          _platform.updatePairingState(deviceId, commandResult);
         }
         return commandResult;
       }
@@ -334,7 +334,7 @@ class UniversalBle {
         "FailedToPerform EncryptedCharOperation: $e",
       );
       if (updateCallbackValue) {
-        _platform.updatePairingState(deviceId, false, e.toString());
+        _platform.updatePairingState(deviceId, false);
       }
       return false;
     }

--- a/lib/src/universal_ble_linux/universal_ble_linux.dart
+++ b/lib/src/universal_ble_linux/universal_ble_linux.dart
@@ -281,7 +281,7 @@ class UniversalBleLinux extends UniversalBlePlatform {
       await device.pair();
       return true;
     } catch (error) {
-      updatePairingState(deviceId, false, error.toString());
+      updatePairingState(deviceId, false);
       return false;
     }
   }
@@ -448,7 +448,7 @@ class UniversalBleLinux extends UniversalBlePlatform {
             updateScanResult(device.toBleDevice());
             break;
           case BluezProperty.paired:
-            updatePairingState(device.address, device.paired, null);
+            updatePairingState(device.address, device.paired);
             break;
           // Ignored these properties updates
           case BluezProperty.bonded:

--- a/lib/src/universal_ble_pigeon/universal_ble_pigeon_channel.dart
+++ b/lib/src/universal_ble_pigeon/universal_ble_pigeon_channel.dart
@@ -190,7 +190,7 @@ class _UniversalBleCallbackHandler extends UniversalBleCallbackChannel {
 
   @override
   void onPairStateChange(String deviceId, bool isPaired, String? error) =>
-      pairStateChange(deviceId, isPaired, error);
+      pairStateChange(deviceId, isPaired);
 }
 
 extension _UniversalBleScanResultExtension on UniversalBleScanResult {

--- a/lib/src/universal_ble_platform_interface.dart
+++ b/lib/src/universal_ble_platform_interface.dart
@@ -6,6 +6,7 @@ import 'package:universal_ble/universal_ble.dart';
 abstract class UniversalBlePlatform {
   ScanFilter? _scanFilter;
   StreamController? _connectionStreamController;
+  final Map<String, bool> _pairStateMap = {};
 
   Future<AvailabilityState> getBluetoothAvailabilityState();
 
@@ -93,8 +94,10 @@ abstract class UniversalBlePlatform {
     onAvailabilityChange?.call(state);
   }
 
-  void updatePairingState(String deviceId, bool isPaired, String? error) {
-    onPairingStateChange?.call(deviceId, isPaired, error);
+  void updatePairingState(String deviceId, bool isPaired) {
+    if (_pairStateMap[deviceId] == isPaired) return;
+    _pairStateMap[deviceId] = isPaired;
+    onPairingStateChange?.call(deviceId, isPaired);
   }
 
   // Do not use these directly to push updates
@@ -135,7 +138,6 @@ typedef OnScanResult = void Function(BleDevice scanResult);
 
 typedef OnAvailabilityChange = void Function(AvailabilityState state);
 
-typedef OnPairingStateChange = void Function(
-    String deviceId, bool isPaired, String? error);
+typedef OnPairingStateChange = void Function(String deviceId, bool isPaired);
 
 typedef OnQueueUpdate = void Function(String id, int remainingQueueItems);


### PR DESCRIPTION
### **PR Type**
Enhancement, Documentation


___

### **Description**
- Removed the `error` parameter from `updatePairingState` and related methods across multiple files.
- Simplified `_handlePairingStateChange` by removing error handling.
- Added `_pairStateMap` to track pairing state in the platform interface.
- Updated the `CHANGELOG.md` to document the breaking change.
- Updated the `README.md` to reflect the changes in `onPairingStateChange`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mock_universal_ble.dart</strong><dd><code>Remove error parameter from <code>updatePairingState</code> in mock BLE <br>implementation.</code></dd></summary>
<hr>

example/lib/data/mock_universal_ble.dart

- Removed the `error` parameter from `updatePairingState` calls.



</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/75/files#diff-454b515ccdf581b04aadc925c8ab868f0778b644e4d71b3ef55d7ac9f2254c7a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>peripheral_detail_page.dart</strong><dd><code>Simplify `_handlePairingStateChange` by removing error handling.</code></dd></summary>
<hr>

example/lib/peripheral_details/peripheral_detail_page.dart

<li>Removed handling of the <code>error</code> parameter in <code>_handlePairingStateChange</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/75/files#diff-d27c53e1f72b2e62946d82111ebe75b0ddf554cabd123d995bd8cc6d91f7d34b">+2/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble.dart</strong><dd><code>Remove error parameter from <code>updatePairingState</code> in universal BLE class.</code></dd></summary>
<hr>

lib/src/universal_ble.dart

- Removed the `error` parameter from `updatePairingState` calls.



</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/75/files#diff-0299ec0dda75c972b21ca1a2d8ac5fc87bc4dc3f354c49c7995bcb3d18054304">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble_linux.dart</strong><dd><code>Remove error parameter from <code>updatePairingState</code> in Linux BLE <br>implementation.</code></dd></summary>
<hr>

lib/src/universal_ble_linux/universal_ble_linux.dart

- Removed the `error` parameter from `updatePairingState` calls.



</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/75/files#diff-bd61ea0530e3e409336cd7d8a6d93c00911618355a9bf99fd1cf3d92cb6a02d9">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble_pigeon_channel.dart</strong><dd><code>Remove error parameter from `pairStateChange` in pigeon channel.</code></dd></summary>
<hr>

lib/src/universal_ble_pigeon/universal_ble_pigeon_channel.dart

- Removed the `error` parameter from `pairStateChange` calls.



</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/75/files#diff-9a70cf689f7102ee5d895d7203ec64b6690eb827be8a0fd2778e404a65ed061f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble_platform_interface.dart</strong><dd><code>Remove error parameter and add pairing state map in platform </code><br><code>interface.</code></dd></summary>
<hr>

lib/src/universal_ble_platform_interface.dart

<li>Removed the <code>error</code> parameter from <code>updatePairingState</code> and <br><code>OnPairingStateChange</code> typedef.<br> <li> Added <code>_pairStateMap</code> to track pairing state.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/75/files#diff-127e48afab502be75a7cc9a9d97749f8a34e499dc343bff386b3da7ddd0ea4b3">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document breaking change for `onPairingStateChange` in changelog.</code></dd></summary>
<hr>

CHANGELOG.md

<li>Documented the breaking change for <code>onPairingStateChange</code> no longer <br>returning an error.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/75/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README to reflect changes in `onPairingStateChange`.</code></dd></summary>
<hr>

README.md

<li>Updated example to reflect the removal of the <code>error</code> parameter from <br><code>onPairingStateChange</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/75/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

