### PR TITLE
Fix multiple app filtering in Linux

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -402,7 +402,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.13.0"
+    version: "0.14.0"
   vector_math:
     dependency: transitive
     description:


### PR DESCRIPTION
### **PR Type**
enhancement, bug_fix


___

### **Description**
- Improved the BLE device filtering mechanism by simplifying the scan filter logic and removing unnecessary custom filter checks.
- Added stream subscriptions to handle device addition and removal events, improving the responsiveness of the application.
- Implemented proper setup and disposal of listeners to manage device events efficiently.
- Removed redundant code, including an extension method for checking custom filters, to streamline the codebase.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>universal_ble_linux.dart</strong><dd><code>Improve BLE device filtering and event handling in Linux</code>&nbsp; </dd></summary>
<hr>

lib/src/universal_ble_linux/universal_ble_linux.dart

<li>Added stream subscriptions for device addition and removal.<br> <li> Simplified the scan filter logic by removing custom filter checks.<br> <li> Implemented listener setup and disposal for device events.<br> <li> Removed redundant extension method for custom filter check.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/100/files#diff-bd61ea0530e3e409336cd7d8a6d93c00911618355a9bf99fd1cf3d92cb6a02d9">+16/-35</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information