### PR TITLE
Improve requestMTU() docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ On most platforms, the MTU can only be queried but not manually set:
 - **iOS/macOS**: System automatically sets MTU to 185 bytes maximum
 - **Android 14+**: System automatically sets MTU to 517 bytes for the first GATT client
 - **Windows**: MTU can only be queried
-- **Linux**: 
+- **Linux**: MTU can only be queried
 - **Web**: No mechanism to query or modify MTU size
 
 #### Best Practices

--- a/README.md
+++ b/README.md
@@ -235,6 +235,34 @@ UniversalBle.enableBluetooth();
 UniversalBle.disableBluetooth();
 ```
 
+### Request MTU
+
+This method will **attempt** to set the MTU (Maximum Transmission Unit) but it is not guaranteed to succeed due to platform limitations. It will always return the current MTU.
+
+```dart
+int mtu = await UniversalBle.requestMtu(widget.deviceId, 247);
+```
+
+#### Platform Limitations
+
+On most platforms, the MTU can only be queried but not manually set:
+
+- **iOS/macOS**: System automatically sets MTU to 185 bytes maximum
+- **Android 14+**: System automatically sets MTU to 517 bytes for the first GATT client
+- **Windows**: MTU can only be queried
+- **Linux**: 
+- **Web**: No mechanism to query or modify MTU size
+
+#### Best Practices
+
+When developing cross-platform BLE applications and devices:
+
+- Design for default MTU size (23 bytes) as default
+- Dynamically adapt to use larger packet sizes when the system provides them
+- Take advantage of the increased throughput when available without requiring it
+- Implement data fragmentation for larger transfers
+- Handle platform-specific MTU size based on current value
+
 ## Command Queue
 
 By default, all commands are executed in a global queue (`QueueType.global`), with each command waiting for the previous one to finish.

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -208,7 +208,8 @@ class UniversalBle {
   }
 
   /// Request MTU value.
-  /// `requestMtu` is not supported on `Linux` and `Web.
+  /// It will **attempt** to set the MTU (Maximum Transmission Unit) but it is not guaranteed to succeed due to platform limitations.
+  /// It will always return the current MTU.
   static Future<int> requestMtu(String deviceId, int expectedMtu) async {
     return await _bleCommandQueue.queueCommand(
       () => _platform.requestMtu(deviceId, expectedMtu),


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Enhanced documentation for the `requestMtu` method in `UniversalBle`.

- Added platform-specific limitations and best practices for MTU handling.

- Updated README with detailed usage and examples for `requestMtu`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>universal_ble.dart</strong><dd><code>Clarify `requestMtu` method behavior and limitations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/src/universal_ble.dart

<li>Updated <code>requestMtu</code> method documentation to clarify behavior.<br> <li> Highlighted platform limitations and guaranteed return of current MTU.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/140/files#diff-0299ec0dda75c972b21ca1a2d8ac5fc87bc4dc3f354c49c7995bcb3d18054304">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add `requestMtu` usage, limitations, and best practices</code>&nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Added detailed explanation for <code>requestMtu</code> method.<br> <li> Included platform-specific limitations for MTU handling.<br> <li> Provided best practices for cross-platform BLE applications.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/140/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+28/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>