### PR TITLE
Fix: Unable to establish connection on channel when hot restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.17.0
 * Fix Windows crash when calling pair APIs with an unknown deviceId
+* Fix Windows warning `Unable to establish connection on channel` when hot restart
 
 ## 0.16.0
 * BREAKING CHANGE: `payload` is now `payloadPrefix`

--- a/windows/src/universal_ble_plugin.h
+++ b/windows/src/universal_ble_plugin.h
@@ -74,7 +74,11 @@ namespace universal_ble
         static void SuccessCallback() {}
         static void ErrorCallback(const FlutterError &error)
         {
-            std::cout << "ErrorCallback: " << error.message() << std::endl;
+            // Ignore ChannelConnection Error, This might occur because of HotReload
+            if (error.code() != "channel-error")
+            {
+                std::cout << "ErrorCode: " << error.code() << " Message: " << error.message() << std::endl;
+            }
         }
 
         // Disallow copy and assign.


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue with channel connection errors during hot restart.

- Added conditional logging to ignore specific "channel-error" codes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>universal_ble_plugin.h</strong><dd><code>Improved error handling in `ErrorCallback` method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

windows/src/universal_ble_plugin.h

<li>Modified <code>ErrorCallback</code> to conditionally log errors.<br> <li> Added logic to ignore "channel-error" during hot reload.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/142/files#diff-5e53d816e18b3a55d63090396aac40ab0c2159f0bf24d5ae5687d003c22c809f">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>