### PR TITLE
Convert supportsInAppPairing to method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * BREAKING CHANGE: `manufacturerDataHead` is removed from `BleDevice`
 * BREAKING CHANGE: rename `WebConfig` to `WebOptions`
 * BREAKING CHANGE: rename `ManufacturerDataFilter.data` to `ManufacturerDataFilter.payload`
+* BREAKING CHANGE: Convert supportsInAppPairing to method
 * Deprecation: `manufacturerData` is deprecated in BleDevice and will be removed in the future
 * Improve `scanFilter` handling
 * Use `ManufacturerData` object instead of `Uint8List` for manufacturerData
@@ -21,6 +22,7 @@
 * Fix notifications for characteristics without cccd on Android
 * Add `connectionStream` API to get connection updates as stream
 * Promote Linux to stable
+* Add supportsInAppPairing && hasSystemPairingApi
 
 ## 0.11.1
 * Trim spaces in UUIDs

--- a/lib/src/models/ble_capabilities.dart
+++ b/lib/src/models/ble_capabilities.dart
@@ -1,22 +1,30 @@
 import 'package:flutter/foundation.dart';
 
 class BleCapabilities {
+  /// You should pass wether your peripheral uses "Just Works" pairing.
+  /// Defaults to true since most devices use this kind of pairing.
+  ///
   /// Returns true if pairing is possible either by API or by encrypted characteristic.
   ///
-  /// All platforms return true except Web/Windows and Web/Linux which return false.
+  /// Platforms other than Web/Windows and Web/Linux always return true.
   ///
-  /// Under conditions, `Web/Windows` and `Web/Linux` could still trigger in-app pairing.
-  /// Peripherals that require "Numeric Comparison" or "Passkey Entry" can
-  /// successfully trigger pairing.
+  /// Web/Windows and Web/Linux return false if the peripheral uses "Just Works" pairing
+  /// or true otherwise.
   ///
   /// `Web/Linux` could also, under certain conditions, trigger "Just Works" pairing
   /// but it very unreliable, therefore we return false.
-  static final bool supportsInAppPairing =
-      _triggersPairingWithEncryptedChar || hasSystemPairingApi;
+  static bool supportsInAppPairing({bool peripheralUsesJustWorks = true}) =>
+      _triggersPairingWithEncryptedChar(peripheralUsesJustWorks) ||
+      hasSystemPairingApi;
 
-  static final _triggersPairingWithEncryptedChar =
-      defaultTargetPlatform != TargetPlatform.windows ||
-          defaultTargetPlatform != TargetPlatform.linux;
+  static _triggersPairingWithEncryptedChar(bool peripheralUsesJustWorks) {
+    if (defaultTargetPlatform == TargetPlatform.windows ||
+        defaultTargetPlatform == TargetPlatform.linux) {
+      return !peripheralUsesJustWorks;
+    }
+
+    return true;
+  }
 
   static bool hasSystemPairingApi = !kIsWeb &&
       (defaultTargetPlatform == TargetPlatform.android ||


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Converted `supportsInAppPairing` from a static final variable to a method to allow more dynamic behavior.
- Introduced a new parameter `peripheralUsesJustWorks` to customize the pairing logic based on peripheral capabilities.
- Enhanced the logic to determine if in-app pairing is supported, particularly for Web/Windows and Web/Linux platforms.
- Improved documentation comments to clarify the behavior and conditions for pairing support.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ble_capabilities.dart</strong><dd><code>Convert `supportsInAppPairing` to a method with enhanced logic</code></dd></summary>
<hr>

lib/src/models/ble_capabilities.dart

<li>Converted <code>supportsInAppPairing</code> from a static final variable to a <br>method.<br> <li> Added a parameter <code>peripheralUsesJustWorks</code> to the method.<br> <li> Updated logic to determine pairing support based on the platform and <br>peripheral pairing method.<br> <li> Improved documentation comments for the method.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/87/files#diff-bf35187f7081c593e1b40e6c3d5d22aa9b8eb0ff78a94ee022cccf5234cfa36d">+18/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

