### PR TITLE
Bump flutter_web_bluetooth to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.14.0
 * BREAKING CHANGE: `bleDevice.name` now filters out non-printable characters
 * Add `bleDevice.rawName`
+* Bump flutter_web_bluetooth to 1.0.0
 
 ## 0.13.0
 * BREAKING CHANGE: `scanFilter` filters are now in OR relation 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -156,10 +156,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_web_bluetooth
-      sha256: "52ce64f65d7321c4bf6abfe9dac02fb888731339a5e0ad6de59fb916c20c9f02"
+      sha256: "1363831def5eed1e1064d1eca04e8ccb35446e8f758579c3c519e156b77926da"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.3"
+    version: "1.0.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -175,14 +175,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -419,6 +411,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.2.5"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   webdriver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.6
-  flutter_web_bluetooth: ^0.2.2
+  flutter_web_bluetooth: ^1.0.0
   bluez: ^0.8.2
 
 dev_dependencies:


### PR DESCRIPTION
### **User description**
Addresses https://github.com/Navideck/universal_ble/issues/101


___

### **PR Type**
enhancement, dependencies


___

### **Description**
- Updated the `flutter_web_bluetooth` dependency in `pubspec.yaml` to version 1.0.0, ensuring compatibility with the latest features and improvements.
- This change addresses the need to keep dependencies up-to-date as per the related ticket.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pubspec.yaml</strong><dd><code>Update `flutter_web_bluetooth` dependency to version 1.0.0</code></dd></summary>
<hr>

pubspec.yaml

<li>Updated <code>flutter_web_bluetooth</code> dependency from version 0.2.2 to 1.0.0.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/102/files#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information