### PR TITLE
Support ble extended advertising on Windows

### DIFF
--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -107,6 +107,7 @@ namespace universal_ble
       {
         bluetoothLEWatcher = BluetoothLEAdvertisementWatcher();
         bluetoothLEWatcher.ScanningMode(BluetoothLEScanningMode::Active);
+        (void)bluetoothLEWatcher.AllowExtendedAdvertisements();
         resetScanFilter();
 
         if (filter != nullptr)


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added support for Bluetooth Low Energy (BLE) extended advertisements on Windows by modifying the `BluetoothLEAdvertisementWatcher` to allow extended advertisements.
- This enhancement enables the use of extended advertising features in BLE applications on Windows.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>universal_ble_plugin.cpp</strong><dd><code>Enable BLE extended advertisements on Windows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

windows/src/universal_ble_plugin.cpp

<li>Added support for allowing extended advertisements in Bluetooth LE.<br> <li> Modified the BluetoothLEAdvertisementWatcher to enable extended <br>advertisements.<br>


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/114/files#diff-c744a38517e9dcb9177126ffd1392b9decc2b53e55772d4270f4387a4f4c9357">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information