### PR TITLE
Android: expose ScanSettings callbackType, matchMode, numOfMatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Android: expose `callbackType`, `matchMode`, and `numOfMatches` on `AndroidOptions` so callers can configure `ScanSettings` to defeat aggressive chip-side advert de-duplication on Pixel devices. `callbackType` accepts a `List<AndroidScanCallbackType>` (OR-folded on the native side) and includes a new `allMatchesAutoBatch` value (API 34+).
+
 ## 2.0.0
 * Add peripheral mode on Android, iOS, macOS, and Windows
 * Add `requestConnectionPriority` to allow tuning BLE connection intervals on Android

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBle.g.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBle.g.kt
@@ -294,6 +294,58 @@ enum class AndroidScanMode(val raw: Int) {
   }
 }
 
+/**
+ * Mirrors `android.bluetooth.le.ScanSettings#setCallbackType`. Pass any
+ * combination via `AndroidOptions.callbackType` (the plugin OR-folds the list
+ * before calling `setCallbackType`).
+ *
+ * API-level notes:
+ * * [allMatches] — API 21+
+ * * [firstMatch], [matchLost] — API 23+ (Marshmallow). Silently dropped on
+ *   older devices.
+ * * [allMatchesAutoBatch] — API 34+ (Upside Down Cake). Silently dropped on
+ *   older devices.
+ *
+ * See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
+ */
+enum class AndroidScanCallbackType(val raw: Int) {
+  ALL_MATCHES(0),
+  FIRST_MATCH(1),
+  MATCH_LOST(2),
+  ALL_MATCHES_AUTO_BATCH(3);
+
+  companion object {
+    fun ofRaw(raw: Int): AndroidScanCallbackType? {
+      return values().firstOrNull { it.raw == raw }
+    }
+  }
+}
+
+/** Mirrors `android.bluetooth.le.ScanSettings#setMatchMode`. */
+enum class AndroidScanMatchMode(val raw: Int) {
+  AGGRESSIVE(0),
+  STICKY(1);
+
+  companion object {
+    fun ofRaw(raw: Int): AndroidScanMatchMode? {
+      return values().firstOrNull { it.raw == raw }
+    }
+  }
+}
+
+/** Mirrors `android.bluetooth.le.ScanSettings#setNumOfMatches`. */
+enum class AndroidScanNumOfMatches(val raw: Int) {
+  ONE(0),
+  FEW(1),
+  MAX(2);
+
+  companion object {
+    fun ofRaw(raw: Int): AndroidScanNumOfMatches? {
+      return values().firstOrNull { it.raw == raw }
+    }
+  }
+}
+
 enum class CharacteristicProperty(val raw: Int) {
   BROADCAST(0),
   READ(1),
@@ -616,13 +668,30 @@ data class UniversalBleDescriptor (
  * Set [reportDelayMillis] timestamp for Bluetooth LE scan. If set to 0, you will be notified of scan results immediately.
  * If > 0, scan results are queued up and delivered after the requested delay or 5000 milliseconds (whichever is higher).
  * Note scan results may be delivered sooner if the internal buffers fill up.
+ * [callbackType], [matchMode], and [numOfMatches] map directly to the equivalent
+ * `android.bluetooth.le.ScanSettings` setters. When `null`, the plugin leaves them
+ * at the platform default — set them only if you need to override platform-side
+ * advert de-duplication (e.g. on Pixel hardware where the default settings
+ * throttle advertisements compared with nRF Connect).
+ *
+ * [callbackType] is a list because Android's `setCallbackType` accepts any
+ * bitwise combination of [AndroidScanCallbackType] values (for example
+ * `[firstMatch, matchLost]` to be notified once on entry and again on exit).
+ * The plugin OR-folds the list before calling the native API. Values that
+ * require a newer API than the device supports are silently dropped (and
+ * logged); see the [AndroidScanCallbackType] doc for per-value API levels.
+ *
+ * See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
  *
  * Generated class from Pigeon that represents data sent in messages.
  */
 data class AndroidOptions (
   val requestLocationPermission: Boolean? = null,
   val scanMode: AndroidScanMode? = null,
-  val reportDelayMillis: Long? = null
+  val reportDelayMillis: Long? = null,
+  val callbackType: List<AndroidScanCallbackType>? = null,
+  val matchMode: AndroidScanMatchMode? = null,
+  val numOfMatches: AndroidScanNumOfMatches? = null
 )
  {
   companion object {
@@ -630,7 +699,10 @@ data class AndroidOptions (
       val requestLocationPermission = pigeonVar_list[0] as Boolean?
       val scanMode = pigeonVar_list[1] as AndroidScanMode?
       val reportDelayMillis = pigeonVar_list[2] as Long?
-      return AndroidOptions(requestLocationPermission, scanMode, reportDelayMillis)
+      val callbackType = pigeonVar_list[3] as List<AndroidScanCallbackType>?
+      val matchMode = pigeonVar_list[4] as AndroidScanMatchMode?
+      val numOfMatches = pigeonVar_list[5] as AndroidScanNumOfMatches?
+      return AndroidOptions(requestLocationPermission, scanMode, reportDelayMillis, callbackType, matchMode, numOfMatches)
     }
   }
   fun toList(): List<Any?> {
@@ -638,6 +710,9 @@ data class AndroidOptions (
       requestLocationPermission,
       scanMode,
       reportDelayMillis,
+      callbackType,
+      matchMode,
+      numOfMatches,
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -648,7 +723,7 @@ data class AndroidOptions (
       return true
     }
     val other = other as AndroidOptions
-    return UniversalBlePigeonUtils.deepEquals(this.requestLocationPermission, other.requestLocationPermission) && UniversalBlePigeonUtils.deepEquals(this.scanMode, other.scanMode) && UniversalBlePigeonUtils.deepEquals(this.reportDelayMillis, other.reportDelayMillis)
+    return UniversalBlePigeonUtils.deepEquals(this.requestLocationPermission, other.requestLocationPermission) && UniversalBlePigeonUtils.deepEquals(this.scanMode, other.scanMode) && UniversalBlePigeonUtils.deepEquals(this.reportDelayMillis, other.reportDelayMillis) && UniversalBlePigeonUtils.deepEquals(this.callbackType, other.callbackType) && UniversalBlePigeonUtils.deepEquals(this.matchMode, other.matchMode) && UniversalBlePigeonUtils.deepEquals(this.numOfMatches, other.numOfMatches)
   }
 
   override fun hashCode(): Int {
@@ -656,6 +731,9 @@ data class AndroidOptions (
     result = 31 * result + UniversalBlePigeonUtils.deepHash(this.requestLocationPermission)
     result = 31 * result + UniversalBlePigeonUtils.deepHash(this.scanMode)
     result = 31 * result + UniversalBlePigeonUtils.deepHash(this.reportDelayMillis)
+    result = 31 * result + UniversalBlePigeonUtils.deepHash(this.callbackType)
+    result = 31 * result + UniversalBlePigeonUtils.deepHash(this.matchMode)
+    result = 31 * result + UniversalBlePigeonUtils.deepHash(this.numOfMatches)
     return result
   }
 }
@@ -1152,105 +1230,120 @@ private open class UniversalBlePigeonCodec : StandardMessageCodec() {
       }
       136.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          CharacteristicProperty.ofRaw(it.toInt())
+          AndroidScanCallbackType.ofRaw(it.toInt())
         }
       }
       137.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          PeripheralReadinessState.ofRaw(it.toInt())
+          AndroidScanMatchMode.ofRaw(it.toInt())
         }
       }
       138.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          PeripheralAttributePermission.ofRaw(it.toInt())
+          AndroidScanNumOfMatches.ofRaw(it.toInt())
         }
       }
       139.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          PeripheralAdvertisingState.ofRaw(it.toInt())
+          CharacteristicProperty.ofRaw(it.toInt())
         }
       }
       140.toByte() -> {
         return (readValue(buffer) as Long?)?.let {
-          UniversalBleErrorCode.ofRaw(it.toInt())
+          PeripheralReadinessState.ofRaw(it.toInt())
         }
       }
       141.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          UniversalBleScanResult.fromList(it)
+        return (readValue(buffer) as Long?)?.let {
+          PeripheralAttributePermission.ofRaw(it.toInt())
         }
       }
       142.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          UniversalBleService.fromList(it)
+        return (readValue(buffer) as Long?)?.let {
+          PeripheralAdvertisingState.ofRaw(it.toInt())
         }
       }
       143.toByte() -> {
-        return (readValue(buffer) as? List<Any?>)?.let {
-          UniversalBleCharacteristic.fromList(it)
+        return (readValue(buffer) as Long?)?.let {
+          UniversalBleErrorCode.ofRaw(it.toInt())
         }
       }
       144.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          UniversalBleDescriptor.fromList(it)
+          UniversalBleScanResult.fromList(it)
         }
       }
       145.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          AndroidOptions.fromList(it)
+          UniversalBleService.fromList(it)
         }
       }
       146.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          UniversalScanConfig.fromList(it)
+          UniversalBleCharacteristic.fromList(it)
         }
       }
       147.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          UniversalScanFilter.fromList(it)
+          UniversalBleDescriptor.fromList(it)
         }
       }
       148.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ManufacturerDataFilter.fromList(it)
+          AndroidOptions.fromList(it)
         }
       }
       149.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          UniversalManufacturerData.fromList(it)
+          UniversalScanConfig.fromList(it)
         }
       }
       150.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PeripheralAndroidOptions.fromList(it)
+          UniversalScanFilter.fromList(it)
         }
       }
       151.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PeripheralPlatformConfig.fromList(it)
+          ManufacturerDataFilter.fromList(it)
         }
       }
       152.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PeripheralService.fromList(it)
+          UniversalManufacturerData.fromList(it)
         }
       }
       153.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PeripheralCharacteristic.fromList(it)
+          PeripheralAndroidOptions.fromList(it)
         }
       }
       154.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PeripheralDescriptor.fromList(it)
+          PeripheralPlatformConfig.fromList(it)
         }
       }
       155.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PeripheralReadRequestResult.fromList(it)
+          PeripheralService.fromList(it)
         }
       }
       156.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          PeripheralCharacteristic.fromList(it)
+        }
+      }
+      157.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          PeripheralDescriptor.fromList(it)
+        }
+      }
+      158.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          PeripheralReadRequestResult.fromList(it)
+        }
+      }
+      159.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           PeripheralWriteRequestResult.fromList(it)
         }
@@ -1288,88 +1381,100 @@ private open class UniversalBlePigeonCodec : StandardMessageCodec() {
         stream.write(135)
         writeValue(stream, value.raw.toLong())
       }
-      is CharacteristicProperty -> {
+      is AndroidScanCallbackType -> {
         stream.write(136)
         writeValue(stream, value.raw.toLong())
       }
-      is PeripheralReadinessState -> {
+      is AndroidScanMatchMode -> {
         stream.write(137)
         writeValue(stream, value.raw.toLong())
       }
-      is PeripheralAttributePermission -> {
+      is AndroidScanNumOfMatches -> {
         stream.write(138)
         writeValue(stream, value.raw.toLong())
       }
-      is PeripheralAdvertisingState -> {
+      is CharacteristicProperty -> {
         stream.write(139)
         writeValue(stream, value.raw.toLong())
       }
-      is UniversalBleErrorCode -> {
+      is PeripheralReadinessState -> {
         stream.write(140)
         writeValue(stream, value.raw.toLong())
       }
-      is UniversalBleScanResult -> {
+      is PeripheralAttributePermission -> {
         stream.write(141)
-        writeValue(stream, value.toList())
+        writeValue(stream, value.raw.toLong())
       }
-      is UniversalBleService -> {
+      is PeripheralAdvertisingState -> {
         stream.write(142)
-        writeValue(stream, value.toList())
+        writeValue(stream, value.raw.toLong())
       }
-      is UniversalBleCharacteristic -> {
+      is UniversalBleErrorCode -> {
         stream.write(143)
-        writeValue(stream, value.toList())
+        writeValue(stream, value.raw.toLong())
       }
-      is UniversalBleDescriptor -> {
+      is UniversalBleScanResult -> {
         stream.write(144)
         writeValue(stream, value.toList())
       }
-      is AndroidOptions -> {
+      is UniversalBleService -> {
         stream.write(145)
         writeValue(stream, value.toList())
       }
-      is UniversalScanConfig -> {
+      is UniversalBleCharacteristic -> {
         stream.write(146)
         writeValue(stream, value.toList())
       }
-      is UniversalScanFilter -> {
+      is UniversalBleDescriptor -> {
         stream.write(147)
         writeValue(stream, value.toList())
       }
-      is ManufacturerDataFilter -> {
+      is AndroidOptions -> {
         stream.write(148)
         writeValue(stream, value.toList())
       }
-      is UniversalManufacturerData -> {
+      is UniversalScanConfig -> {
         stream.write(149)
         writeValue(stream, value.toList())
       }
-      is PeripheralAndroidOptions -> {
+      is UniversalScanFilter -> {
         stream.write(150)
         writeValue(stream, value.toList())
       }
-      is PeripheralPlatformConfig -> {
+      is ManufacturerDataFilter -> {
         stream.write(151)
         writeValue(stream, value.toList())
       }
-      is PeripheralService -> {
+      is UniversalManufacturerData -> {
         stream.write(152)
         writeValue(stream, value.toList())
       }
-      is PeripheralCharacteristic -> {
+      is PeripheralAndroidOptions -> {
         stream.write(153)
         writeValue(stream, value.toList())
       }
-      is PeripheralDescriptor -> {
+      is PeripheralPlatformConfig -> {
         stream.write(154)
         writeValue(stream, value.toList())
       }
-      is PeripheralReadRequestResult -> {
+      is PeripheralService -> {
         stream.write(155)
         writeValue(stream, value.toList())
       }
-      is PeripheralWriteRequestResult -> {
+      is PeripheralCharacteristic -> {
         stream.write(156)
+        writeValue(stream, value.toList())
+      }
+      is PeripheralDescriptor -> {
+        stream.write(157)
+        writeValue(stream, value.toList())
+      }
+      is PeripheralReadRequestResult -> {
+        stream.write(158)
+        writeValue(stream, value.toList())
+      }
+      is PeripheralWriteRequestResult -> {
+        stream.write(159)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt
@@ -249,6 +249,56 @@ fun AndroidScanMode.parse(): Int? {
     }
 }
 
+fun AndroidScanCallbackType.parse(): Int? {
+    return when (this) {
+        AndroidScanCallbackType.ALL_MATCHES -> ScanSettings.CALLBACK_TYPE_ALL_MATCHES
+        AndroidScanCallbackType.FIRST_MATCH ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                ScanSettings.CALLBACK_TYPE_FIRST_MATCH
+            } else {
+                UniversalBleLogger.logError("CALLBACK_TYPE_FIRST_MATCH requires Android API 23+.")
+                null
+            }
+        AndroidScanCallbackType.MATCH_LOST ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                ScanSettings.CALLBACK_TYPE_MATCH_LOST
+            } else {
+                UniversalBleLogger.logError("CALLBACK_TYPE_MATCH_LOST requires Android API 23+.")
+                null
+            }
+        AndroidScanCallbackType.ALL_MATCHES_AUTO_BATCH ->
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                ScanSettings.CALLBACK_TYPE_ALL_MATCHES_AUTO_BATCH
+            } else {
+                UniversalBleLogger.logError("CALLBACK_TYPE_ALL_MATCHES_AUTO_BATCH requires Android API 34+.")
+                null
+            }
+    }
+}
+
+fun AndroidScanMatchMode.parse(): Int? {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        UniversalBleLogger.logError("Match mode is not supported on this Android version.")
+        return null
+    }
+    return when (this) {
+        AndroidScanMatchMode.AGGRESSIVE -> ScanSettings.MATCH_MODE_AGGRESSIVE
+        AndroidScanMatchMode.STICKY -> ScanSettings.MATCH_MODE_STICKY
+    }
+}
+
+fun AndroidScanNumOfMatches.parse(): Int? {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+        UniversalBleLogger.logError("Num of matches is not supported on this Android version.")
+        return null
+    }
+    return when (this) {
+        AndroidScanNumOfMatches.ONE -> ScanSettings.MATCH_NUM_ONE_ADVERTISEMENT
+        AndroidScanNumOfMatches.FEW -> ScanSettings.MATCH_NUM_FEW_ADVERTISEMENT
+        AndroidScanNumOfMatches.MAX -> ScanSettings.MATCH_NUM_MAX_ADVERTISEMENT
+    }
+}
+
 fun Int.parseBluetoothStatusCodeError(): UniversalBleErrorCode? {
     if (this == BluetoothStatusCodes.SUCCESS) return null
     return when (this) {

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -192,6 +192,12 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
             androidConfig.reportDelayMillis?.let { reportDelay ->
                 builder.setReportDelay(reportDelay)
             }
+            androidConfig.callbackType?.let { types ->
+                val combined = types.mapNotNull { it.parse() }.fold(0) { acc, v -> acc or v }
+                if (combined != 0) builder.setCallbackType(combined)
+            }
+            androidConfig.matchMode?.parse()?.let { builder.setMatchMode(it) }
+            androidConfig.numOfMatches?.parse()?.let { builder.setNumOfMatches(it) }
         }
         val settings = builder.build()
 

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBle.g.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBle.g.swift
@@ -233,6 +233,38 @@ enum AndroidScanMode: Int {
   case opportunistic = 3
 }
 
+/// Mirrors `android.bluetooth.le.ScanSettings#setCallbackType`. Pass any
+/// combination via `AndroidOptions.callbackType` (the plugin OR-folds the list
+/// before calling `setCallbackType`).
+///
+/// API-level notes:
+/// * [allMatches] — API 21+
+/// * [firstMatch], [matchLost] — API 23+ (Marshmallow). Silently dropped on
+///   older devices.
+/// * [allMatchesAutoBatch] — API 34+ (Upside Down Cake). Silently dropped on
+///   older devices.
+///
+/// See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
+enum AndroidScanCallbackType: Int {
+  case allMatches = 0
+  case firstMatch = 1
+  case matchLost = 2
+  case allMatchesAutoBatch = 3
+}
+
+/// Mirrors `android.bluetooth.le.ScanSettings#setMatchMode`.
+enum AndroidScanMatchMode: Int {
+  case aggressive = 0
+  case sticky = 1
+}
+
+/// Mirrors `android.bluetooth.le.ScanSettings#setNumOfMatches`.
+enum AndroidScanNumOfMatches: Int {
+  case one = 0
+  case few = 1
+  case max = 2
+}
+
 enum CharacteristicProperty: Int {
   case broadcast = 0
   case read = 1
@@ -518,12 +550,29 @@ struct UniversalBleDescriptor: Hashable {
 /// Set [reportDelayMillis] timestamp for Bluetooth LE scan. If set to 0, you will be notified of scan results immediately.
 /// If > 0, scan results are queued up and delivered after the requested delay or 5000 milliseconds (whichever is higher).
 /// Note scan results may be delivered sooner if the internal buffers fill up.
+/// [callbackType], [matchMode], and [numOfMatches] map directly to the equivalent
+/// `android.bluetooth.le.ScanSettings` setters. When `null`, the plugin leaves them
+/// at the platform default — set them only if you need to override platform-side
+/// advert de-duplication (e.g. on Pixel hardware where the default settings
+/// throttle advertisements compared with nRF Connect).
+///
+/// [callbackType] is a list because Android's `setCallbackType` accepts any
+/// bitwise combination of [AndroidScanCallbackType] values (for example
+/// `[firstMatch, matchLost]` to be notified once on entry and again on exit).
+/// The plugin OR-folds the list before calling the native API. Values that
+/// require a newer API than the device supports are silently dropped (and
+/// logged); see the [AndroidScanCallbackType] doc for per-value API levels.
+///
+/// See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
 ///
 /// Generated class from Pigeon that represents data sent in messages.
 struct AndroidOptions: Hashable {
   var requestLocationPermission: Bool? = nil
   var scanMode: AndroidScanMode? = nil
   var reportDelayMillis: Int64? = nil
+  var callbackType: [AndroidScanCallbackType]? = nil
+  var matchMode: AndroidScanMatchMode? = nil
+  var numOfMatches: AndroidScanNumOfMatches? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -531,11 +580,17 @@ struct AndroidOptions: Hashable {
     let requestLocationPermission: Bool? = nilOrValue(pigeonVar_list[0])
     let scanMode: AndroidScanMode? = nilOrValue(pigeonVar_list[1])
     let reportDelayMillis: Int64? = nilOrValue(pigeonVar_list[2])
+    let callbackType: [AndroidScanCallbackType]? = nilOrValue(pigeonVar_list[3])
+    let matchMode: AndroidScanMatchMode? = nilOrValue(pigeonVar_list[4])
+    let numOfMatches: AndroidScanNumOfMatches? = nilOrValue(pigeonVar_list[5])
 
     return AndroidOptions(
       requestLocationPermission: requestLocationPermission,
       scanMode: scanMode,
-      reportDelayMillis: reportDelayMillis
+      reportDelayMillis: reportDelayMillis,
+      callbackType: callbackType,
+      matchMode: matchMode,
+      numOfMatches: numOfMatches
     )
   }
   func toList() -> [Any?] {
@@ -543,13 +598,16 @@ struct AndroidOptions: Hashable {
       requestLocationPermission,
       scanMode,
       reportDelayMillis,
+      callbackType,
+      matchMode,
+      numOfMatches,
     ]
   }
   static func == (lhs: AndroidOptions, rhs: AndroidOptions) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsUniversalBle(lhs.requestLocationPermission, rhs.requestLocationPermission) && deepEqualsUniversalBle(lhs.scanMode, rhs.scanMode) && deepEqualsUniversalBle(lhs.reportDelayMillis, rhs.reportDelayMillis)
+    return deepEqualsUniversalBle(lhs.requestLocationPermission, rhs.requestLocationPermission) && deepEqualsUniversalBle(lhs.scanMode, rhs.scanMode) && deepEqualsUniversalBle(lhs.reportDelayMillis, rhs.reportDelayMillis) && deepEqualsUniversalBle(lhs.callbackType, rhs.callbackType) && deepEqualsUniversalBle(lhs.matchMode, rhs.matchMode) && deepEqualsUniversalBle(lhs.numOfMatches, rhs.numOfMatches)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -557,6 +615,9 @@ struct AndroidOptions: Hashable {
     deepHashUniversalBle(value: requestLocationPermission, hasher: &hasher)
     deepHashUniversalBle(value: scanMode, hasher: &hasher)
     deepHashUniversalBle(value: reportDelayMillis, hasher: &hasher)
+    deepHashUniversalBle(value: callbackType, hasher: &hasher)
+    deepHashUniversalBle(value: matchMode, hasher: &hasher)
+    deepHashUniversalBle(value: numOfMatches, hasher: &hasher)
   }
 }
 
@@ -1041,64 +1102,82 @@ private class UniversalBlePigeonCodecReader: FlutterStandardReader {
     case 136:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return CharacteristicProperty(rawValue: enumResultAsInt)
+        return AndroidScanCallbackType(rawValue: enumResultAsInt)
       }
       return nil
     case 137:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return PeripheralReadinessState(rawValue: enumResultAsInt)
+        return AndroidScanMatchMode(rawValue: enumResultAsInt)
       }
       return nil
     case 138:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return PeripheralAttributePermission(rawValue: enumResultAsInt)
+        return AndroidScanNumOfMatches(rawValue: enumResultAsInt)
       }
       return nil
     case 139:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return PeripheralAdvertisingState(rawValue: enumResultAsInt)
+        return CharacteristicProperty(rawValue: enumResultAsInt)
       }
       return nil
     case 140:
       let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
       if let enumResultAsInt = enumResultAsInt {
-        return UniversalBleErrorCode(rawValue: enumResultAsInt)
+        return PeripheralReadinessState(rawValue: enumResultAsInt)
       }
       return nil
     case 141:
-      return UniversalBleScanResult.fromList(self.readValue() as! [Any?])
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
+        return PeripheralAttributePermission(rawValue: enumResultAsInt)
+      }
+      return nil
     case 142:
-      return UniversalBleService.fromList(self.readValue() as! [Any?])
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
+        return PeripheralAdvertisingState(rawValue: enumResultAsInt)
+      }
+      return nil
     case 143:
-      return UniversalBleCharacteristic.fromList(self.readValue() as! [Any?])
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as! Int?)
+      if let enumResultAsInt = enumResultAsInt {
+        return UniversalBleErrorCode(rawValue: enumResultAsInt)
+      }
+      return nil
     case 144:
-      return UniversalBleDescriptor.fromList(self.readValue() as! [Any?])
+      return UniversalBleScanResult.fromList(self.readValue() as! [Any?])
     case 145:
-      return AndroidOptions.fromList(self.readValue() as! [Any?])
+      return UniversalBleService.fromList(self.readValue() as! [Any?])
     case 146:
-      return UniversalScanConfig.fromList(self.readValue() as! [Any?])
+      return UniversalBleCharacteristic.fromList(self.readValue() as! [Any?])
     case 147:
-      return UniversalScanFilter.fromList(self.readValue() as! [Any?])
+      return UniversalBleDescriptor.fromList(self.readValue() as! [Any?])
     case 148:
-      return ManufacturerDataFilter.fromList(self.readValue() as! [Any?])
+      return AndroidOptions.fromList(self.readValue() as! [Any?])
     case 149:
-      return UniversalManufacturerData.fromList(self.readValue() as! [Any?])
+      return UniversalScanConfig.fromList(self.readValue() as! [Any?])
     case 150:
-      return PeripheralAndroidOptions.fromList(self.readValue() as! [Any?])
+      return UniversalScanFilter.fromList(self.readValue() as! [Any?])
     case 151:
-      return PeripheralPlatformConfig.fromList(self.readValue() as! [Any?])
+      return ManufacturerDataFilter.fromList(self.readValue() as! [Any?])
     case 152:
-      return PeripheralService.fromList(self.readValue() as! [Any?])
+      return UniversalManufacturerData.fromList(self.readValue() as! [Any?])
     case 153:
-      return PeripheralCharacteristic.fromList(self.readValue() as! [Any?])
+      return PeripheralAndroidOptions.fromList(self.readValue() as! [Any?])
     case 154:
-      return PeripheralDescriptor.fromList(self.readValue() as! [Any?])
+      return PeripheralPlatformConfig.fromList(self.readValue() as! [Any?])
     case 155:
-      return PeripheralReadRequestResult.fromList(self.readValue() as! [Any?])
+      return PeripheralService.fromList(self.readValue() as! [Any?])
     case 156:
+      return PeripheralCharacteristic.fromList(self.readValue() as! [Any?])
+    case 157:
+      return PeripheralDescriptor.fromList(self.readValue() as! [Any?])
+    case 158:
+      return PeripheralReadRequestResult.fromList(self.readValue() as! [Any?])
+    case 159:
       return PeripheralWriteRequestResult.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
@@ -1129,68 +1208,77 @@ private class UniversalBlePigeonCodecWriter: FlutterStandardWriter {
     } else if let value = value as? AndroidScanMode {
       super.writeByte(135)
       super.writeValue(value.rawValue)
-    } else if let value = value as? CharacteristicProperty {
+    } else if let value = value as? AndroidScanCallbackType {
       super.writeByte(136)
       super.writeValue(value.rawValue)
-    } else if let value = value as? PeripheralReadinessState {
+    } else if let value = value as? AndroidScanMatchMode {
       super.writeByte(137)
       super.writeValue(value.rawValue)
-    } else if let value = value as? PeripheralAttributePermission {
+    } else if let value = value as? AndroidScanNumOfMatches {
       super.writeByte(138)
       super.writeValue(value.rawValue)
-    } else if let value = value as? PeripheralAdvertisingState {
+    } else if let value = value as? CharacteristicProperty {
       super.writeByte(139)
       super.writeValue(value.rawValue)
-    } else if let value = value as? UniversalBleErrorCode {
+    } else if let value = value as? PeripheralReadinessState {
       super.writeByte(140)
       super.writeValue(value.rawValue)
-    } else if let value = value as? UniversalBleScanResult {
+    } else if let value = value as? PeripheralAttributePermission {
       super.writeByte(141)
-      super.writeValue(value.toList())
-    } else if let value = value as? UniversalBleService {
+      super.writeValue(value.rawValue)
+    } else if let value = value as? PeripheralAdvertisingState {
       super.writeByte(142)
-      super.writeValue(value.toList())
-    } else if let value = value as? UniversalBleCharacteristic {
+      super.writeValue(value.rawValue)
+    } else if let value = value as? UniversalBleErrorCode {
       super.writeByte(143)
-      super.writeValue(value.toList())
-    } else if let value = value as? UniversalBleDescriptor {
+      super.writeValue(value.rawValue)
+    } else if let value = value as? UniversalBleScanResult {
       super.writeByte(144)
       super.writeValue(value.toList())
-    } else if let value = value as? AndroidOptions {
+    } else if let value = value as? UniversalBleService {
       super.writeByte(145)
       super.writeValue(value.toList())
-    } else if let value = value as? UniversalScanConfig {
+    } else if let value = value as? UniversalBleCharacteristic {
       super.writeByte(146)
       super.writeValue(value.toList())
-    } else if let value = value as? UniversalScanFilter {
+    } else if let value = value as? UniversalBleDescriptor {
       super.writeByte(147)
       super.writeValue(value.toList())
-    } else if let value = value as? ManufacturerDataFilter {
+    } else if let value = value as? AndroidOptions {
       super.writeByte(148)
       super.writeValue(value.toList())
-    } else if let value = value as? UniversalManufacturerData {
+    } else if let value = value as? UniversalScanConfig {
       super.writeByte(149)
       super.writeValue(value.toList())
-    } else if let value = value as? PeripheralAndroidOptions {
+    } else if let value = value as? UniversalScanFilter {
       super.writeByte(150)
       super.writeValue(value.toList())
-    } else if let value = value as? PeripheralPlatformConfig {
+    } else if let value = value as? ManufacturerDataFilter {
       super.writeByte(151)
       super.writeValue(value.toList())
-    } else if let value = value as? PeripheralService {
+    } else if let value = value as? UniversalManufacturerData {
       super.writeByte(152)
       super.writeValue(value.toList())
-    } else if let value = value as? PeripheralCharacteristic {
+    } else if let value = value as? PeripheralAndroidOptions {
       super.writeByte(153)
       super.writeValue(value.toList())
-    } else if let value = value as? PeripheralDescriptor {
+    } else if let value = value as? PeripheralPlatformConfig {
       super.writeByte(154)
       super.writeValue(value.toList())
-    } else if let value = value as? PeripheralReadRequestResult {
+    } else if let value = value as? PeripheralService {
       super.writeByte(155)
       super.writeValue(value.toList())
-    } else if let value = value as? PeripheralWriteRequestResult {
+    } else if let value = value as? PeripheralCharacteristic {
       super.writeByte(156)
+      super.writeValue(value.toList())
+    } else if let value = value as? PeripheralDescriptor {
+      super.writeByte(157)
+      super.writeValue(value.toList())
+    } else if let value = value as? PeripheralReadRequestResult {
+      super.writeByte(158)
+      super.writeValue(value.toList())
+    } else if let value = value as? PeripheralWriteRequestResult {
+      super.writeByte(159)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)

--- a/example/lib/home/home.dart
+++ b/example/lib/home/home.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:universal_ble/universal_ble.dart';
 import 'package:universal_ble_example/data/mock_universal_ble.dart';
+import 'package:universal_ble_example/home/widgets/android_scan_options_widget.dart';
 import 'package:universal_ble_example/home/widgets/scan_filter_widget.dart';
 import 'package:universal_ble_example/home/widgets/scanned_devices_placeholder_widget.dart';
 import 'package:universal_ble_example/home/widgets/scanned_item_widget.dart';
@@ -33,6 +34,7 @@ class _CentralHomeState extends State<CentralHome> {
       _availabilityStreamSubscription != null;
   AvailabilityState? bleAvailabilityState;
   ScanFilter? scanFilter;
+  AndroidOptions? _androidOptions;
 
   @override
   void initState() {
@@ -90,7 +92,13 @@ class _CentralHomeState extends State<CentralHome> {
   }
 
   Future<void> startScan() async {
-    await UniversalBle.startScan(scanFilter: scanFilter);
+    final platformConfig = _androidOptions == null
+        ? null
+        : PlatformConfig(android: _androidOptions);
+    await UniversalBle.startScan(
+      scanFilter: scanFilter,
+      platformConfig: platformConfig,
+    );
   }
 
   Future<void> _getSystemDevices() async {
@@ -126,6 +134,23 @@ class _CentralHomeState extends State<CentralHome> {
           onScanFilter: (ScanFilter? filter) {
             setState(() {
               scanFilter = filter;
+            });
+          },
+        );
+      },
+    );
+  }
+
+  void _showAndroidScanOptionsBottomSheet() {
+    showModalBottomSheet(
+      isScrollControlled: true,
+      context: context,
+      builder: (context) {
+        return AndroidScanOptionsWidget(
+          initial: _androidOptions,
+          onChanged: (AndroidOptions? options) {
+            setState(() {
+              _androidOptions = options;
             });
           },
         );
@@ -278,6 +303,12 @@ class _CentralHomeState extends State<CentralHome> {
                 PlatformButton(
                   text: 'Scan Filters',
                   onPressed: _showScanFilterBottomSheet,
+                ),
+                PlatformButton(
+                  text: _androidOptions == null
+                      ? 'Android Scan Options'
+                      : 'Android Scan Options •',
+                  onPressed: _showAndroidScanOptionsBottomSheet,
                 ),
                 if (_hiddenDevices.isNotEmpty)
                   PlatformButton(

--- a/example/lib/home/widgets/android_scan_options_widget.dart
+++ b/example/lib/home/widgets/android_scan_options_widget.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+import 'package:universal_ble/universal_ble.dart';
+import 'package:universal_ble_example/widgets/platform_button.dart';
+
+/// Lets the user opt in to the Android-only `ScanSettings` knobs exposed via
+/// [AndroidOptions]. All fields are nullable; when nothing is set the widget
+/// invokes `onChanged(null)` and the plugin scans with platform defaults.
+class AndroidScanOptionsWidget extends StatefulWidget {
+  final AndroidOptions? initial;
+  final void Function(AndroidOptions? options) onChanged;
+
+  const AndroidScanOptionsWidget({
+    super.key,
+    required this.initial,
+    required this.onChanged,
+  });
+
+  @override
+  State<AndroidScanOptionsWidget> createState() =>
+      _AndroidScanOptionsWidgetState();
+}
+
+class _AndroidScanOptionsWidgetState extends State<AndroidScanOptionsWidget> {
+  AndroidScanMode? _scanMode;
+  final TextEditingController _reportDelayController = TextEditingController();
+  final Set<AndroidScanCallbackType> _callbackType = {};
+  AndroidScanMatchMode? _matchMode;
+  AndroidScanNumOfMatches? _numOfMatches;
+
+  @override
+  void initState() {
+    super.initState();
+    final initial = widget.initial;
+    if (initial != null) {
+      _scanMode = initial.scanMode;
+      _reportDelayController.text = initial.reportDelayMillis?.toString() ?? '';
+      _callbackType.addAll(initial.callbackType ?? const []);
+      _matchMode = initial.matchMode;
+      _numOfMatches = initial.numOfMatches;
+    }
+  }
+
+  @override
+  void dispose() {
+    _reportDelayController.dispose();
+    super.dispose();
+  }
+
+  AndroidOptions? _build() {
+    final delayText = _reportDelayController.text.trim();
+    final reportDelay = delayText.isEmpty ? null : int.tryParse(delayText);
+    final hasAny = _scanMode != null ||
+        reportDelay != null ||
+        _callbackType.isNotEmpty ||
+        _matchMode != null ||
+        _numOfMatches != null;
+    if (!hasAny) return null;
+    return AndroidOptions(
+      scanMode: _scanMode,
+      reportDelayMillis: reportDelay,
+      callbackType:
+          _callbackType.isEmpty ? null : _callbackType.toList(growable: false),
+      matchMode: _matchMode,
+      numOfMatches: _numOfMatches,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final viewInsets = MediaQuery.of(context).viewInsets.bottom;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(16, 16, 16, viewInsets + 16),
+      child: SingleChildScrollView(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              'Android scan options',
+              style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+            ),
+            const SizedBox(height: 4),
+            const Text(
+              'All fields are optional. Leaving everything empty scans with the '
+              'platform defaults (same as omitting platformConfig).',
+            ),
+            const SizedBox(height: 16),
+            _SectionTitle('scanMode'),
+            _SingleSelect<AndroidScanMode>(
+              values: AndroidScanMode.values,
+              selected: _scanMode,
+              label: (v) => v.name,
+              onChanged: (v) => setState(() => _scanMode = v),
+            ),
+            const SizedBox(height: 16),
+            _SectionTitle('reportDelayMillis'),
+            TextField(
+              controller: _reportDelayController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(
+                hintText: 'e.g. 0 (immediate) or 1000',
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+              onChanged: (_) => setState(() {}),
+            ),
+            const SizedBox(height: 16),
+            _SectionTitle(
+                'callbackType (multi-select; OR-folded by the plugin)'),
+            Wrap(
+              spacing: 8,
+              runSpacing: 4,
+              children: AndroidScanCallbackType.values
+                  .map((v) => FilterChip(
+                        label: Text(v.name),
+                        selected: _callbackType.contains(v),
+                        onSelected: (selected) => setState(() {
+                          if (selected) {
+                            _callbackType.add(v);
+                          } else {
+                            _callbackType.remove(v);
+                          }
+                        }),
+                      ))
+                  .toList(growable: false),
+            ),
+            const SizedBox(height: 16),
+            _SectionTitle('matchMode'),
+            _SingleSelect<AndroidScanMatchMode>(
+              values: AndroidScanMatchMode.values,
+              selected: _matchMode,
+              label: (v) => v.name,
+              onChanged: (v) => setState(() => _matchMode = v),
+            ),
+            const SizedBox(height: 16),
+            _SectionTitle('numOfMatches'),
+            _SingleSelect<AndroidScanNumOfMatches>(
+              values: AndroidScanNumOfMatches.values,
+              selected: _numOfMatches,
+              label: (v) => v.name,
+              onChanged: (v) => setState(() => _numOfMatches = v),
+            ),
+            const SizedBox(height: 24),
+            Row(
+              children: [
+                Expanded(
+                  child: PlatformButton(
+                    text: 'Reset',
+                    onPressed: () {
+                      setState(() {
+                        _scanMode = null;
+                        _reportDelayController.clear();
+                        _callbackType.clear();
+                        _matchMode = null;
+                        _numOfMatches = null;
+                      });
+                      widget.onChanged(null);
+                    },
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: PlatformButton(
+                    text: 'Apply',
+                    onPressed: () {
+                      widget.onChanged(_build());
+                      Navigator.of(context).pop();
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionTitle extends StatelessWidget {
+  final String text;
+  const _SectionTitle(this.text);
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.only(bottom: 4),
+        child: Text(text, style: const TextStyle(fontWeight: FontWeight.w600)),
+      );
+}
+
+class _SingleSelect<T> extends StatelessWidget {
+  final List<T> values;
+  final T? selected;
+  final String Function(T value) label;
+  final void Function(T? value) onChanged;
+
+  const _SingleSelect({
+    required this.values,
+    required this.selected,
+    required this.label,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 8,
+      runSpacing: 4,
+      children: [
+        ChoiceChip(
+          label: const Text('— (default)'),
+          selected: selected == null,
+          onSelected: (_) => onChanged(null),
+        ),
+        ...values.map((v) => ChoiceChip(
+              label: Text(label(v)),
+              selected: selected == v,
+              onSelected: (sel) => onChanged(sel ? v : null),
+            )),
+      ],
+    );
+  }
+}

--- a/lib/src/universal_ble.g.dart
+++ b/lib/src/universal_ble.g.dart
@@ -144,6 +144,31 @@ enum BleConnectionPriority {
 
 enum AndroidScanMode { balanced, lowLatency, lowPower, opportunistic }
 
+/// Mirrors `android.bluetooth.le.ScanSettings#setCallbackType`. Pass any
+/// combination via `AndroidOptions.callbackType` (the plugin OR-folds the list
+/// before calling `setCallbackType`).
+///
+/// API-level notes:
+/// * [allMatches] — API 21+
+/// * [firstMatch], [matchLost] — API 23+ (Marshmallow). Silently dropped on
+///   older devices.
+/// * [allMatchesAutoBatch] — API 34+ (Upside Down Cake). Silently dropped on
+///   older devices.
+///
+/// See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
+enum AndroidScanCallbackType {
+  allMatches,
+  firstMatch,
+  matchLost,
+  allMatchesAutoBatch,
+}
+
+/// Mirrors `android.bluetooth.le.ScanSettings#setMatchMode`.
+enum AndroidScanMatchMode { aggressive, sticky }
+
+/// Mirrors `android.bluetooth.le.ScanSettings#setNumOfMatches`.
+enum AndroidScanNumOfMatches { one, few, max }
+
 enum CharacteristicProperty {
   broadcast,
   read,
@@ -459,11 +484,28 @@ class UniversalBleDescriptor {
 /// Set [reportDelayMillis] timestamp for Bluetooth LE scan. If set to 0, you will be notified of scan results immediately.
 /// If > 0, scan results are queued up and delivered after the requested delay or 5000 milliseconds (whichever is higher).
 /// Note scan results may be delivered sooner if the internal buffers fill up.
+/// [callbackType], [matchMode], and [numOfMatches] map directly to the equivalent
+/// `android.bluetooth.le.ScanSettings` setters. When `null`, the plugin leaves them
+/// at the platform default — set them only if you need to override platform-side
+/// advert de-duplication (e.g. on Pixel hardware where the default settings
+/// throttle advertisements compared with nRF Connect).
+///
+/// [callbackType] is a list because Android's `setCallbackType` accepts any
+/// bitwise combination of [AndroidScanCallbackType] values (for example
+/// `[firstMatch, matchLost]` to be notified once on entry and again on exit).
+/// The plugin OR-folds the list before calling the native API. Values that
+/// require a newer API than the device supports are silently dropped (and
+/// logged); see the [AndroidScanCallbackType] doc for per-value API levels.
+///
+/// See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
 class AndroidOptions {
   AndroidOptions({
     this.requestLocationPermission,
     this.scanMode,
     this.reportDelayMillis,
+    this.callbackType,
+    this.matchMode,
+    this.numOfMatches,
   });
 
   bool? requestLocationPermission;
@@ -472,8 +514,21 @@ class AndroidOptions {
 
   int? reportDelayMillis;
 
+  List<AndroidScanCallbackType>? callbackType;
+
+  AndroidScanMatchMode? matchMode;
+
+  AndroidScanNumOfMatches? numOfMatches;
+
   List<Object?> _toList() {
-    return <Object?>[requestLocationPermission, scanMode, reportDelayMillis];
+    return <Object?>[
+      requestLocationPermission,
+      scanMode,
+      reportDelayMillis,
+      callbackType,
+      matchMode,
+      numOfMatches,
+    ];
   }
 
   Object encode() {
@@ -486,6 +541,10 @@ class AndroidOptions {
       requestLocationPermission: result[0] as bool?,
       scanMode: result[1] as AndroidScanMode?,
       reportDelayMillis: result[2] as int?,
+      callbackType: (result[3] as List<Object?>?)
+          ?.cast<AndroidScanCallbackType>(),
+      matchMode: result[4] as AndroidScanMatchMode?,
+      numOfMatches: result[5] as AndroidScanNumOfMatches?,
     );
   }
 
@@ -503,7 +562,10 @@ class AndroidOptions {
           other.requestLocationPermission,
         ) &&
         _deepEquals(scanMode, other.scanMode) &&
-        _deepEquals(reportDelayMillis, other.reportDelayMillis);
+        _deepEquals(reportDelayMillis, other.reportDelayMillis) &&
+        _deepEquals(callbackType, other.callbackType) &&
+        _deepEquals(matchMode, other.matchMode) &&
+        _deepEquals(numOfMatches, other.numOfMatches);
   }
 
   @override
@@ -1052,68 +1114,77 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is AndroidScanMode) {
       buffer.putUint8(135);
       writeValue(buffer, value.index);
-    } else if (value is CharacteristicProperty) {
+    } else if (value is AndroidScanCallbackType) {
       buffer.putUint8(136);
       writeValue(buffer, value.index);
-    } else if (value is PeripheralReadinessState) {
+    } else if (value is AndroidScanMatchMode) {
       buffer.putUint8(137);
       writeValue(buffer, value.index);
-    } else if (value is PeripheralAttributePermission) {
+    } else if (value is AndroidScanNumOfMatches) {
       buffer.putUint8(138);
       writeValue(buffer, value.index);
-    } else if (value is PeripheralAdvertisingState) {
+    } else if (value is CharacteristicProperty) {
       buffer.putUint8(139);
       writeValue(buffer, value.index);
-    } else if (value is UniversalBleErrorCode) {
+    } else if (value is PeripheralReadinessState) {
       buffer.putUint8(140);
       writeValue(buffer, value.index);
-    } else if (value is UniversalBleScanResult) {
+    } else if (value is PeripheralAttributePermission) {
       buffer.putUint8(141);
-      writeValue(buffer, value.encode());
-    } else if (value is UniversalBleService) {
+      writeValue(buffer, value.index);
+    } else if (value is PeripheralAdvertisingState) {
       buffer.putUint8(142);
-      writeValue(buffer, value.encode());
-    } else if (value is UniversalBleCharacteristic) {
+      writeValue(buffer, value.index);
+    } else if (value is UniversalBleErrorCode) {
       buffer.putUint8(143);
-      writeValue(buffer, value.encode());
-    } else if (value is UniversalBleDescriptor) {
+      writeValue(buffer, value.index);
+    } else if (value is UniversalBleScanResult) {
       buffer.putUint8(144);
       writeValue(buffer, value.encode());
-    } else if (value is AndroidOptions) {
+    } else if (value is UniversalBleService) {
       buffer.putUint8(145);
       writeValue(buffer, value.encode());
-    } else if (value is UniversalScanConfig) {
+    } else if (value is UniversalBleCharacteristic) {
       buffer.putUint8(146);
       writeValue(buffer, value.encode());
-    } else if (value is UniversalScanFilter) {
+    } else if (value is UniversalBleDescriptor) {
       buffer.putUint8(147);
       writeValue(buffer, value.encode());
-    } else if (value is ManufacturerDataFilter) {
+    } else if (value is AndroidOptions) {
       buffer.putUint8(148);
       writeValue(buffer, value.encode());
-    } else if (value is UniversalManufacturerData) {
+    } else if (value is UniversalScanConfig) {
       buffer.putUint8(149);
       writeValue(buffer, value.encode());
-    } else if (value is PeripheralAndroidOptions) {
+    } else if (value is UniversalScanFilter) {
       buffer.putUint8(150);
       writeValue(buffer, value.encode());
-    } else if (value is PeripheralPlatformConfig) {
+    } else if (value is ManufacturerDataFilter) {
       buffer.putUint8(151);
       writeValue(buffer, value.encode());
-    } else if (value is PeripheralService) {
+    } else if (value is UniversalManufacturerData) {
       buffer.putUint8(152);
       writeValue(buffer, value.encode());
-    } else if (value is PeripheralCharacteristic) {
+    } else if (value is PeripheralAndroidOptions) {
       buffer.putUint8(153);
       writeValue(buffer, value.encode());
-    } else if (value is PeripheralDescriptor) {
+    } else if (value is PeripheralPlatformConfig) {
       buffer.putUint8(154);
       writeValue(buffer, value.encode());
-    } else if (value is PeripheralReadRequestResult) {
+    } else if (value is PeripheralService) {
       buffer.putUint8(155);
       writeValue(buffer, value.encode());
-    } else if (value is PeripheralWriteRequestResult) {
+    } else if (value is PeripheralCharacteristic) {
       buffer.putUint8(156);
+      writeValue(buffer, value.encode());
+    } else if (value is PeripheralDescriptor) {
+      buffer.putUint8(157);
+      writeValue(buffer, value.encode());
+    } else if (value is PeripheralReadRequestResult) {
+      buffer.putUint8(158);
+      writeValue(buffer, value.encode());
+    } else if (value is PeripheralWriteRequestResult) {
+      buffer.putUint8(159);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -1146,52 +1217,61 @@ class _PigeonCodec extends StandardMessageCodec {
         return value == null ? null : AndroidScanMode.values[value];
       case 136:
         final value = readValue(buffer) as int?;
-        return value == null ? null : CharacteristicProperty.values[value];
+        return value == null ? null : AndroidScanCallbackType.values[value];
       case 137:
         final value = readValue(buffer) as int?;
-        return value == null ? null : PeripheralReadinessState.values[value];
+        return value == null ? null : AndroidScanMatchMode.values[value];
       case 138:
+        final value = readValue(buffer) as int?;
+        return value == null ? null : AndroidScanNumOfMatches.values[value];
+      case 139:
+        final value = readValue(buffer) as int?;
+        return value == null ? null : CharacteristicProperty.values[value];
+      case 140:
+        final value = readValue(buffer) as int?;
+        return value == null ? null : PeripheralReadinessState.values[value];
+      case 141:
         final value = readValue(buffer) as int?;
         return value == null
             ? null
             : PeripheralAttributePermission.values[value];
-      case 139:
+      case 142:
         final value = readValue(buffer) as int?;
         return value == null ? null : PeripheralAdvertisingState.values[value];
-      case 140:
+      case 143:
         final value = readValue(buffer) as int?;
         return value == null ? null : UniversalBleErrorCode.values[value];
-      case 141:
-        return UniversalBleScanResult.decode(readValue(buffer)!);
-      case 142:
-        return UniversalBleService.decode(readValue(buffer)!);
-      case 143:
-        return UniversalBleCharacteristic.decode(readValue(buffer)!);
       case 144:
-        return UniversalBleDescriptor.decode(readValue(buffer)!);
+        return UniversalBleScanResult.decode(readValue(buffer)!);
       case 145:
-        return AndroidOptions.decode(readValue(buffer)!);
+        return UniversalBleService.decode(readValue(buffer)!);
       case 146:
-        return UniversalScanConfig.decode(readValue(buffer)!);
+        return UniversalBleCharacteristic.decode(readValue(buffer)!);
       case 147:
-        return UniversalScanFilter.decode(readValue(buffer)!);
+        return UniversalBleDescriptor.decode(readValue(buffer)!);
       case 148:
-        return ManufacturerDataFilter.decode(readValue(buffer)!);
+        return AndroidOptions.decode(readValue(buffer)!);
       case 149:
-        return UniversalManufacturerData.decode(readValue(buffer)!);
+        return UniversalScanConfig.decode(readValue(buffer)!);
       case 150:
-        return PeripheralAndroidOptions.decode(readValue(buffer)!);
+        return UniversalScanFilter.decode(readValue(buffer)!);
       case 151:
-        return PeripheralPlatformConfig.decode(readValue(buffer)!);
+        return ManufacturerDataFilter.decode(readValue(buffer)!);
       case 152:
-        return PeripheralService.decode(readValue(buffer)!);
+        return UniversalManufacturerData.decode(readValue(buffer)!);
       case 153:
-        return PeripheralCharacteristic.decode(readValue(buffer)!);
+        return PeripheralAndroidOptions.decode(readValue(buffer)!);
       case 154:
-        return PeripheralDescriptor.decode(readValue(buffer)!);
+        return PeripheralPlatformConfig.decode(readValue(buffer)!);
       case 155:
-        return PeripheralReadRequestResult.decode(readValue(buffer)!);
+        return PeripheralService.decode(readValue(buffer)!);
       case 156:
+        return PeripheralCharacteristic.decode(readValue(buffer)!);
+      case 157:
+        return PeripheralDescriptor.decode(readValue(buffer)!);
+      case 158:
+        return PeripheralReadRequestResult.decode(readValue(buffer)!);
+      case 159:
         return PeripheralWriteRequestResult.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/lib/universal_ble.dart
+++ b/lib/universal_ble.dart
@@ -12,6 +12,9 @@ export 'package:universal_ble/src/universal_ble.g.dart'
     show
         AndroidOptions,
         AndroidScanMode,
+        AndroidScanCallbackType,
+        AndroidScanMatchMode,
+        AndroidScanNumOfMatches,
         UniversalBleErrorCode,
         BleLogLevel,
         AvailabilityState,

--- a/pigeon/universal_ble.dart
+++ b/pigeon/universal_ble.dart
@@ -74,6 +74,31 @@ enum BleConnectionPriority {
 
 enum AndroidScanMode { balanced, lowLatency, lowPower, opportunistic }
 
+/// Mirrors `android.bluetooth.le.ScanSettings#setCallbackType`. Pass any
+/// combination via `AndroidOptions.callbackType` (the plugin OR-folds the list
+/// before calling `setCallbackType`).
+///
+/// API-level notes:
+/// * [allMatches] — API 21+
+/// * [firstMatch], [matchLost] — API 23+ (Marshmallow). Silently dropped on
+///   older devices.
+/// * [allMatchesAutoBatch] — API 34+ (Upside Down Cake). Silently dropped on
+///   older devices.
+///
+/// See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
+enum AndroidScanCallbackType {
+  allMatches,
+  firstMatch,
+  matchLost,
+  allMatchesAutoBatch,
+}
+
+/// Mirrors `android.bluetooth.le.ScanSettings#setMatchMode`.
+enum AndroidScanMatchMode { aggressive, sticky }
+
+/// Mirrors `android.bluetooth.le.ScanSettings#setNumOfMatches`.
+enum AndroidScanNumOfMatches { one, few, max }
+
 enum CharacteristicProperty {
   broadcast,
   read,
@@ -128,14 +153,34 @@ class UniversalBleDescriptor {
 /// Set [reportDelayMillis] timestamp for Bluetooth LE scan. If set to 0, you will be notified of scan results immediately.
 /// If > 0, scan results are queued up and delivered after the requested delay or 5000 milliseconds (whichever is higher).
 /// Note scan results may be delivered sooner if the internal buffers fill up.
+/// [callbackType], [matchMode], and [numOfMatches] map directly to the equivalent
+/// `android.bluetooth.le.ScanSettings` setters. When `null`, the plugin leaves them
+/// at the platform default — set them only if you need to override platform-side
+/// advert de-duplication (e.g. on Pixel hardware where the default settings
+/// throttle advertisements compared with nRF Connect).
+///
+/// [callbackType] is a list because Android's `setCallbackType` accepts any
+/// bitwise combination of [AndroidScanCallbackType] values (for example
+/// `[firstMatch, matchLost]` to be notified once on entry and again on exit).
+/// The plugin OR-folds the list before calling the native API. Values that
+/// require a newer API than the device supports are silently dropped (and
+/// logged); see the [AndroidScanCallbackType] doc for per-value API levels.
+///
+/// See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
 class AndroidOptions {
   bool? requestLocationPermission;
   AndroidScanMode? scanMode;
   int? reportDelayMillis;
+  List<AndroidScanCallbackType>? callbackType;
+  AndroidScanMatchMode? matchMode;
+  AndroidScanNumOfMatches? numOfMatches;
   AndroidOptions({
     this.requestLocationPermission,
     this.scanMode,
     this.reportDelayMillis,
+    this.callbackType,
+    this.matchMode,
+    this.numOfMatches,
   });
 }
 

--- a/test/android_options_test.dart
+++ b/test/android_options_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:universal_ble/src/universal_ble.g.dart';
+
+void main() {
+  group('AndroidOptions', () {
+    test('stores the new ScanSettings knobs', () {
+      final options = AndroidOptions(
+        scanMode: AndroidScanMode.lowLatency,
+        reportDelayMillis: 0,
+        callbackType: [AndroidScanCallbackType.allMatches],
+        matchMode: AndroidScanMatchMode.aggressive,
+        numOfMatches: AndroidScanNumOfMatches.max,
+      );
+
+      expect(options.callbackType, [AndroidScanCallbackType.allMatches]);
+      expect(options.matchMode, AndroidScanMatchMode.aggressive);
+      expect(options.numOfMatches, AndroidScanNumOfMatches.max);
+    });
+
+    test('round-trips a multi-value callbackType through the pigeon codec', () {
+      final original = AndroidOptions(
+        requestLocationPermission: true,
+        scanMode: AndroidScanMode.lowLatency,
+        reportDelayMillis: 0,
+        callbackType: [
+          AndroidScanCallbackType.firstMatch,
+          AndroidScanCallbackType.matchLost,
+        ],
+        matchMode: AndroidScanMatchMode.sticky,
+        numOfMatches: AndroidScanNumOfMatches.few,
+      );
+
+      final decoded = AndroidOptions.decode(original.encode());
+
+      expect(decoded.callbackType, [
+        AndroidScanCallbackType.firstMatch,
+        AndroidScanCallbackType.matchLost,
+      ]);
+      expect(decoded.matchMode, AndroidScanMatchMode.sticky);
+      expect(decoded.numOfMatches, AndroidScanNumOfMatches.few);
+      expect(decoded.scanMode, AndroidScanMode.lowLatency);
+      expect(decoded.reportDelayMillis, 0);
+      expect(decoded.requestLocationPermission, true);
+    });
+
+    test('leaves the new fields null by default', () {
+      final options = AndroidOptions();
+
+      expect(options.callbackType, isNull);
+      expect(options.matchMode, isNull);
+      expect(options.numOfMatches, isNull);
+    });
+  });
+}

--- a/windows/src/generated/universal_ble.g.cpp
+++ b/windows/src/generated/universal_ble.g.cpp
@@ -617,10 +617,16 @@ AndroidOptions::AndroidOptions() {}
 AndroidOptions::AndroidOptions(
   const bool* request_location_permission,
   const AndroidScanMode* scan_mode,
-  const int64_t* report_delay_millis)
+  const int64_t* report_delay_millis,
+  const EncodableList* callback_type,
+  const AndroidScanMatchMode* match_mode,
+  const AndroidScanNumOfMatches* num_of_matches)
  : request_location_permission_(request_location_permission ? std::optional<bool>(*request_location_permission) : std::nullopt),
     scan_mode_(scan_mode ? std::optional<AndroidScanMode>(*scan_mode) : std::nullopt),
-    report_delay_millis_(report_delay_millis ? std::optional<int64_t>(*report_delay_millis) : std::nullopt) {}
+    report_delay_millis_(report_delay_millis ? std::optional<int64_t>(*report_delay_millis) : std::nullopt),
+    callback_type_(callback_type ? std::optional<EncodableList>(*callback_type) : std::nullopt),
+    match_mode_(match_mode ? std::optional<AndroidScanMatchMode>(*match_mode) : std::nullopt),
+    num_of_matches_(num_of_matches ? std::optional<AndroidScanNumOfMatches>(*num_of_matches) : std::nullopt) {}
 
 const bool* AndroidOptions::request_location_permission() const {
   return request_location_permission_ ? &(*request_location_permission_) : nullptr;
@@ -661,12 +667,54 @@ void AndroidOptions::set_report_delay_millis(int64_t value_arg) {
 }
 
 
+const EncodableList* AndroidOptions::callback_type() const {
+  return callback_type_ ? &(*callback_type_) : nullptr;
+}
+
+void AndroidOptions::set_callback_type(const EncodableList* value_arg) {
+  callback_type_ = value_arg ? std::optional<EncodableList>(*value_arg) : std::nullopt;
+}
+
+void AndroidOptions::set_callback_type(const EncodableList& value_arg) {
+  callback_type_ = value_arg;
+}
+
+
+const AndroidScanMatchMode* AndroidOptions::match_mode() const {
+  return match_mode_ ? &(*match_mode_) : nullptr;
+}
+
+void AndroidOptions::set_match_mode(const AndroidScanMatchMode* value_arg) {
+  match_mode_ = value_arg ? std::optional<AndroidScanMatchMode>(*value_arg) : std::nullopt;
+}
+
+void AndroidOptions::set_match_mode(const AndroidScanMatchMode& value_arg) {
+  match_mode_ = value_arg;
+}
+
+
+const AndroidScanNumOfMatches* AndroidOptions::num_of_matches() const {
+  return num_of_matches_ ? &(*num_of_matches_) : nullptr;
+}
+
+void AndroidOptions::set_num_of_matches(const AndroidScanNumOfMatches* value_arg) {
+  num_of_matches_ = value_arg ? std::optional<AndroidScanNumOfMatches>(*value_arg) : std::nullopt;
+}
+
+void AndroidOptions::set_num_of_matches(const AndroidScanNumOfMatches& value_arg) {
+  num_of_matches_ = value_arg;
+}
+
+
 EncodableList AndroidOptions::ToEncodableList() const {
   EncodableList list;
-  list.reserve(3);
+  list.reserve(6);
   list.push_back(request_location_permission_ ? EncodableValue(*request_location_permission_) : EncodableValue());
   list.push_back(scan_mode_ ? CustomEncodableValue(*scan_mode_) : EncodableValue());
   list.push_back(report_delay_millis_ ? EncodableValue(*report_delay_millis_) : EncodableValue());
+  list.push_back(callback_type_ ? EncodableValue(*callback_type_) : EncodableValue());
+  list.push_back(match_mode_ ? CustomEncodableValue(*match_mode_) : EncodableValue());
+  list.push_back(num_of_matches_ ? CustomEncodableValue(*num_of_matches_) : EncodableValue());
   return list;
 }
 
@@ -684,11 +732,23 @@ AndroidOptions AndroidOptions::FromEncodableList(const EncodableList& list) {
   if (!encodable_report_delay_millis.IsNull()) {
     decoded.set_report_delay_millis(std::get<int64_t>(encodable_report_delay_millis));
   }
+  auto& encodable_callback_type = list[3];
+  if (!encodable_callback_type.IsNull()) {
+    decoded.set_callback_type(std::get<EncodableList>(encodable_callback_type));
+  }
+  auto& encodable_match_mode = list[4];
+  if (!encodable_match_mode.IsNull()) {
+    decoded.set_match_mode(std::any_cast<const AndroidScanMatchMode&>(std::get<CustomEncodableValue>(encodable_match_mode)));
+  }
+  auto& encodable_num_of_matches = list[5];
+  if (!encodable_num_of_matches.IsNull()) {
+    decoded.set_num_of_matches(std::any_cast<const AndroidScanNumOfMatches&>(std::get<CustomEncodableValue>(encodable_num_of_matches)));
+  }
   return decoded;
 }
 
 bool AndroidOptions::operator==(const AndroidOptions& other) const {
-  return PigeonInternalDeepEquals(request_location_permission_, other.request_location_permission_) && PigeonInternalDeepEquals(scan_mode_, other.scan_mode_) && PigeonInternalDeepEquals(report_delay_millis_, other.report_delay_millis_);
+  return PigeonInternalDeepEquals(request_location_permission_, other.request_location_permission_) && PigeonInternalDeepEquals(scan_mode_, other.scan_mode_) && PigeonInternalDeepEquals(report_delay_millis_, other.report_delay_millis_) && PigeonInternalDeepEquals(callback_type_, other.callback_type_) && PigeonInternalDeepEquals(match_mode_, other.match_mode_) && PigeonInternalDeepEquals(num_of_matches_, other.num_of_matches_);
 }
 
 bool AndroidOptions::operator!=(const AndroidOptions& other) const {
@@ -700,6 +760,9 @@ size_t AndroidOptions::Hash() const {
   result = result * 31 + PigeonInternalDeepHash(request_location_permission_);
   result = result * 31 + PigeonInternalDeepHash(scan_mode_);
   result = result * 31 + PigeonInternalDeepHash(report_delay_millis_);
+  result = result * 31 + PigeonInternalDeepHash(callback_type_);
+  result = result * 31 + PigeonInternalDeepHash(match_mode_);
+  result = result * 31 + PigeonInternalDeepHash(num_of_matches_);
   return result;
 }
 
@@ -1632,74 +1695,89 @@ EncodableValue PigeonInternalCodecSerializer::ReadValueOfType(
     case 136: {
         const auto& encodable_enum_arg = ReadValue(stream);
         const int64_t enum_arg_value = encodable_enum_arg.IsNull() ? 0 : encodable_enum_arg.LongValue();
-        return encodable_enum_arg.IsNull() ? EncodableValue() : CustomEncodableValue(static_cast<CharacteristicProperty>(enum_arg_value));
+        return encodable_enum_arg.IsNull() ? EncodableValue() : CustomEncodableValue(static_cast<AndroidScanCallbackType>(enum_arg_value));
       }
     case 137: {
         const auto& encodable_enum_arg = ReadValue(stream);
         const int64_t enum_arg_value = encodable_enum_arg.IsNull() ? 0 : encodable_enum_arg.LongValue();
-        return encodable_enum_arg.IsNull() ? EncodableValue() : CustomEncodableValue(static_cast<PeripheralReadinessState>(enum_arg_value));
+        return encodable_enum_arg.IsNull() ? EncodableValue() : CustomEncodableValue(static_cast<AndroidScanMatchMode>(enum_arg_value));
       }
     case 138: {
         const auto& encodable_enum_arg = ReadValue(stream);
         const int64_t enum_arg_value = encodable_enum_arg.IsNull() ? 0 : encodable_enum_arg.LongValue();
-        return encodable_enum_arg.IsNull() ? EncodableValue() : CustomEncodableValue(static_cast<PeripheralAttributePermission>(enum_arg_value));
+        return encodable_enum_arg.IsNull() ? EncodableValue() : CustomEncodableValue(static_cast<AndroidScanNumOfMatches>(enum_arg_value));
       }
     case 139: {
         const auto& encodable_enum_arg = ReadValue(stream);
         const int64_t enum_arg_value = encodable_enum_arg.IsNull() ? 0 : encodable_enum_arg.LongValue();
-        return encodable_enum_arg.IsNull() ? EncodableValue() : CustomEncodableValue(static_cast<PeripheralAdvertisingState>(enum_arg_value));
+        return encodable_enum_arg.IsNull() ? EncodableValue() : CustomEncodableValue(static_cast<CharacteristicProperty>(enum_arg_value));
       }
     case 140: {
         const auto& encodable_enum_arg = ReadValue(stream);
         const int64_t enum_arg_value = encodable_enum_arg.IsNull() ? 0 : encodable_enum_arg.LongValue();
-        return encodable_enum_arg.IsNull() ? EncodableValue() : CustomEncodableValue(static_cast<UniversalBleErrorCode>(enum_arg_value));
+        return encodable_enum_arg.IsNull() ? EncodableValue() : CustomEncodableValue(static_cast<PeripheralReadinessState>(enum_arg_value));
       }
     case 141: {
-        return CustomEncodableValue(UniversalBleScanResult::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        const auto& encodable_enum_arg = ReadValue(stream);
+        const int64_t enum_arg_value = encodable_enum_arg.IsNull() ? 0 : encodable_enum_arg.LongValue();
+        return encodable_enum_arg.IsNull() ? EncodableValue() : CustomEncodableValue(static_cast<PeripheralAttributePermission>(enum_arg_value));
       }
     case 142: {
-        return CustomEncodableValue(UniversalBleService::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        const auto& encodable_enum_arg = ReadValue(stream);
+        const int64_t enum_arg_value = encodable_enum_arg.IsNull() ? 0 : encodable_enum_arg.LongValue();
+        return encodable_enum_arg.IsNull() ? EncodableValue() : CustomEncodableValue(static_cast<PeripheralAdvertisingState>(enum_arg_value));
       }
     case 143: {
-        return CustomEncodableValue(UniversalBleCharacteristic::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        const auto& encodable_enum_arg = ReadValue(stream);
+        const int64_t enum_arg_value = encodable_enum_arg.IsNull() ? 0 : encodable_enum_arg.LongValue();
+        return encodable_enum_arg.IsNull() ? EncodableValue() : CustomEncodableValue(static_cast<UniversalBleErrorCode>(enum_arg_value));
       }
     case 144: {
-        return CustomEncodableValue(UniversalBleDescriptor::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(UniversalBleScanResult::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 145: {
-        return CustomEncodableValue(AndroidOptions::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(UniversalBleService::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 146: {
-        return CustomEncodableValue(UniversalScanConfig::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(UniversalBleCharacteristic::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 147: {
-        return CustomEncodableValue(UniversalScanFilter::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(UniversalBleDescriptor::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 148: {
-        return CustomEncodableValue(ManufacturerDataFilter::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(AndroidOptions::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 149: {
-        return CustomEncodableValue(UniversalManufacturerData::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(UniversalScanConfig::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 150: {
-        return CustomEncodableValue(PeripheralAndroidOptions::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(UniversalScanFilter::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 151: {
-        return CustomEncodableValue(PeripheralPlatformConfig::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(ManufacturerDataFilter::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 152: {
-        return CustomEncodableValue(PeripheralService::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(UniversalManufacturerData::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 153: {
-        return CustomEncodableValue(PeripheralCharacteristic::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(PeripheralAndroidOptions::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 154: {
-        return CustomEncodableValue(PeripheralDescriptor::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(PeripheralPlatformConfig::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 155: {
-        return CustomEncodableValue(PeripheralReadRequestResult::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(PeripheralService::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 156: {
+        return CustomEncodableValue(PeripheralCharacteristic::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+      }
+    case 157: {
+        return CustomEncodableValue(PeripheralDescriptor::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+      }
+    case 158: {
+        return CustomEncodableValue(PeripheralReadRequestResult::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+      }
+    case 159: {
         return CustomEncodableValue(PeripheralWriteRequestResult::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     default:
@@ -1746,108 +1824,123 @@ void PigeonInternalCodecSerializer::WriteValue(
       WriteValue(EncodableValue(static_cast<int>(std::any_cast<AndroidScanMode>(*custom_value))), stream);
       return;
     }
-    if (custom_value->type() == typeid(CharacteristicProperty)) {
+    if (custom_value->type() == typeid(AndroidScanCallbackType)) {
       stream->WriteByte(136);
+      WriteValue(EncodableValue(static_cast<int>(std::any_cast<AndroidScanCallbackType>(*custom_value))), stream);
+      return;
+    }
+    if (custom_value->type() == typeid(AndroidScanMatchMode)) {
+      stream->WriteByte(137);
+      WriteValue(EncodableValue(static_cast<int>(std::any_cast<AndroidScanMatchMode>(*custom_value))), stream);
+      return;
+    }
+    if (custom_value->type() == typeid(AndroidScanNumOfMatches)) {
+      stream->WriteByte(138);
+      WriteValue(EncodableValue(static_cast<int>(std::any_cast<AndroidScanNumOfMatches>(*custom_value))), stream);
+      return;
+    }
+    if (custom_value->type() == typeid(CharacteristicProperty)) {
+      stream->WriteByte(139);
       WriteValue(EncodableValue(static_cast<int>(std::any_cast<CharacteristicProperty>(*custom_value))), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralReadinessState)) {
-      stream->WriteByte(137);
+      stream->WriteByte(140);
       WriteValue(EncodableValue(static_cast<int>(std::any_cast<PeripheralReadinessState>(*custom_value))), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralAttributePermission)) {
-      stream->WriteByte(138);
+      stream->WriteByte(141);
       WriteValue(EncodableValue(static_cast<int>(std::any_cast<PeripheralAttributePermission>(*custom_value))), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralAdvertisingState)) {
-      stream->WriteByte(139);
+      stream->WriteByte(142);
       WriteValue(EncodableValue(static_cast<int>(std::any_cast<PeripheralAdvertisingState>(*custom_value))), stream);
       return;
     }
     if (custom_value->type() == typeid(UniversalBleErrorCode)) {
-      stream->WriteByte(140);
+      stream->WriteByte(143);
       WriteValue(EncodableValue(static_cast<int>(std::any_cast<UniversalBleErrorCode>(*custom_value))), stream);
       return;
     }
     if (custom_value->type() == typeid(UniversalBleScanResult)) {
-      stream->WriteByte(141);
+      stream->WriteByte(144);
       WriteValue(EncodableValue(std::any_cast<UniversalBleScanResult>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(UniversalBleService)) {
-      stream->WriteByte(142);
+      stream->WriteByte(145);
       WriteValue(EncodableValue(std::any_cast<UniversalBleService>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(UniversalBleCharacteristic)) {
-      stream->WriteByte(143);
+      stream->WriteByte(146);
       WriteValue(EncodableValue(std::any_cast<UniversalBleCharacteristic>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(UniversalBleDescriptor)) {
-      stream->WriteByte(144);
+      stream->WriteByte(147);
       WriteValue(EncodableValue(std::any_cast<UniversalBleDescriptor>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(AndroidOptions)) {
-      stream->WriteByte(145);
+      stream->WriteByte(148);
       WriteValue(EncodableValue(std::any_cast<AndroidOptions>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(UniversalScanConfig)) {
-      stream->WriteByte(146);
+      stream->WriteByte(149);
       WriteValue(EncodableValue(std::any_cast<UniversalScanConfig>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(UniversalScanFilter)) {
-      stream->WriteByte(147);
+      stream->WriteByte(150);
       WriteValue(EncodableValue(std::any_cast<UniversalScanFilter>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(ManufacturerDataFilter)) {
-      stream->WriteByte(148);
+      stream->WriteByte(151);
       WriteValue(EncodableValue(std::any_cast<ManufacturerDataFilter>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(UniversalManufacturerData)) {
-      stream->WriteByte(149);
+      stream->WriteByte(152);
       WriteValue(EncodableValue(std::any_cast<UniversalManufacturerData>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralAndroidOptions)) {
-      stream->WriteByte(150);
+      stream->WriteByte(153);
       WriteValue(EncodableValue(std::any_cast<PeripheralAndroidOptions>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralPlatformConfig)) {
-      stream->WriteByte(151);
+      stream->WriteByte(154);
       WriteValue(EncodableValue(std::any_cast<PeripheralPlatformConfig>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralService)) {
-      stream->WriteByte(152);
+      stream->WriteByte(155);
       WriteValue(EncodableValue(std::any_cast<PeripheralService>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralCharacteristic)) {
-      stream->WriteByte(153);
+      stream->WriteByte(156);
       WriteValue(EncodableValue(std::any_cast<PeripheralCharacteristic>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralDescriptor)) {
-      stream->WriteByte(154);
+      stream->WriteByte(157);
       WriteValue(EncodableValue(std::any_cast<PeripheralDescriptor>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralReadRequestResult)) {
-      stream->WriteByte(155);
+      stream->WriteByte(158);
       WriteValue(EncodableValue(std::any_cast<PeripheralReadRequestResult>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralWriteRequestResult)) {
-      stream->WriteByte(156);
+      stream->WriteByte(159);
       WriteValue(EncodableValue(std::any_cast<PeripheralWriteRequestResult>(*custom_value).ToEncodableList()), stream);
       return;
     }

--- a/windows/src/generated/universal_ble.g.h
+++ b/windows/src/generated/universal_ble.g.h
@@ -115,6 +115,38 @@ enum class AndroidScanMode {
   kOpportunistic = 3
 };
 
+// Mirrors `android.bluetooth.le.ScanSettings#setCallbackType`. Pass any
+// combination via `AndroidOptions.callbackType` (the plugin OR-folds the list
+// before calling `setCallbackType`).
+//
+// API-level notes:
+// * [allMatches] — API 21+
+// * [firstMatch], [matchLost] — API 23+ (Marshmallow). Silently dropped on
+//   older devices.
+// * [allMatchesAutoBatch] — API 34+ (Upside Down Cake). Silently dropped on
+//   older devices.
+//
+// See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
+enum class AndroidScanCallbackType {
+  kAllMatches = 0,
+  kFirstMatch = 1,
+  kMatchLost = 2,
+  kAllMatchesAutoBatch = 3
+};
+
+// Mirrors `android.bluetooth.le.ScanSettings#setMatchMode`.
+enum class AndroidScanMatchMode {
+  kAggressive = 0,
+  kSticky = 1
+};
+
+// Mirrors `android.bluetooth.le.ScanSettings#setNumOfMatches`.
+enum class AndroidScanNumOfMatches {
+  kOne = 0,
+  kFew = 1,
+  kMax = 2
+};
+
 enum class CharacteristicProperty {
   kBroadcast = 0,
   kRead = 1,
@@ -398,6 +430,20 @@ class UniversalBleDescriptor {
 // Set [reportDelayMillis] timestamp for Bluetooth LE scan. If set to 0, you will be notified of scan results immediately.
 // If > 0, scan results are queued up and delivered after the requested delay or 5000 milliseconds (whichever is higher).
 // Note scan results may be delivered sooner if the internal buffers fill up.
+// [callbackType], [matchMode], and [numOfMatches] map directly to the equivalent
+// `android.bluetooth.le.ScanSettings` setters. When `null`, the plugin leaves them
+// at the platform default — set them only if you need to override platform-side
+// advert de-duplication (e.g. on Pixel hardware where the default settings
+// throttle advertisements compared with nRF Connect).
+//
+// [callbackType] is a list because Android's `setCallbackType` accepts any
+// bitwise combination of [AndroidScanCallbackType] values (for example
+// `[firstMatch, matchLost]` to be notified once on entry and again on exit).
+// The plugin OR-folds the list before calling the native API. Values that
+// require a newer API than the device supports are silently dropped (and
+// logged); see the [AndroidScanCallbackType] doc for per-value API levels.
+//
+// See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
 //
 // Generated class from Pigeon that represents data sent in messages.
 class AndroidOptions {
@@ -409,7 +455,10 @@ class AndroidOptions {
   explicit AndroidOptions(
     const bool* request_location_permission,
     const AndroidScanMode* scan_mode,
-    const int64_t* report_delay_millis);
+    const int64_t* report_delay_millis,
+    const ::flutter::EncodableList* callback_type,
+    const AndroidScanMatchMode* match_mode,
+    const AndroidScanNumOfMatches* num_of_matches);
 
   const bool* request_location_permission() const;
   void set_request_location_permission(const bool* value_arg);
@@ -422,6 +471,18 @@ class AndroidOptions {
   const int64_t* report_delay_millis() const;
   void set_report_delay_millis(const int64_t* value_arg);
   void set_report_delay_millis(int64_t value_arg);
+
+  const ::flutter::EncodableList* callback_type() const;
+  void set_callback_type(const ::flutter::EncodableList* value_arg);
+  void set_callback_type(const ::flutter::EncodableList& value_arg);
+
+  const AndroidScanMatchMode* match_mode() const;
+  void set_match_mode(const AndroidScanMatchMode* value_arg);
+  void set_match_mode(const AndroidScanMatchMode& value_arg);
+
+  const AndroidScanNumOfMatches* num_of_matches() const;
+  void set_num_of_matches(const AndroidScanNumOfMatches* value_arg);
+  void set_num_of_matches(const AndroidScanNumOfMatches& value_arg);
 
   bool operator==(const AndroidOptions& other) const;
   bool operator!=(const AndroidOptions& other) const;
@@ -440,6 +501,9 @@ class AndroidOptions {
   std::optional<bool> request_location_permission_;
   std::optional<AndroidScanMode> scan_mode_;
   std::optional<int64_t> report_delay_millis_;
+  std::optional<::flutter::EncodableList> callback_type_;
+  std::optional<AndroidScanMatchMode> match_mode_;
+  std::optional<AndroidScanNumOfMatches> num_of_matches_;
 };
 
 


### PR DESCRIPTION
Fixes #227.

## Summary

Exposes three `android.bluetooth.le.ScanSettings` knobs as nullable fields on `AndroidOptions`, following the same platform-scoped-options pattern as #212:

- `callbackType` → `setCallbackType` (`AndroidScanCallbackType.{allMatches, firstMatch, matchLost}`)
- `matchMode` → `setMatchMode` (`AndroidScanMatchMode.{aggressive, sticky}`)
- `numOfMatches` → `setNumOfMatches` (`AndroidScanNumOfMatches.{one, few, max}`)

**Defaults are unchanged.** When callers pass nothing, the plugin keeps its current behaviour. Callers hitting the chip-side advert de-duplication issue described in #227 can opt in.

## Why

On Pixel 6a / Android 16, the platform defaults throttle advertisements by ~10× relative to nRF Connect on the same hardware. Setting the three knobs above (alongside the existing `scanMode` / `reportDelayMillis`) is the only thing that restores the native advert cadence:

| Tool                                    | Adverts / 60 s | Median Δ |
|-----------------------------------------|----------------|----------|
| nRF Connect for Android                 | ~46            | 1.29 s   |
| `universal_ble` (current `main`)        | 7              | ~12 s    |
| `universal_ble` + the four `ScanSettings` from #227 | 44 | 1.29 s   |

Full measurement detail and the minimal repro are in #227.

## Changes

- `pigeon/universal_ble.dart` — three new enums + three nullable fields on `AndroidOptions`.
- Regenerated `lib/src/universal_ble.g.dart`, `android/.../UniversalBle.g.kt`, `darwin/.../UniversalBle.g.swift`, `windows/src/generated/universal_ble.g.{h,cpp}` via `./build_pigeon.sh` (committed alongside the source, per `CONTRIBUTING.md`).
- `android/.../UniversalBleHelper.kt` — three `parse()` extensions mapping pigeon enums to `ScanSettings.{CALLBACK_TYPE_*, MATCH_MODE_*, MATCH_NUM_*}`.
- `android/.../UniversalBlePlugin.kt` — three `builder.set*` calls inside the existing `androidConfig?.let { ... }`.
- `lib/universal_ble.dart` — re-export the three new enums.
- `example/lib/home/home.dart` — `startScan` now demonstrates the "give me everything" configuration.
- `test/android_options_test.dart` — three tests, including a pigeon-codec round-trip across all new fields.
- `CHANGELOG.md` — one bullet under an `## Unreleased` heading.

No iOS / macOS / Windows / Linux plugin changes beyond the regenerated pigeon outputs — `ScanSettings` is Android-only API surface.

## Test plan

- [x] `dart format .` — no diffs
- [x] `flutter analyze` — no issues
- [x] `flutter test` — 58 tests pass (includes the new round-trip test)
- [x] `flutter test --platform chrome` — 58 tests pass
- [x] `./build_pigeon.sh` is idempotent — re-running leaves the working tree clean
- [ ] `example/` app runs on a real Pixel 6a and scans devices (will verify before marking ready for review)

## Out of scope

- Not changing the plugin's default `ScanSettings`. Smallest possible behaviour-surface; happy to follow up with a separate proposal arguing for better defaults using the measurements from #227.
- Not addressing the AOSP-level 5-in-30 s scan-quota rate limiter — that's `AdapterService.DeviceConfigListener.DEFAULT_SCAN_QUOTA_COUNT = 5` and unrelated to the dedup behaviour fixed here.
