### PR TITLE
Fix android cleanup after disconnection

### DIFF
--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -715,6 +715,8 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
     private fun cleanConnection(gatt: BluetoothGatt) {
         knownGatts.remove(gatt)
         gatt.disconnect()
+        gatt.close()
+
         readResultFutureList.removeAll {
             if (it.deviceId == gatt.device.address) {
                 it.result(Result.failure(DeviceDisconnectedError))


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Added a call to `gatt.close()` in the `cleanConnection` method to ensure proper cleanup of Bluetooth GATT connections after disconnection.
- This change addresses potential resource leaks by ensuring that the GATT connection is fully closed.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UniversalBlePlugin.kt</strong><dd><code>Ensure proper cleanup of Bluetooth GATT connections</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt

<li>Added <code>gatt.close()</code> after <code>gatt.disconnect()</code> in <code>cleanConnection</code> method.<br> <li> Ensures proper cleanup of Bluetooth GATT connections.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/106/files#diff-9bf8297311d93083e68b98b07fd87ec8038bf693833cef20b676ac88a4aa837e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information