### PR TITLE
Improve callbacks error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.15.0
 * `getSystemDevices(withServices:)` now sets several generic services by default as filter
 * `getConnectionState` on Android will now return `BleConnectionState.disconnected` if device is connected to the system but not to the app
-* Improve Callback error handling
+* Improve callback error handling
 
 ## 0.14.0
 * BREAKING CHANGE: `bleDevice.name` now filters out non-printable characters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.15.0
 * `getSystemDevices(withServices:)` now sets several generic services by default as filter
 * `getConnectionState` on Android will now return `BleConnectionState.disconnected` if device is connected to the system but not to the app
+* Improve Callback error handling
 
 ## 0.14.0
 * BREAKING CHANGE: `bleDevice.name` now filters out non-printable characters

--- a/lib/src/ble_command_queue.dart
+++ b/lib/src/ble_command_queue.dart
@@ -32,7 +32,9 @@ class BleCommandQueue {
   Queue _newQueue(String id) {
     final queue = Queue();
     queue.onRemainingItemsUpdate = (int items) {
-      onQueueUpdate?.call(id, items);
+      try {
+        onQueueUpdate?.call(id, items);
+      } catch (_) {}
     };
     _queueMap[id] = queue;
     return queue;

--- a/lib/src/models/ble_connection_update.dart
+++ b/lib/src/models/ble_connection_update.dart
@@ -1,8 +1,10 @@
 class BleConnectionUpdate {
+  final String deviceId;
   final bool isConnected;
   final String? error;
 
   BleConnectionUpdate({
+    required this.deviceId,
     required this.isConnected,
     this.error,
   });

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -101,13 +101,19 @@ class UniversalBle {
             }
           }
         },
+        onError: (error) {
+          if (!completer.isCompleted) {
+            connectionSubscription?.cancel();
+            completer.completeError(ConnectionException(error));
+          }
+        },
       );
 
       _platform
           .connect(deviceId, connectionTimeout: connectionTimeout)
           .catchError(
         (error) {
-          if (completer.isCompleted == false) {
+          if (!completer.isCompleted) {
             connectionSubscription?.cancel();
             completer.completeError(ConnectionException(error));
           }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added error handling for callback invocations across multiple methods.

- Introduced `deviceId` field in `BleConnectionUpdate` class.

- Improved connection stream handling in `UniversalBlePlatform`.

- Enhanced error handling during BLE connection and disconnection processes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ble_command_queue.dart</strong><dd><code>Add error handling for queue update callbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/ble_command_queue.dart

<li>Wrapped <code>onQueueUpdate</code> callback in a try-catch block.<br> <li> Prevented unhandled exceptions during queue updates.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/130/files#diff-138d252ab7b0ff99064abd1138bbcf0d9ef5f88d5992c456b8b4200ccd8bf53f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ble_connection_update.dart</strong><dd><code>Introduce `deviceId` field in connection updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/models/ble_connection_update.dart

<li>Added <code>deviceId</code> field to <code>BleConnectionUpdate</code> class.<br> <li> Updated constructor to require <code>deviceId</code>.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/130/files#diff-dc976d54bd58aef08c8508c74279e2fffd3daec703988bad8088a3e5354fa8f6">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>universal_ble.dart</strong><dd><code>Improve error handling in BLE connection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/universal_ble.dart

<li>Added <code>onError</code> handler for connection subscription.<br> <li> Improved error handling during BLE connection attempts.<br> <li> Ensured proper cancellation of subscriptions on errors.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/130/files#diff-0299ec0dda75c972b21ca1a2d8ac5fc87bc4dc3f354c49c7995bcb3d18054304">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>universal_ble_platform_interface.dart</strong><dd><code>Enhance callback safety and streamline connection stream</code>&nbsp; </dd></summary>
<hr>

lib/src/universal_ble_platform_interface.dart

<li>Added try-catch blocks for all callback invocations.<br> <li> Updated connection stream to directly use <code>BleConnectionUpdate</code>.<br> <li> Improved handling of pairing state and availability updates.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/130/files#diff-127e48afab502be75a7cc9a9d97749f8a34e499dc343bff386b3da7ddd0ea4b3">+27/-23</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information