### PR TITLE
Improve system connected devices docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ See the [Bluetooth Availability](#bluetooth-availability) section for more.
 #### System Devices
 
 Already connected devices, connected either through previous sessions, other apps or through system settings, won't show up as scan results. You can get those using `getSystemDevices()`.
+On Apple, connected devices by other apps that do not require system pairing, won't be returned as system devices.
 
 ```dart
 // Get already connected devices.

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -293,6 +293,7 @@ class UniversalBle {
   /// Get connected devices to the system (connected by any app).
   /// Use [withServices] to filter devices by services.
   /// On `Apple`, [withServices] is required to get any connected devices. If not passed, several [18XX] generic services will be set by default.
+  /// On `Apple`, connected devices by other apps that do not require system pairing, won't be returned as system devices.
   /// On `Android`, `Linux` and `Windows`, if [withServices] is used, then internally all services will be discovered for each device first (either by connecting or by using cached services).
   /// Not supported on `Web`.
   static Future<List<BleDevice>> getSystemDevices({


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Clarified behavior of `getSystemDevices` on Apple in code comments.

- Updated README to reflect `getSystemDevices` behavior on Apple.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>universal_ble.dart</strong><dd><code>Clarify `getSystemDevices` behavior in code comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/universal_ble.dart

<li>Added clarification about <code>getSystemDevices</code> behavior on Apple.<br> <li> Explained limitations for devices not requiring system pairing.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/125/files#diff-0299ec0dda75c972b21ca1a2d8ac5fc87bc4dc3f354c49c7995bcb3d18054304">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README for `getSystemDevices` behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Updated documentation for <code>getSystemDevices</code> behavior on Apple.<br> <li> Highlighted limitation for devices not requiring system pairing.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/125/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information