### PR TITLE
Update webconfig api

### DIFF
--- a/lib/src/models/platform_config.dart
+++ b/lib/src/models/platform_config.dart
@@ -6,18 +6,17 @@ class PlatformConfig {
 }
 
 /// Web config to scan devices
-/// [optionalServices] is a list of service uuid's to ensure that you can access the specified services after connecting to the device,
+/// [useAsScanFilter] can be set to false if we want to use ScanFilter properties as `optionalServices` or `optionalManufacturerData` where
+///  `optionalServices` is a list of service uuid's to ensure that you can access the specified services after connecting to the device,
 /// by default services from scanFilter will be used
-/// [optionalManufacturerData] is list of `CompanyIdentifier's` and used to add `ManufacturerData` in advertisement results of selected device from web dialog,
+/// `optionalManufacturerData` is list of `CompanyIdentifier's` and used to add `ManufacturerData` in advertisement results of selected device from web dialog,
 /// by default manufacturerData from scanFilter will be used
 /// Checkout more details on [web](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice)
 /// Note: you will only get advertisements if Experimental Flag is enabled in the browser
 class WebConfig {
-  List<String> optionalServices;
-  List<int> optionalManufacturerData;
+  final bool useAsScanFilter;
 
   WebConfig({
-    this.optionalServices = const [],
-    this.optionalManufacturerData = const [],
+    this.useAsScanFilter = true,
   });
 }

--- a/lib/src/models/platform_config.dart
+++ b/lib/src/models/platform_config.dart
@@ -6,17 +6,15 @@ class PlatformConfig {
 }
 
 /// Web config to scan devices
-/// [useAsScanFilter] can be set to false if we want to use ScanFilter properties as `optionalServices` or `optionalManufacturerData` where
-///  `optionalServices` is a list of service uuid's to ensure that you can access the specified services after connecting to the device,
-/// by default services from scanFilter will be used
+/// if [scanAll] is true, then scanFilter properties will be used only as `optionalServices` or `optionalManufacturerData`, and no filter will be applied to scan results, where
+/// `optionalServices` is a list of service uuid's to ensure that you can access the specified services after connecting to the device,
 /// `optionalManufacturerData` is list of `CompanyIdentifier's` and used to add `ManufacturerData` in advertisement results of selected device from web dialog,
-/// by default manufacturerData from scanFilter will be used
 /// Checkout more details on [web](https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth/requestDevice)
 /// Note: you will only get advertisements if Experimental Flag is enabled in the browser
 class WebConfig {
-  final bool useAsScanFilter;
+  final bool? scanAll;
 
   WebConfig({
-    this.useAsScanFilter = true,
+    this.scanAll,
   });
 }

--- a/lib/src/universal_ble_web/universal_ble_web.dart
+++ b/lib/src/universal_ble_web/universal_ble_web.dart
@@ -348,46 +348,45 @@ class UniversalBleWeb extends UniversalBlePlatform {
     List<int> optionalManufacturerData = [];
     List<String> optionalServices = [];
 
-    if (webConfig != null) {
-      optionalServices.addAll(webConfig.optionalServices.toValidUUIDList());
-      optionalManufacturerData.addAll(webConfig.optionalManufacturerData);
-    }
-
     if (scanFilter != null) {
       // Add services filter
       for (var service in scanFilter.withServices.toValidUUIDList()) {
-        filters.add(RequestFilterBuilder(services: [service]));
-        if (webConfig == null || webConfig.optionalServices.isEmpty) {
-          optionalServices.add(service);
+        if (webConfig?.useAsScanFilter ?? true) {
+          filters.add(RequestFilterBuilder(services: [service]));
         }
+
+        // Add to optional services
+        optionalServices.add(service);
       }
 
       // Add manufacturer data filter
       for (var manufacturerData in scanFilter.withManufacturerData) {
-        filters.add(
-          RequestFilterBuilder(
-            manufacturerData: [
-              ManufacturerDataFilterBuilder(
-                companyIdentifier: manufacturerData.companyIdentifier,
-                dataPrefix: manufacturerData.data,
-                mask: manufacturerData.mask,
-              ),
-            ],
-          ),
-        );
+        if (webConfig?.useAsScanFilter ?? true) {
+          filters.add(
+            RequestFilterBuilder(
+              manufacturerData: [
+                ManufacturerDataFilterBuilder(
+                  companyIdentifier: manufacturerData.companyIdentifier,
+                  dataPrefix: manufacturerData.data,
+                  mask: manufacturerData.mask,
+                ),
+              ],
+            ),
+          );
+        }
 
-        // Add optionalManufacturerData from scanFilter if webConfig is not provided
-        if (webConfig == null || webConfig.optionalManufacturerData.isEmpty) {
-          int? companyId = manufacturerData.companyIdentifier;
-          if (companyId != null) {
-            optionalManufacturerData.add(companyId);
-          }
+        // Add to optionalManufacturerData
+        int? companyId = manufacturerData.companyIdentifier;
+        if (companyId != null) {
+          optionalManufacturerData.add(companyId);
         }
       }
 
       // Add name filter
       for (var name in scanFilter.withNamePrefix) {
-        filters.add(RequestFilterBuilder(namePrefix: name));
+        if (webConfig?.useAsScanFilter ?? true) {
+          filters.add(RequestFilterBuilder(namePrefix: name));
+        }
       }
     }
 

--- a/lib/src/universal_ble_web/universal_ble_web.dart
+++ b/lib/src/universal_ble_web/universal_ble_web.dart
@@ -351,7 +351,7 @@ class UniversalBleWeb extends UniversalBlePlatform {
     if (scanFilter != null) {
       // Add services filter
       for (var service in scanFilter.withServices.toValidUUIDList()) {
-        if (webConfig?.useAsScanFilter ?? true) {
+        if (webConfig?.scanAll != true) {
           filters.add(RequestFilterBuilder(services: [service]));
         }
 
@@ -361,7 +361,7 @@ class UniversalBleWeb extends UniversalBlePlatform {
 
       // Add manufacturer data filter
       for (var manufacturerData in scanFilter.withManufacturerData) {
-        if (webConfig?.useAsScanFilter ?? true) {
+        if (webConfig?.scanAll != true) {
           filters.add(
             RequestFilterBuilder(
               manufacturerData: [
@@ -384,7 +384,7 @@ class UniversalBleWeb extends UniversalBlePlatform {
 
       // Add name filter
       for (var name in scanFilter.withNamePrefix) {
-        if (webConfig?.useAsScanFilter ?? true) {
+        if (webConfig?.scanAll != true) {
           filters.add(RequestFilterBuilder(namePrefix: name));
         }
       }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced a new `scanAll` boolean property in the `WebConfig` class to control scanning behavior.
- Updated the scanning logic in `UniversalBleWeb` to utilize the `scanAll` property, allowing for more flexible filtering.
- Removed previous handling of `optionalServices` and `optionalManufacturerData` from `WebConfig`, simplifying the configuration.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>platform_config.dart</strong><dd><code>Add `scanAll` property to `WebConfig` class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/models/platform_config.dart

<li>Added a new <code>scanAll</code> boolean property to <code>WebConfig</code>.<br> <li> Updated documentation comments to reflect changes in <code>WebConfig</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/76/files#diff-99e03d399a7bb858c4b52765e51993f3b21a5a75c4d5019e037efd01916379c8">+5/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble_web.dart</strong><dd><code>Update scanning logic with `scanAll` property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/universal_ble_web/universal_ble_web.dart

<li>Modified logic to use <code>scanAll</code> property for filtering.<br> <li> Removed usage of <code>optionalServices</code> and <code>optionalManufacturerData</code> from <br><code>WebConfig</code>.<br> <li> Updated filter application based on <code>scanAll</code> property.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/76/files#diff-dc72e700f7c098e3f4e71b5d1f38c8514d3007af606d0fd15b1e5f0ecbd580cd">+25/-26</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

