### PR TITLE
Improve Android bluetoothGatt management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 0.14.0
+## 0.15.0
 * `getSystemDevices(withServices:)` now sets several generic services by default as filter
-* Fix `getConnectionState` on Android, Now it will return `BleConnectionState.disconnected` if device is connected to System but not with App
+* `getConnectionState` on Android will now return `BleConnectionState.disconnected` if device is connected to the system but not to the app
 
 ## 0.14.0
 * BREAKING CHANGE: `bleDevice.name` now filters out non-printable characters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.14.0
 * `getSystemDevices(withServices:)` now sets several generic services by default as filter
+* Fix `getConnectionState` on Android, Now it will return `BleConnectionState.disconnected` if device is connected to System but not with App
 
 ## 0.14.0
 * BREAKING CHANGE: `bleDevice.name` now filters out non-printable characters


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improved BluetoothGatt management by replacing `knownGatts` list with a `Map`.

- Added utility functions for managing BluetoothGatt cache.

- Enhanced connection state handling for better app-device synchronization.

- Refactored service discovery logic for improved error handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UniversalBleHelper.kt</strong><dd><code>Refactor BluetoothGatt management utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt

<li>Replaced <code>knownGatts</code> list with a <code>Map</code> for better management.<br> <li> Added utility functions like <code>saveCacheIfNeeded</code>, <code>removeCache</code>, and <br><code>findGatt</code>.<br> <li> Improved error handling for unknown device IDs.<br> <li> Enhanced logic for checking and managing known Gatt connections.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/124/files#diff-07528325c9af8065d3fe07cc2436350a5db4dde75378b96e4801cdc7675b128a">+20/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UniversalBlePlugin.kt</strong><dd><code>Enhance connection and service discovery logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt

<li>Updated connection handling to use <code>findGatt</code> and <code>isKnownGatt</code>.<br> <li> Replaced manual <code>knownGatts</code> management with utility functions.<br> <li> Improved service discovery error handling and callback logic.<br> <li> Removed unused <code>devicesStateMap</code> for cleaner state management.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/124/files#diff-9bf8297311d93083e68b98b07fd87ec8038bf693833cef20b676ac88a4aa837e">+22/-22</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information