### PR TITLE
Enhance getSystemDevice API on macOS with Broader Default Services Fi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 0.14.0
+* `getSystemDevices(withServices:)` now sets several generic services by default as filter
+
+## 0.14.0
 * BREAKING CHANGE: `bleDevice.name` now filters out non-printable characters
 * Add `bleDevice.rawName`
 * Add `disableBluetooth` API

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ See the [Bluetooth Availability](#bluetooth-availability) section for more.
 Already connected devices, connected either through previous sessions, other apps or through system settings, won't show up as scan results. You can get those using `getSystemDevices()`.
 
 ```dart
-// Get already connected devices
-// You can set `withServices` to narrow down the results
-// On `Apple`, `withServices` is required to get connected devices, else [1800] service will be used as default filter.
+// Get already connected devices.
+// You can set `withServices` to narrow down the results.
+// On `Apple`, `withServices` is required to get any connected devices. If not passed, several [18XX] generic services will be set by default.
 List<BleDevice> devices = await UniversalBle.getSystemDevices(withServices: []);
 ```
 

--- a/darwin/Classes/UniversalBlePlugin.swift
+++ b/darwin/Classes/UniversalBlePlugin.swift
@@ -52,11 +52,11 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
   func enableBluetooth(completion: @escaping (Result<Bool, Error>) -> Void) {
     completion(Result.failure(PigeonError(code: "NotSupported", message: nil, details: nil)))
   }
-    
+
   func disableBluetooth(completion: @escaping (Result<Bool, any Error>) -> Void) {
     completion(Result.failure(PigeonError(code: "NotSupported", message: nil, details: nil)))
   }
-    
+
   func startScan(filter: UniversalScanFilter?) throws {
     // If filter has any other filter other than official one
     let usesCustomFilters = filter?.usesCustomFilters ?? false
@@ -291,9 +291,12 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
   }
 
   func getSystemDevices(withServices: [String], completion: @escaping (Result<[UniversalBleScanResult], Error>) -> Void) {
-    var filterCBUUID = withServices.map { CBUUID(string: $0) }
-    // We can't keep this filter empty, so adding a default filter
-    if filterCBUUID.isEmpty { filterCBUUID.append(CBUUID(string: "1800")) }
+    var servicesFilter = withServices
+    if servicesFilter.isEmpty {
+      // Add few general services as filter
+      servicesFilter = ["1800", "1801", "180A", "180D", "1810", "181B", "1808", "181D", "1816", "1814", "181A", "1802", "1803", "1804", "1815", "1805", "1807", "1806", "1848", "185E", "180F", "1812", "180E", "1813"]
+    }
+    var filterCBUUID = servicesFilter.map { CBUUID(string: $0) }
     let bleDevices = manager.retrieveConnectedPeripherals(withServices: filterCBUUID)
     bleDevices.forEach { discoveredPeripherals[$0.uuid.uuidString] = $0 }
     completion(Result.success(bleDevices.map {

--- a/darwin/Classes/UniversalBlePlugin.swift
+++ b/darwin/Classes/UniversalBlePlugin.swift
@@ -293,7 +293,7 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
   func getSystemDevices(withServices: [String], completion: @escaping (Result<[UniversalBleScanResult], Error>) -> Void) {
     var servicesFilter = withServices
     if servicesFilter.isEmpty {
-      // Add few general services as filter
+      // Add several generic services
       servicesFilter = ["1800", "1801", "180A", "180D", "1810", "181B", "1808", "181D", "1816", "1814", "181A", "1802", "1803", "1804", "1815", "1805", "1807", "1806", "1848", "185E", "180F", "1812", "180E", "1813"]
     }
     var filterCBUUID = servicesFilter.map { CBUUID(string: $0) }

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -5,9 +5,11 @@
 *.swp
 .DS_Store
 .atom/
+.build/
 .buildlog/
 .history
 .svn/
+.swiftpm/
 migrate_working_dir/
 
 # IntelliJ related

--- a/example/lib/home/home.dart
+++ b/example/lib/home/home.dart
@@ -71,6 +71,19 @@ class _MyAppState extends State<MyApp> {
     );
   }
 
+  Future<void> _getSystemDevices() async {
+    List<BleDevice> devices = await UniversalBle.getSystemDevices(
+      withServices: scanFilter?.withServices,
+    );
+    if (devices.isEmpty) {
+      showSnackbar("No Connected Devices Found");
+    }
+    setState(() {
+      _bleDevices.clear();
+      _bleDevices.addAll(devices);
+    });
+  }
+
   void _showScanFilterBottomSheet() {
     showModalBottomSheet(
       isScrollControlled: true,
@@ -179,17 +192,7 @@ class _MyAppState extends State<MyApp> {
                 if (BleCapabilities.supportsConnectedDevicesApi)
                   PlatformButton(
                     text: 'Connected Devices',
-                    onPressed: () async {
-                      List<BleDevice> devices =
-                          await UniversalBle.getSystemDevices();
-                      if (devices.isEmpty) {
-                        showSnackbar("No Connected Devices Found");
-                      }
-                      setState(() {
-                        _bleDevices.clear();
-                        _bleDevices.addAll(devices);
-                      });
-                    },
+                    onPressed: _getSystemDevices,
                   ),
                 PlatformButton(
                   text: 'Queue: ${_queueType.name}',

--- a/example/lib/home/widgets/scan_filter_widget.dart
+++ b/example/lib/home/widgets/scan_filter_widget.dart
@@ -115,19 +115,19 @@ class _ScanFilterWidgetState extends State<ScanFilterWidget> {
           const Divider(),
           const SizedBox(height: 10),
           TextFormField(
-            controller: widget.servicesFilterController,
+            controller: widget.namePrefixController,
             maxLines: 2,
             decoration: const InputDecoration(
-              labelText: "Services",
+              labelText: "Name Prefixes",
               border: OutlineInputBorder(),
             ),
           ),
           const SizedBox(height: 10),
           TextFormField(
-            controller: widget.namePrefixController,
+            controller: widget.servicesFilterController,
             maxLines: 2,
             decoration: const InputDecoration(
-              labelText: "Name Prefixes",
+              labelText: "Services",
               border: OutlineInputBorder(),
             ),
           ),

--- a/example/macos/Runner/AppDelegate.swift
+++ b/example/macos/Runner/AppDelegate.swift
@@ -6,4 +6,8 @@ class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true
   }
+
+  override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
+    return true
+  }
 }

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -292,7 +292,7 @@ class UniversalBle {
 
   /// Get connected devices to the system (connected by any app).
   /// Use [withServices] to filter devices by services.
-  /// On `Apple`, [withServices] is required to get connected devices, else [1800] service will be used as default filter.
+  /// On `Apple`, [withServices] is required to get any connected devices. If not passed, several [18XX] generic services will be set by default.
   /// On `Android`, `Linux` and `Windows`, if [withServices] is used, then internally all services will be discovered for each device first (either by connecting or by using cached services).
   /// Not supported on `Web`.
   static Future<List<BleDevice>> getSystemDevices({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: universal_ble
 description: A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE) plugin for Flutter
-version: 0.14.0
+version: 0.15.0
 homepage: https://navideck.com
 repository: https://github.com/Navideck/universal_ble
 issue_tracker: https://github.com/Navideck/universal_ble/issues


### PR DESCRIPTION
### **User description**
…lter


___

### **PR Type**
Enhancement


___

### **Description**
- Enhanced `getSystemDevices` API to include broader default services filter.

- Added support for secure restorable state in macOS example app.

- Minor formatting adjustments in `UniversalBlePlugin.swift`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UniversalBlePlugin.swift</strong><dd><code>Broaden default services filter in `getSystemDevices` API</code></dd></summary>
<hr>

darwin/Classes/UniversalBlePlugin.swift

<li>Broadened default services filter in <code>getSystemDevices</code> API.<br> <li> Adjusted logic to handle empty service filters.<br> <li> Minor formatting changes for better readability.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/121/files#diff-87832239a271a17152d0bd5fd33a705cd1398bda21bfdfff19934f405c09965f">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AppDelegate.swift</strong><dd><code>Add secure restorable state support in macOS app</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

example/macos/Runner/AppDelegate.swift

<li>Added <code>applicationSupportsSecureRestorableState</code> method.<br> <li> Enabled secure restorable state for macOS example app.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/121/files#diff-5a61c3185e92974948025146f2b598dd71a7ec65914191898f0effdbb054de70">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information