### PR TITLE
Fix Windows Bluetooth availability state in Release build

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,13 @@
             "type": "dart"
         },
         {
+            "name": "example release",
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "release"
+        },
+        {
             "name": "example_mock",
             "cwd": "example",
             "request": "launch",

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -34,6 +34,8 @@ namespace universal_ble
   std::unique_ptr<UniversalBleCallbackChannel> callbackChannel;
   std::unordered_map<std::string, winrt::event_token> characteristicsTokens{}; // TODO: Remove the map and store the token inside the characteristic object
 
+  bool initialized = false;
+  
   void UniversalBlePlugin::RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar)
   {
     auto plugin = std::make_unique<UniversalBlePlugin>(registrar);

--- a/windows/src/universal_ble_plugin.h
+++ b/windows/src/universal_ble_plugin.h
@@ -85,7 +85,6 @@ namespace universal_ble
 
         UniversalBleUiThreadHandler uiThreadHandler_;
         Radio bluetoothRadio{nullptr};
-        bool initialized = false;
         RadioState oldRadioState = RadioState::Unknown;
         BluetoothLEAdvertisementWatcher bluetoothLEWatcher{nullptr};
         DeviceWatcher deviceWatcher{nullptr};

--- a/windows/src/universal_ble_plugin.h
+++ b/windows/src/universal_ble_plugin.h
@@ -85,6 +85,7 @@ namespace universal_ble
 
         UniversalBleUiThreadHandler uiThreadHandler_;
         Radio bluetoothRadio{nullptr};
+        bool initialized = false;
         RadioState oldRadioState = RadioState::Unknown;
         BluetoothLEAdvertisementWatcher bluetoothLEWatcher{nullptr};
         DeviceWatcher deviceWatcher{nullptr};


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improved the handling of Bluetooth availability state by adding an initialization check and updating the logic for determining the state.
- Introduced an `initialized` flag in the `UniversalBlePlugin` class to track initialization status.
- Added a new launch configuration for Dart in release mode in the `.vscode/launch.json` file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>universal_ble_plugin.cpp</strong><dd><code>Improve Bluetooth availability state handling and initialization</code></dd></summary>
<hr>

windows/src/universal_ble_plugin.cpp

<li>Added initialization check for Bluetooth availability state.<br> <li> Updated logic for determining Bluetooth availability state.<br> <li> Triggered state change callback when Bluetooth radio is found.<br> <li> Set <code>initialized</code> flag to true after radio check.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/112/files#diff-c744a38517e9dcb9177126ffd1392b9decc2b53e55772d4270f4387a4f4c9357">+18/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>universal_ble_plugin.h</strong><dd><code>Add initialization flag for Bluetooth plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

windows/src/universal_ble_plugin.h

- Introduced `initialized` boolean flag.



</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/112/files#diff-5e53d816e18b3a55d63090396aac40ab0c2159f0bf24d5ae5687d003c22c809f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>launch.json</strong><dd><code>Add release mode configuration for Dart launch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.vscode/launch.json

- Added new launch configuration for release mode.



</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/112/files#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information