### PR TITLE
Make supportsInAppPairing more accurate

### DIFF
--- a/lib/src/models/ble_capabilities.dart
+++ b/lib/src/models/ble_capabilities.dart
@@ -2,12 +2,20 @@ import 'package:flutter/foundation.dart';
 
 class BleCapabilities {
   /// Returns true if pairing is possible either by API or by encrypted characteristic.
-  /// All platforms support this except Windows/Web.
+  /// 
+  /// All platforms support this except Web/Windows and Web/Linux.
+  /// 
+  /// On `Web/Windows` and `Web/Linux` it is known to only work for devices that require passkey pairing.
+  /// If your device requires passkey pairing you can consider this true for all platforms.
+  /// 
+  /// `Web/Linux` could under certain circumstances present a pairing dialog also for devices that do
+  /// not use passkey pairing but it very unreliable so we consider it unsupported.
   static final bool supportsInAppPairing =
       _triggersPairingWithEncryptedChar || hasSystemPairingApi;
 
   static final _triggersPairingWithEncryptedChar =
-      defaultTargetPlatform != TargetPlatform.windows;
+      defaultTargetPlatform != TargetPlatform.windows ||
+          defaultTargetPlatform != TargetPlatform.linux;
 
   static bool hasSystemPairingApi = !kIsWeb &&
       (defaultTargetPlatform == TargetPlatform.android ||

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -232,14 +232,11 @@ class UniversalBle {
   /// You can optionally pass a pairingCommand if you know an encrypted read or write characteristic.
   /// If you do, it returns true if it can successfully execute the command after pairing.
   ///
-  /// Throws UnsupportedError on `Web/Windows`
+  /// On `Web/Windows` and `Web/Linux` it is known to work only for devices that require passkey pairing.
   static Future<bool?> pair(
     String deviceId, {
     BleCommand? pairingCommand,
   }) async {
-    if (!BleCapabilities.supportsInAppPairing) {
-      throw UnsupportedError("Not supported");
-    }
     if (BleCapabilities.hasSystemPairingApi) {
       return _platform.pair(deviceId);
     }


### PR DESCRIPTION
### **User description**
- Allow pairing on all platforms
- Mark Web/Linux as not supporting in-app pairing


___

### **PR Type**
enhancement


___

### **Description**
- Updated the `BleCapabilities` class to clarify that pairing is not supported on Web/Windows and Web/Linux, except for devices requiring passkey pairing.
- Modified the logic to include Web/Linux as an unsupported platform for in-app pairing.
- Updated the `pair` method in `UniversalBle` to remove the `UnsupportedError` and clarify the conditions under which pairing is supported.
- Enhanced documentation to reflect the changes in platform support for pairing.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ble_capabilities.dart</strong><dd><code>Update platform support logic and documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/models/ble_capabilities.dart

<li>Updated documentation to clarify platform support for pairing.<br> <li> Modified logic to include Web/Linux in unsupported platforms.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/85/files#diff-bf35187f7081c593e1b40e6c3d5d22aa9b8eb0ff78a94ee022cccf5234cfa36d">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>universal_ble.dart</strong><dd><code>Refactor pairing logic and update documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/universal_ble.dart

<li>Updated documentation to clarify pairing support on Web platforms.<br> <li> Removed UnsupportedError for unsupported platforms.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/85/files#diff-0299ec0dda75c972b21ca1a2d8ac5fc87bc4dc3f354c49c7995bcb3d18054304">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

