### PR TITLE
macos localName

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,10 +1,8 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  package="com.navideck.universal_ble">
-   <uses-permission
-       android:name="android.permission.BLUETOOTH"
-       android:maxSdkVersion="30" />
-   <uses-permission
-       android:name="android.permission.BLUETOOTH_ADMIN"
-       android:maxSdkVersion="30" />   
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools" package="com.navideck.universal_ble">   
+    <uses-permission android:name="android.permission.BLUETOOTH"  />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"  />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation"  />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"  />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE"  />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"  />
 </manifest>

--- a/darwin/Classes/UniversalBlePlugin.swift
+++ b/darwin/Classes/UniversalBlePlugin.swift
@@ -322,6 +322,7 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
     peripheral.saveCache()
 
     // Extract manufacturer data and service UUIDs from the advertisement data
+    let localName = advertisementData[CBAdvertisementDataLocalNameKey] as? String
     let manufacturerData = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data
     let services = (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID])
 
@@ -336,13 +337,13 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
     }
 
     // Apply custom filters and return early if the peripheral doesn't match
-    if !universalBleFilterUtil.filterDevice(name: peripheral.name, manufacturerData: universalManufacturerData, services: services) {
+    if !universalBleFilterUtil.filterDevice(name: localName, manufacturerData: universalManufacturerData, services: services) {
       return
     }
 
     callbackChannel.onScanResult(result: UniversalBleScanResult(
       deviceId: peripheral.uuid.uuidString,
-      name: peripheral.name,
+      name: localName,
       isPaired: nil,
       rssi: RSSI as? Int64,
       manufacturerDataList: manufacturerDataList,


### PR DESCRIPTION
### **User description**
bugfix macOS localName.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the use of `localName` instead of `peripheral.name` in filtering devices.

- Updated scan result to use `localName` for device name.

- Improved handling of advertisement data in macOS BLE scanning.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UniversalBlePlugin.swift</strong><dd><code>Use `localName` for BLE device filtering and results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

darwin/Classes/UniversalBlePlugin.swift

<li>Added extraction of <code>localName</code> from advertisement data.<br> <li> Replaced <code>peripheral.name</code> with <code>localName</code> in device filtering.<br> <li> Updated scan result to use <code>localName</code> for device name.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/126/files#diff-87832239a271a17152d0bd5fd33a705cd1398bda21bfdfff19934f405c09965f">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information