### PR TITLE
Fix Android cleanup on gatt disconnect

### DIFF
--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt
@@ -178,9 +178,9 @@ fun <T> SparseArray<T>.toList(): List<Pair<Int, T>> {
 fun BluetoothGatt.getCharacteristic(
     service: String,
     characteristic: String,
-): BluetoothGattCharacteristic? =
-    getService(UUID.fromString(service)).getCharacteristic(UUID.fromString(characteristic))
-
+): BluetoothGattCharacteristic? {
+    return getService(UUID.fromString(service))?.getCharacteristic(UUID.fromString(characteristic))
+}
 
 fun subscriptionFailedError(error: String? = null): Result<Unit> {
     return Result.failure(

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -716,7 +716,6 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
     private fun cleanConnection(gatt: BluetoothGatt) {
         knownGatts.remove(gatt)
         gatt.disconnect()
-        gatt.close()
 
         readResultFutureList.removeAll {
             if (it.deviceId == gatt.device.address) {
@@ -885,6 +884,8 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
                     gatt.device.address, false, status.parseHciErrorCode()
                 ) {}
             }
+            Log.d(TAG, "Closing gatt for ${gatt.device.name}")
+            gatt.close()
         }
     }
 


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed a bug in `UniversalBleHelper.kt` by adding null safety to the `getCharacteristic` method to prevent potential null pointer exceptions.
- In `UniversalBlePlugin.kt`, moved the `gatt.close()` call to ensure it is executed after the gatt is disconnected, improving the cleanup process.
- Added a log statement to track when a gatt is closed, aiding in debugging and monitoring.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UniversalBleHelper.kt</strong><dd><code>Add null safety to BluetoothGatt getCharacteristic method</code></dd></summary>
<hr>

android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt

<li>Modified <code>getCharacteristic</code> function to handle null service.<br> <li> Added null safety check when retrieving a characteristic.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/109/files#diff-07528325c9af8065d3fe07cc2436350a5db4dde75378b96e4801cdc7675b128a">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UniversalBlePlugin.kt</strong><dd><code>Fix gatt closure timing and add logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt

<li>Moved <code>gatt.close()</code> to ensure it's called after disconnect.<br> <li> Added logging for gatt closure.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/109/files#diff-9bf8297311d93083e68b98b07fd87ec8038bf693833cef20b676ac88a4aa837e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information