### PR TITLE
Improve Android permission documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,23 +347,20 @@ BleUuidParser.compare("180a","0000180A-0000-1000-8000-00805F9B34FB"); // true
 Add the following permissions to your AndroidManifest.xml file:
 
 ```xml
-<uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
 <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="30" />
-```
-
-If you are targeting **Android 11 or lower**, also add:
-```xml
+<uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+<uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="28" />
 <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
+<uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
 ```
 
-If you use `BLUETOOTH_SCAN` to determine location, modify your AndroidManifest.xml file to include the following entry:
+If your app uses iBeacons or BLUETOOTH_SCAN to determine location, change the last 2 permissions to:
 
 ```xml
- <uses-permission android:name="android.permission.BLUETOOTH_SCAN" tools:remove="android:usesPermissionFlags" tools:targetApi="s" />
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
 ```
-
-If your app uses location services, remove `android:maxSdkVersion="30"` from the location permission tags.
 
 ### iOS / macOS
 

--- a/README.md
+++ b/README.md
@@ -349,8 +349,12 @@ Add the following permissions to your AndroidManifest.xml file:
 ```xml
 <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />
 <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
 <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="30" />
+```
+
+If you are targeting **Android 11 or lower**, also add:
+```xml
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
 ```
 
 If you use `BLUETOOTH_SCAN` to determine location, modify your AndroidManifest.xml file to include the following entry:

--- a/README.md
+++ b/README.md
@@ -375,7 +375,14 @@ Add the `Bluetooth` capability to the macOS app from Xcode.
 
 Your Bluetooth adapter needs to support at least Bluetooth 4.0. If you have more than 1 adapters, the first one returned from the system will be picked.
 
-When publishing on Windows you need to declare the following [capabilities](https://learn.microsoft.com/en-us/windows/uwp/packaging/app-capability-declarations): `bluetooth, radios`.
+When publishing on Windows, you need to declare the following [capabilities](https://learn.microsoft.com/en-us/windows/uwp/packaging/app-capability-declarations): `bluetooth, radios`.
+
+When publishing on Linux as a snap, you need to declare the `bluez` plug in `snapcraft.yaml`.
+```
+...
+  plugs:
+    - bluez
+```
 
 ### Web
 


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Clarified Android permissions for different target versions.

- Added specific instructions for Android 11 or lower.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Updated Android permission documentation for clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Added instructions for Android 11 or lower permissions.<br> <li> Moved <code>ACCESS_FINE_LOCATION</code> permission to a conditional section.


</details>


  </td>
  <td><a href="https://github.com/Navideck/universal_ble/pull/147/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>