### PR TITLE
Do not normalize UUIDs on native side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.16.0
 * Bump bluez to 0.8.3
 * Improve readme
+* Do not normalize UUIDs on native side
 * Reverse _permissionStatus return values in example app
 
 ## 0.15.0

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt
@@ -73,16 +73,8 @@ fun Int.toBleConnectionState(): BleConnectionState {
     }
 }
 
-fun String.validFullUUID(): String {
-    return when (this.count()) {
-        4 -> "0000$this-0000-1000-8000-00805F9B34FB"
-        8 -> "$this-0000-1000-8000-00805F9B34FB"
-        else -> this
-    }
-}
-
 fun List<String>.toUUIDList(): List<UUID> {
-    return this.map { UUID.fromString(it.validFullUUID()) }
+    return this.map { UUID.fromString(it) }
 }
 
 

--- a/darwin/Classes/UniversalBleHelper.swift
+++ b/darwin/Classes/UniversalBleHelper.swift
@@ -143,20 +143,6 @@ public extension CBPeripheral {
     }
 }
 
-extension String {
-    var validFullUUID: String {
-        let uuidLength = count
-        if uuidLength == 4 || uuidLength == 8 {
-            let baseUuid = "00000000-0000-1000-8000-00805F9B34FB"
-            let start = baseUuid.startIndex
-            let range = baseUuid.index(start, offsetBy: 4 - uuidLength) ..< baseUuid.index(start, offsetBy: 4)
-            return baseUuid.replacingCharacters(in: range, with: self).lowercased()
-        } else {
-            return self
-        }
-    }
-}
-
 extension FlutterStandardTypedData {
     func toData() -> Data {
         return Data(data)

--- a/darwin/Classes/UniversalBlePlugin.swift
+++ b/darwin/Classes/UniversalBlePlugin.swift
@@ -348,7 +348,7 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
       isPaired: nil,
       rssi: RSSI as? Int64,
       manufacturerDataList: manufacturerDataList,
-      services: services?.map { $0.uuidStr.validFullUUID }
+      services: services?.map { $0.uuidStr }
     )) { _ in }
   }
 
@@ -492,7 +492,7 @@ extension String {
 extension [String] {
   func toCBUUID() throws -> [CBUUID] {
     return try compactMap { serviceUUID in
-      guard UUID(uuidString: serviceUUID.validFullUUID) != nil else {
+      guard UUID(uuidString: serviceUUID) != nil else {
         throw PigeonError(code: "IllegalArgument", message: "Invalid service UUID:\(serviceUUID)", details: nil)
       }
       return CBUUID(string: serviceUUID)


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Removed UUID normalization logic from both Android and iOS implementations.

- Simplified UUID handling by directly using provided UUID strings.

- Updated related methods to remove dependency on `validFullUUID`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UniversalBleHelper.kt</strong><dd><code>Removed UUID normalization logic in Android helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt

<li>Removed the <code>validFullUUID</code> function for UUID normalization.<br> <li> Updated <code>toUUIDList</code> to directly use provided UUID strings.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/138/files#diff-07528325c9af8065d3fe07cc2436350a5db4dde75378b96e4801cdc7675b128a">+1/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UniversalBleHelper.swift</strong><dd><code>Removed UUID normalization logic in iOS helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

darwin/Classes/UniversalBleHelper.swift

<li>Removed the <code>validFullUUID</code> extension for UUID normalization.<br> <li> Simplified UUID handling by eliminating unnecessary logic.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/138/files#diff-64579e5454d2beef64b5056e1f9eea6e9f92006164a448fcd4207c126df2af48">+0/-14</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UniversalBlePlugin.swift</strong><dd><code>Simplified UUID handling in iOS plugin</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

darwin/Classes/UniversalBlePlugin.swift

<li>Updated UUID handling in <code>onScanResult</code> to directly use UUID strings.<br> <li> Removed usage of <code>validFullUUID</code> in service UUID validation.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/138/files#diff-87832239a271a17152d0bd5fd33a705cd1398bda21bfdfff19934f405c09965f">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>