### PR TITLE
Handle Android scan abuse

### DIFF
--- a/android/src/main/kotlin/com/navideck/universal_ble/SafeScanner.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/SafeScanner.kt
@@ -16,6 +16,21 @@ private const val NUM_SCAN_DURATIONS_KEPT = 5
 private const val EXCESSIVE_SCANNING_PERIOD_MS = 30 * 1000L
 private const val TAG = "UniversalBlePlugin"
 
+/**
+ * A safe wrapper for Bluetooth LE scanning operations that prevents excessive scanning.
+ * 
+ * This class manages BLE scanning while adhering to Android's scanning frequency limits by:
+ * - Tracking scan start times over a 30-second window
+ * - Limiting to 5 scan operations within this window
+ * - Automatically scheduling delayed scans when frequency limits are exceeded
+ * - Providing safe start/stop scan operations with error handling
+ * 
+ * The scanner will automatically delay new scan requests if the frequency limit is reached,
+ * and will retry once sufficient time has passed. This helps prevent scan failure errors
+ * and ensures compliance with Android's scanning restrictions.
+ *
+ * @property bluetoothManager The system's BluetoothManager used for scanning operations
+ */
 @SuppressLint("MissingPermission")
 class SafeScanner(private val bluetoothManager: BluetoothManager) {
     private val handler = Handler(Looper.myLooper()!!)

--- a/android/src/main/kotlin/com/navideck/universal_ble/SafeScanner.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/SafeScanner.kt
@@ -1,0 +1,63 @@
+package com.navideck.universal_ble
+
+import android.annotation.SuppressLint
+import android.bluetooth.le.BluetoothLeScanner
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanFilter
+import android.bluetooth.le.ScanSettings
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import java.util.LinkedList
+
+private const val NUM_SCAN_DURATIONS_KEPT = 5
+private const val EXCESSIVE_SCANNING_PERIOD_MS = 30 * 1000L
+private const val TAG = "UniversalBlePlugin"
+
+@SuppressLint("MissingPermission")
+class SafeScanner(private val scanner: BluetoothLeScanner) {
+    private val handler = Handler(Looper.myLooper()!!)
+    private val startTimes = LinkedList<Long>()
+    private var awaitingScan = false
+
+    fun startScan(filters: List<ScanFilter>, settings: ScanSettings, callback: ScanCallback) {
+        val now = System.currentTimeMillis()
+        startTimes.removeAll { now - it > EXCESSIVE_SCANNING_PERIOD_MS }
+
+        if (startTimes.size >= NUM_SCAN_DURATIONS_KEPT) {
+            if (awaitingScan) {
+                Log.e(TAG, "startScan: too frequent, awaiting scan..")
+                return
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                callback.onScanFailed(ScanCallback.SCAN_FAILED_SCANNING_TOO_FREQUENTLY)
+            }
+
+            awaitingScan = true
+            val delay = startTimes.first + EXCESSIVE_SCANNING_PERIOD_MS - now + 2_000
+            Log.e(TAG, "startScan: too frequent, schedule auto-start after $delay ms $startTimes")
+
+            handler.postDelayed({
+                Log.d(TAG, "Retrying scan after delay")
+                awaitingScan = false
+                startScan(filters, settings, callback)
+            }, delay)
+        } else {
+            awaitingScan = false
+            startTimes.addLast(now)
+            try {
+                scanner.startScan(filters, settings, callback)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to start Scan : $e")
+            }
+        }
+    }
+
+    fun stopScan(callback: ScanCallback) {
+        awaitingScan = false
+        handler.removeCallbacksAndMessages(null)
+        scanner.stopScan(callback)
+    }
+}

--- a/android/src/main/kotlin/com/navideck/universal_ble/SafeScanner.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/SafeScanner.kt
@@ -1,6 +1,7 @@
 package com.navideck.universal_ble
 
 import android.annotation.SuppressLint
+import android.bluetooth.BluetoothManager
 import android.bluetooth.le.BluetoothLeScanner
 import android.bluetooth.le.ScanCallback
 import android.bluetooth.le.ScanFilter
@@ -16,7 +17,7 @@ private const val EXCESSIVE_SCANNING_PERIOD_MS = 30 * 1000L
 private const val TAG = "UniversalBlePlugin"
 
 @SuppressLint("MissingPermission")
-class SafeScanner(private val scanner: BluetoothLeScanner) {
+class SafeScanner(private val bluetoothManager: BluetoothManager) {
     private val handler = Handler(Looper.myLooper()!!)
     private val startTimes = LinkedList<Long>()
     private var awaitingScan = false
@@ -48,7 +49,7 @@ class SafeScanner(private val scanner: BluetoothLeScanner) {
             awaitingScan = false
             startTimes.addLast(now)
             try {
-                scanner.startScan(filters, settings, callback)
+                bluetoothManager.adapter.bluetoothLeScanner?.startScan(filters, settings, callback)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to start Scan : $e")
             }
@@ -58,6 +59,6 @@ class SafeScanner(private val scanner: BluetoothLeScanner) {
     fun stopScan(callback: ScanCallback) {
         awaitingScan = false
         handler.removeCallbacksAndMessages(null)
-        scanner.stopScan(callback)
+        bluetoothManager.adapter.bluetoothLeScanner?.stopScan(callback)
     }
 }

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -37,6 +37,7 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
     private lateinit var context: Context
     private var activity: Activity? = null
     private lateinit var bluetoothManager: BluetoothManager
+    private lateinit var safeScanner: SafeScanner
     private val cachedServicesMap = mutableMapOf<String, List<String>>()
     private val devicesStateMap = mutableMapOf<String, Int>()
     private val universalBleFilterUtil = UniversalBleFilterUtil()
@@ -50,13 +51,13 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
     private val subscriptionResultFutureList = mutableListOf<SubscriptionResultFuture>()
     private val pairResultFutures = mutableMapOf<String, (Result<Boolean>) -> Unit>()
 
-
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         UniversalBlePlatformChannel.setUp(flutterPluginBinding.binaryMessenger, this)
         callbackChannel = UniversalBleCallbackChannel(flutterPluginBinding.binaryMessenger)
         context = flutterPluginBinding.applicationContext
         mainThreadHandler = Handler(Looper.getMainLooper())
         bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
+        safeScanner = SafeScanner(bluetoothManager.adapter.bluetoothLeScanner)
 
         val intentFilter = IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED)
         intentFilter.addAction(BluetoothDevice.ACTION_BOND_STATE_CHANGED)
@@ -74,7 +75,6 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
         callbackChannel = null
         mainThreadHandler = null
     }
-
 
     override fun getBluetoothAvailabilityState(callback: (Result<Long>) -> Unit) {
         callback(
@@ -132,7 +132,7 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
                 scanFilters = filter?.toScanFilters(filterServices) ?: emptyList<ScanFilter>()
             }
 
-            bluetoothManager.adapter.bluetoothLeScanner?.startScan(
+            safeScanner.startScan(
                 scanFilters, settings, scanCallback
             )
         } catch (e: Exception) {
@@ -150,7 +150,7 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
             "Bluetooth not enabled",
         )
         // check if already scanning
-        bluetoothManager.adapter.bluetoothLeScanner?.stopScan(scanCallback)
+        safeScanner.stopScan(scanCallback)
     }
 
     override fun connect(deviceId: String) {

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.bluetooth.*
 import android.bluetooth.BluetoothDevice.BOND_BONDED
+import android.bluetooth.le.BluetoothLeScanner
 import android.bluetooth.le.ScanCallback
 import android.bluetooth.le.ScanFilter
 import android.bluetooth.le.ScanResult
@@ -57,7 +58,7 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
         context = flutterPluginBinding.applicationContext
         mainThreadHandler = Handler(Looper.getMainLooper())
         bluetoothManager = context.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
-        safeScanner = SafeScanner(bluetoothManager.adapter.bluetoothLeScanner)
+        safeScanner = SafeScanner(bluetoothManager)
 
         val intentFilter = IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED)
         intentFilter.addAction(BluetoothDevice.ACTION_BOND_STATE_CHANGED)


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Introduced a new `SafeScanner` class to manage Bluetooth scanning frequency and prevent excessive scanning.
- Integrated `SafeScanner` into the `UniversalBlePlugin` to replace direct Bluetooth scanner calls.
- Implemented logic to delay scans if they occur too frequently, enhancing the robustness of the scanning process.
- Added error handling for scan failures to improve reliability.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SafeScanner.kt</strong><dd><code>Add SafeScanner class to manage Bluetooth scan frequency</code>&nbsp; </dd></summary>
<hr>

android/src/main/kotlin/com/navideck/universal_ble/SafeScanner.kt

<li>Introduced a new <code>SafeScanner</code> class to handle Bluetooth scanning.<br> <li> Implemented logic to prevent excessive scanning by delaying scans if <br>they occur too frequently.<br> <li> Added error handling for scan failures.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/104/files#diff-3cfe12d024bfd42514a3b94797ae9cf778a1e9f9495e48adc86ab405c314cde6">+63/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UniversalBlePlugin.kt</strong><dd><code>Integrate SafeScanner into UniversalBlePlugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt

<li>Integrated <code>SafeScanner</code> into <code>UniversalBlePlugin</code>.<br> <li> Replaced direct scanner calls with <code>SafeScanner</code> methods.<br> <li> Initialized <code>SafeScanner</code> in the plugin setup.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/104/files#diff-9bf8297311d93083e68b98b07fd87ec8038bf693833cef20b676ac88a4aa837e">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information