### PR TITLE
Update README and BLE API documentation for MTU handling

### DIFF
--- a/lib/src/extensions/ble_device_extension.dart
+++ b/lib/src/extensions/ble_device_extension.dart
@@ -22,7 +22,13 @@ extension BleDeviceExtension on BleDevice {
   /// Disconnects from the device.
   Future<void> disconnect() => UniversalBle.disconnect(deviceId);
 
-  /// Requests a specific MTU (Maximum Transmission Unit) size for the connection.
+  /// Requests an MTU (Maximum Transmission Unit) value for the connection.
+  ///
+  /// **⚠️ Note:** Requesting an MTU is a *best-effort* operation. The final MTU is
+  /// often controlled by the OS and remote device. Returns the negotiated MTU value,
+  /// which may differ from `expectedMtu`.
+  ///
+  /// See [UniversalBle.requestMtu] for platform limitations and best practices.
   Future<int> requestMtu(int expectedMtu) =>
       UniversalBle.requestMtu(deviceId, expectedMtu);
 

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -313,9 +313,21 @@ class UniversalBle {
     );
   }
 
-  /// Request MTU value.
-  /// It will **attempt** to set the MTU (Maximum Transmission Unit) but it is not guaranteed to succeed due to platform limitations.
-  /// It will always return the current MTU.
+  /// Requests an MTU (Maximum Transmission Unit) value for the connection.
+  ///
+  /// **⚠️ Note:** Requesting an MTU is a *best-effort* operation. On many platforms
+  /// the final MTU is fully controlled by the OS and remote device. This method
+  /// returns the current/negotiated MTU value, which may differ from `expectedMtu`.
+  ///
+  /// **Platform Limitations:**
+  /// * **iOS/macOS**: MTU is OS-managed; apps cannot request it (~185-517 bytes auto-negotiated)
+  /// * **Android ≤13**: May request once per connection (up to 517), default is 23
+  /// * **Android 14+**: First GATT client drives MTU to 517; subsequent requests ignored
+  /// * **Windows/Linux**: MTU is automatically negotiated; apps can only query it
+  /// * **Web**: Not supported (no API available)
+  ///
+  /// **Best Practices:** Design for default ATT MTU (23 bytes), treat requests as
+  /// opportunistic, and implement fragmentation for larger payloads.
   static Future<int> requestMtu(
     String deviceId,
     int expectedMtu, {


### PR DESCRIPTION
- Clarified MTU request behavior and platform limitations in README.md.
- Added best practices for MTU management in cross-platform BLE applications.
- Enhanced documentation for `requestMtu` method in UniversalBle and BleDeviceExtension to reflect best-effort nature of MTU requests and platform-specific behaviors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies MTU request behavior and platform limits, adds best-practice guidance and a hot-restart reset section, and updates `requestMtu` docs in code.
> 
> - **README**:
>   - **MTU**: Clarifies best-effort MTU negotiation, adds platform-specific limitations (iOS/macOS, Android versions, Windows/Linux, Web) and best practices; fixes code fence.
>   - **New Section**: Adds "Resetting State on Hot Restart" with a cleanup helper example.
> - **API Docs**:
>   - **`lib/src/universal_ble.dart`**: Expands `requestMtu` docs with platform limitations and best practices.
>   - **`lib/src/extensions/ble_device_extension.dart`**: Updates `requestMtu` method docs to reflect negotiated MTU behavior and link to `UniversalBle.requestMtu`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60ed65cfd620306120bbd213cf79a1fb04b15c89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->