### PR TITLE
fix: linux: getSystemDevices (issue #153)

### DIFF
--- a/lib/src/universal_ble_linux/universal_ble_linux.dart
+++ b/lib/src/universal_ble_linux/universal_ble_linux.dart
@@ -350,6 +350,7 @@ class UniversalBleLinux extends UniversalBlePlatform {
   Future<List<BleDevice>> getSystemDevices(
     List<String>? withServices,
   ) async {
+    await _ensureInitialized();
     List<BlueZDevice> devices =
         _client.devices.where((device) => device.connected).toList();
     if (withServices != null && withServices.isNotEmpty) {


### PR DESCRIPTION
make sure getSystemDevices connects the bluez client first. this ensures that the list of devices is correctly populated.

