### PR TITLE
Fix Windows filter with services

### DIFF
--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleFilterUtil.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleFilterUtil.kt
@@ -103,7 +103,7 @@ class UniversalBleFilterUtil {
 }
 
 fun UniversalScanFilter.hasCustomFilter(): Boolean {
-    // Only NamePrefix Filtering is not allowed in native filters
+    // NamePrefix Filtering is not supported in native filters
     return withNamePrefix.isNotEmpty()
 }
 

--- a/darwin/Classes/UniversalBlePlugin.swift
+++ b/darwin/Classes/UniversalBlePlugin.swift
@@ -54,7 +54,7 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
   }
 
   func startScan(filter: UniversalScanFilter?) throws {
-    // If filter have any other filter other then official one
+    // If filter has any other filter other than official one
     let hasCustomFilter = filter?.hasCustomFilters ?? false
 
     // Apply services filter

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -111,8 +111,9 @@ namespace universal_ble
 
         if (filter != nullptr)
         {
-          // Only Services filter supported natively
-          bool hasCustomFilters = filter->with_manufacturer_data().size() > 0 || filter->with_name_prefix().size() > 0;
+          // Native filter supports only 1 service
+          bool hasCustomFilters = filter->with_services().size() > 1 || filter->with_manufacturer_data().size() > 0 || filter->with_name_prefix().size() > 0;
+
           if (hasCustomFilters)
           {
             std::cout << "Using Custom Scan Filter" << std::endl;


### PR DESCRIPTION
### **PR Type**
bug_fix


___

### **Description**
- Fixed the logic in the Windows BLE plugin to correctly handle filters with multiple services.
- Added a comment to clarify that the native filter supports only one service.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>universal_ble_plugin.cpp</strong><dd><code>Fix service filter logic in Windows BLE plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

windows/src/universal_ble_plugin.cpp

<li>Updated the condition to check for multiple services in the filter.<br> <li> Added a comment clarifying the native filter's support for only one <br>service.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/111/files#diff-c744a38517e9dcb9177126ffd1392b9decc2b53e55772d4270f4387a4f4c9357">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information