### PR TITLE
Use deviceId when checking for equality on ble devices

### DIFF
--- a/lib/src/models/ble_device.dart
+++ b/lib/src/models/ble_device.dart
@@ -44,8 +44,13 @@ class BleDevice {
   }
 
   @override
-  bool operator ==(Object other) =>
-      other is BleDevice && other.deviceId == deviceId;
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is BleDevice &&
+        runtimeType == other.runtimeType &&
+        other.deviceId == deviceId;
+  }
 
   @override
   int get hashCode => Object.hash(runtimeType, deviceId);


### PR DESCRIPTION
I'm storing some BleDevices in a Set and would like it to dedupe based on the deviceId