### PR TITLE
Rename in-app pairing capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * BREAKING CHANGE: `manufacturerDataHead` is removed from `BleDevice`
 * BREAKING CHANGE: rename `WebConfig` to `WebOptions`
 * BREAKING CHANGE: rename `ManufacturerDataFilter.data` to `ManufacturerDataFilter.payload`
+* BREAKING CHANGE: rename in-app pairing capabilities
 * Deprecation: `manufacturerData` is deprecated in BleDevice and will be removed in the future
 * Improve `scanFilter` handling
 * Use `ManufacturerData` object instead of `Uint8List` for manufacturerData

--- a/example/lib/peripheral_details/peripheral_detail_page.dart
+++ b/example/lib/peripheral_details/peripheral_detail_page.dart
@@ -403,7 +403,7 @@ class _PeripheralDetailPageState extends State<PeripheralDetailPage> {
                               text: 'Unsubscribe',
                             ),
                             PlatformButton(
-                              enabled: BleCapabilities.supportsInAppPairing,
+                              enabled: BleCapabilities.supportsAllPairingKinds,
                               onPressed: () async {
                                 bool? pairingResult = await UniversalBle.pair(
                                   widget.deviceId,

--- a/lib/src/models/ble_capabilities.dart
+++ b/lib/src/models/ble_capabilities.dart
@@ -1,23 +1,31 @@
 import 'package:flutter/foundation.dart';
 
 class BleCapabilities {
-  /// Returns true if pairing is possible either by API or by encrypted characteristic.
+  /// Returns true if in-app pairing is possible either by API or by encrypted characteristic
+  /// using any kind of security level (JustWorks, Numeric Comparison or Passkey Entry).
   ///
-  /// All platforms return true except Web/Windows and Web/Linux which return false.
+  /// All platforms return true except Web/Windows and Web/Linux which return false
+  /// because they only support "Numeric Comparison" and "Passkey Entry".
   ///
-  /// Under conditions, `Web/Windows` and `Web/Linux` could still trigger in-app pairing.
-  /// Peripherals that require "Numeric Comparison" or "Passkey Entry" can
-  /// successfully trigger pairing.
+  /// When false, triggering pairing depends on the security level requested by your peripheral.
+  /// In that case, it is recommended to use `triggersJustWorksPairingWithEncryptedChar`
+  /// in conjunction with the security level of your peripheral.
+  static final bool supportsAllPairingKinds =
+      triggersJustWorksPairingWithEncryptedChar || hasSystemPairingApi;
+
+  /// Returns true if the platform triggers JustWorks pairing when trying to read or write
+  /// to an encrypted characteristic.
+  ///
+  /// Higher security level pairing modes like "Numeric Comparison" or "Passkey Entry"
+  /// trigger pairing on all platforms.
   ///
   /// `Web/Linux` could also, under certain conditions, trigger "Just Works" pairing
   /// but it very unreliable, therefore we return false.
-  static final bool supportsInAppPairing =
-      _triggersPairingWithEncryptedChar || hasSystemPairingApi;
-
-  static final _triggersPairingWithEncryptedChar =
+  static final triggersJustWorksPairingWithEncryptedChar =
       defaultTargetPlatform != TargetPlatform.windows &&
           defaultTargetPlatform != TargetPlatform.linux;
 
+  /// Returns true if pair()/unpair() are supported on the platform.
   static bool hasSystemPairingApi = !kIsWeb &&
       (defaultTargetPlatform == TargetPlatform.android ||
           defaultTargetPlatform == TargetPlatform.windows ||

--- a/lib/src/universal_ble_pigeon/universal_ble.g.dart
+++ b/lib/src/universal_ble_pigeon/universal_ble.g.dart
@@ -15,7 +15,8 @@ PlatformException _createConnectionError(String channelName) {
   );
 }
 
-List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty = false}) {
+List<Object?> wrapResponse(
+    {Object? result, PlatformException? error, bool empty = false}) {
   if (empty) {
     return <Object?>[];
   }
@@ -65,7 +66,8 @@ class UniversalBleScanResult {
       name: result[1] as String?,
       isPaired: result[2] as bool?,
       rssi: result[3] as int?,
-      manufacturerDataList: (result[4] as List<Object?>?)?.cast<UniversalManufacturerData?>(),
+      manufacturerDataList:
+          (result[4] as List<Object?>?)?.cast<UniversalManufacturerData?>(),
       services: (result[5] as List<Object?>?)?.cast<String?>(),
     );
   }
@@ -92,7 +94,8 @@ class UniversalBleService {
     result as List<Object?>;
     return UniversalBleService(
       uuid: result[0]! as String,
-      characteristics: (result[1] as List<Object?>?)?.cast<UniversalBleCharacteristic?>(),
+      characteristics:
+          (result[1] as List<Object?>?)?.cast<UniversalBleCharacteristic?>(),
     );
   }
 }
@@ -150,7 +153,8 @@ class UniversalScanFilter {
     return UniversalScanFilter(
       withServices: (result[0] as List<Object?>?)!.cast<String?>(),
       withNamePrefix: (result[1] as List<Object?>?)!.cast<String?>(),
-      withManufacturerData: (result[2] as List<Object?>?)!.cast<UniversalManufacturerDataFilter?>(),
+      withManufacturerData: (result[2] as List<Object?>?)!
+          .cast<UniversalManufacturerDataFilter?>(),
     );
   }
 }
@@ -212,7 +216,6 @@ class UniversalManufacturerData {
   }
 }
 
-
 class _PigeonCodec extends StandardMessageCodec {
   const _PigeonCodec();
   @override
@@ -220,19 +223,19 @@ class _PigeonCodec extends StandardMessageCodec {
     if (value is UniversalBleScanResult) {
       buffer.putUint8(129);
       writeValue(buffer, value.encode());
-    } else     if (value is UniversalBleService) {
+    } else if (value is UniversalBleService) {
       buffer.putUint8(130);
       writeValue(buffer, value.encode());
-    } else     if (value is UniversalBleCharacteristic) {
+    } else if (value is UniversalBleCharacteristic) {
       buffer.putUint8(131);
       writeValue(buffer, value.encode());
-    } else     if (value is UniversalScanFilter) {
+    } else if (value is UniversalScanFilter) {
       buffer.putUint8(132);
       writeValue(buffer, value.encode());
-    } else     if (value is UniversalManufacturerDataFilter) {
+    } else if (value is UniversalManufacturerDataFilter) {
       buffer.putUint8(133);
       writeValue(buffer, value.encode());
-    } else     if (value is UniversalManufacturerData) {
+    } else if (value is UniversalManufacturerData) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
     } else {
@@ -243,17 +246,17 @@ class _PigeonCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 129: 
+      case 129:
         return UniversalBleScanResult.decode(readValue(buffer)!);
-      case 130: 
+      case 130:
         return UniversalBleService.decode(readValue(buffer)!);
-      case 131: 
+      case 131:
         return UniversalBleCharacteristic.decode(readValue(buffer)!);
-      case 132: 
+      case 132:
         return UniversalScanFilter.decode(readValue(buffer)!);
-      case 133: 
+      case 133:
         return UniversalManufacturerDataFilter.decode(readValue(buffer)!);
-      case 134: 
+      case 134:
         return UniversalManufacturerData.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -266,9 +269,11 @@ class UniversalBlePlatformChannel {
   /// Constructor for [UniversalBlePlatformChannel].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  UniversalBlePlatformChannel({BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
+  UniversalBlePlatformChannel(
+      {BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
       : __pigeon_binaryMessenger = binaryMessenger,
-        __pigeon_messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+        __pigeon_messageChannelSuffix =
+            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? __pigeon_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -276,8 +281,10 @@ class UniversalBlePlatformChannel {
   final String __pigeon_messageChannelSuffix;
 
   Future<int> getBluetoothAvailabilityState() async {
-    final String __pigeon_channelName = 'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.getBluetoothAvailabilityState$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.getBluetoothAvailabilityState$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -303,8 +310,10 @@ class UniversalBlePlatformChannel {
   }
 
   Future<bool> enableBluetooth() async {
-    final String __pigeon_channelName = 'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.enableBluetooth$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.enableBluetooth$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -330,8 +339,10 @@ class UniversalBlePlatformChannel {
   }
 
   Future<void> startScan(UniversalScanFilter? filter) async {
-    final String __pigeon_channelName = 'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.startScan$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.startScan$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -352,8 +363,10 @@ class UniversalBlePlatformChannel {
   }
 
   Future<void> stopScan() async {
-    final String __pigeon_channelName = 'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.stopScan$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.stopScan$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -374,8 +387,10 @@ class UniversalBlePlatformChannel {
   }
 
   Future<void> connect(String deviceId) async {
-    final String __pigeon_channelName = 'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.connect$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.connect$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -396,8 +411,10 @@ class UniversalBlePlatformChannel {
   }
 
   Future<void> disconnect(String deviceId) async {
-    final String __pigeon_channelName = 'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.disconnect$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.disconnect$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -417,15 +434,19 @@ class UniversalBlePlatformChannel {
     }
   }
 
-  Future<void> setNotifiable(String deviceId, String service, String characteristic, int bleInputProperty) async {
-    final String __pigeon_channelName = 'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.setNotifiable$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+  Future<void> setNotifiable(String deviceId, String service,
+      String characteristic, int bleInputProperty) async {
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.setNotifiable$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
     );
-    final List<Object?>? __pigeon_replyList =
-        await __pigeon_channel.send(<Object?>[deviceId, service, characteristic, bleInputProperty]) as List<Object?>?;
+    final List<Object?>? __pigeon_replyList = await __pigeon_channel.send(
+            <Object?>[deviceId, service, characteristic, bleInputProperty])
+        as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {
@@ -440,8 +461,10 @@ class UniversalBlePlatformChannel {
   }
 
   Future<List<UniversalBleService?>> discoverServices(String deviceId) async {
-    final String __pigeon_channelName = 'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.discoverServices$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.discoverServices$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -462,19 +485,23 @@ class UniversalBlePlatformChannel {
         message: 'Host platform returned null value for non-null return value.',
       );
     } else {
-      return (__pigeon_replyList[0] as List<Object?>?)!.cast<UniversalBleService?>();
+      return (__pigeon_replyList[0] as List<Object?>?)!
+          .cast<UniversalBleService?>();
     }
   }
 
-  Future<Uint8List> readValue(String deviceId, String service, String characteristic) async {
-    final String __pigeon_channelName = 'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.readValue$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+  Future<Uint8List> readValue(
+      String deviceId, String service, String characteristic) async {
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.readValue$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
     );
-    final List<Object?>? __pigeon_replyList =
-        await __pigeon_channel.send(<Object?>[deviceId, service, characteristic]) as List<Object?>?;
+    final List<Object?>? __pigeon_replyList = await __pigeon_channel
+        .send(<Object?>[deviceId, service, characteristic]) as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {
@@ -494,14 +521,16 @@ class UniversalBlePlatformChannel {
   }
 
   Future<int> requestMtu(String deviceId, int expectedMtu) async {
-    final String __pigeon_channelName = 'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.requestMtu$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.requestMtu$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
     );
-    final List<Object?>? __pigeon_replyList =
-        await __pigeon_channel.send(<Object?>[deviceId, expectedMtu]) as List<Object?>?;
+    final List<Object?>? __pigeon_replyList = await __pigeon_channel
+        .send(<Object?>[deviceId, expectedMtu]) as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {
@@ -520,15 +549,24 @@ class UniversalBlePlatformChannel {
     }
   }
 
-  Future<void> writeValue(String deviceId, String service, String characteristic, Uint8List value, int bleOutputProperty) async {
-    final String __pigeon_channelName = 'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.writeValue$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+  Future<void> writeValue(String deviceId, String service,
+      String characteristic, Uint8List value, int bleOutputProperty) async {
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.writeValue$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
     );
-    final List<Object?>? __pigeon_replyList =
-        await __pigeon_channel.send(<Object?>[deviceId, service, characteristic, value, bleOutputProperty]) as List<Object?>?;
+    final List<Object?>? __pigeon_replyList = await __pigeon_channel
+        .send(<Object?>[
+      deviceId,
+      service,
+      characteristic,
+      value,
+      bleOutputProperty
+    ]) as List<Object?>?;
     if (__pigeon_replyList == null) {
       throw _createConnectionError(__pigeon_channelName);
     } else if (__pigeon_replyList.length > 1) {
@@ -543,8 +581,10 @@ class UniversalBlePlatformChannel {
   }
 
   Future<bool> isPaired(String deviceId) async {
-    final String __pigeon_channelName = 'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.isPaired$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.isPaired$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -570,8 +610,10 @@ class UniversalBlePlatformChannel {
   }
 
   Future<bool> pair(String deviceId) async {
-    final String __pigeon_channelName = 'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.pair$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.pair$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -597,8 +639,10 @@ class UniversalBlePlatformChannel {
   }
 
   Future<void> unPair(String deviceId) async {
-    final String __pigeon_channelName = 'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.unPair$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.unPair$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -618,9 +662,12 @@ class UniversalBlePlatformChannel {
     }
   }
 
-  Future<List<UniversalBleScanResult?>> getSystemDevices(List<String?> withServices) async {
-    final String __pigeon_channelName = 'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.getSystemDevices$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+  Future<List<UniversalBleScanResult?>> getSystemDevices(
+      List<String?> withServices) async {
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.getSystemDevices$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -641,13 +688,16 @@ class UniversalBlePlatformChannel {
         message: 'Host platform returned null value for non-null return value.',
       );
     } else {
-      return (__pigeon_replyList[0] as List<Object?>?)!.cast<UniversalBleScanResult?>();
+      return (__pigeon_replyList[0] as List<Object?>?)!
+          .cast<UniversalBleScanResult?>();
     }
   }
 
   Future<int> getConnectionState(String deviceId) async {
-    final String __pigeon_channelName = 'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.getConnectionState$__pigeon_messageChannelSuffix';
-    final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.getConnectionState$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
       __pigeon_channelName,
       pigeonChannelCodec,
       binaryMessenger: __pigeon_binaryMessenger,
@@ -683,22 +733,30 @@ abstract class UniversalBleCallbackChannel {
 
   void onScanResult(UniversalBleScanResult result);
 
-  void onValueChanged(String deviceId, String characteristicId, Uint8List value);
+  void onValueChanged(
+      String deviceId, String characteristicId, Uint8List value);
 
   void onConnectionChanged(String deviceId, bool connected);
 
-  static void setUp(UniversalBleCallbackChannel? api, {BinaryMessenger? binaryMessenger, String messageChannelSuffix = '',}) {
-    messageChannelSuffix = messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
+  static void setUp(
+    UniversalBleCallbackChannel? api, {
+    BinaryMessenger? binaryMessenger,
+    String messageChannelSuffix = '',
+  }) {
+    messageChannelSuffix =
+        messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onAvailabilityChanged$messageChannelSuffix', pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
+              Object?>(
+          'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onAvailabilityChanged$messageChannelSuffix',
+          pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-          'Argument for dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onAvailabilityChanged was null.');
+              'Argument for dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onAvailabilityChanged was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final int? arg_state = (args[0] as int?);
           assert(arg_state != null,
@@ -708,22 +766,25 @@ abstract class UniversalBleCallbackChannel {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onPairStateChange$messageChannelSuffix', pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
+              Object?>(
+          'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onPairStateChange$messageChannelSuffix',
+          pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-          'Argument for dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onPairStateChange was null.');
+              'Argument for dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onPairStateChange was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_deviceId = (args[0] as String?);
           assert(arg_deviceId != null,
@@ -737,24 +798,28 @@ abstract class UniversalBleCallbackChannel {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onScanResult$messageChannelSuffix', pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
+              Object?>(
+          'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onScanResult$messageChannelSuffix',
+          pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-          'Argument for dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onScanResult was null.');
+              'Argument for dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onScanResult was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final UniversalBleScanResult? arg_result = (args[0] as UniversalBleScanResult?);
+          final UniversalBleScanResult? arg_result =
+              (args[0] as UniversalBleScanResult?);
           assert(arg_result != null,
               'Argument for dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onScanResult was null, expected non-null UniversalBleScanResult.');
           try {
@@ -762,22 +827,25 @@ abstract class UniversalBleCallbackChannel {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onValueChanged$messageChannelSuffix', pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
+              Object?>(
+          'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onValueChanged$messageChannelSuffix',
+          pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-          'Argument for dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onValueChanged was null.');
+              'Argument for dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onValueChanged was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_deviceId = (args[0] as String?);
           assert(arg_deviceId != null,
@@ -789,26 +857,30 @@ abstract class UniversalBleCallbackChannel {
           assert(arg_value != null,
               'Argument for dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onValueChanged was null, expected non-null Uint8List.');
           try {
-            api.onValueChanged(arg_deviceId!, arg_characteristicId!, arg_value!);
+            api.onValueChanged(
+                arg_deviceId!, arg_characteristicId!, arg_value!);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
-      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onConnectionChanged$messageChannelSuffix', pigeonChannelCodec,
+      final BasicMessageChannel<Object?> __pigeon_channel = BasicMessageChannel<
+              Object?>(
+          'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onConnectionChanged$messageChannelSuffix',
+          pigeonChannelCodec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         __pigeon_channel.setMessageHandler(null);
       } else {
         __pigeon_channel.setMessageHandler((Object? message) async {
           assert(message != null,
-          'Argument for dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onConnectionChanged was null.');
+              'Argument for dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onConnectionChanged was null.');
           final List<Object?> args = (message as List<Object?>?)!;
           final String? arg_deviceId = (args[0] as String?);
           assert(arg_deviceId != null,
@@ -821,8 +893,9 @@ abstract class UniversalBleCallbackChannel {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          }          catch (e) {
-            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
+          } catch (e) {
+            return wrapResponse(
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }


### PR DESCRIPTION
### **PR Type**
enhancement, documentation


___

### **Description**
- Renamed `supportsInAppPairing` to `supportsAllInAppPairingKinds` in `BleCapabilities` to better reflect the supported security levels.
- Updated the enabling condition for a button in `PeripheralDetailPage` to use the new `supportsAllInAppPairingKinds`.
- Improved code readability by reformatting lines and adjusting spacing in `universal_ble.g.dart`.
- Documented the breaking change in `CHANGELOG.md` regarding the renaming of in-app pairing capabilities.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>peripheral_detail_page.dart</strong><dd><code>Update button enabling condition for pairing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example/lib/peripheral_details/peripheral_detail_page.dart

<li>Updated the button enabling condition to use <br><code>supportsAllInAppPairingKinds</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/88/files#diff-d27c53e1f72b2e62946d82111ebe75b0ddf554cabd123d995bd8cc6d91f7d34b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ble_capabilities.dart</strong><dd><code>Rename and document in-app pairing capabilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/models/ble_capabilities.dart

<li>Renamed <code>supportsInAppPairing</code> to <code>supportsAllInAppPairingKinds</code>.<br> <li> Added detailed comments explaining the conditions for in-app pairing.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/88/files#diff-bf35187f7081c593e1b40e6c3d5d22aa9b8eb0ff78a94ee022cccf5234cfa36d">+18/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>universal_ble.g.dart</strong><dd><code>Code formatting improvements for readability</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/universal_ble_pigeon/universal_ble.g.dart

<li>Reformatted code for better readability.<br> <li> Adjusted line breaks and spacing in method definitions.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/88/files#diff-23aeae5146301c4596bf4b4f71fb72e39877ee48c7135bec3fc9ae81b2d81b3e">+167/-94</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document breaking change in in-app pairing capabilities</code>&nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Added a breaking change note about renaming in-app pairing <br>capabilities.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/88/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

