### PR TITLE
iOS/macOS: retain peripheral from retrievePeripherals to fix API MISUSE on connect

### DIFF
--- a/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
@@ -676,6 +676,7 @@ extension String {
     if let uuid = UUID(uuidString: self) {
       let peripherals = manager.retrievePeripherals(withIdentifiers: [uuid])
       if let peripheral = peripherals.first {
+        discoveredPeripherals[self] = peripheral
         return peripheral
       }
     }


### PR DESCRIPTION
## Summary

In `findPeripheral` (extension on `String`), the peripheral returned by
`manager.retrievePeripherals(withIdentifiers:)` is returned to the caller
without being inserted into `discoveredPeripherals`. The cache-hit branch
just above already returns from that dict — this branch should populate it.

Without the retain, ARC releases the `CBPeripheral` as soon as the caller's
frame unwinds. If the caller then immediately passes it to
`manager.connect(...)`, CoreBluetooth ends up holding `.connecting` state
on a peripheral with no other strong references and logs:

    API MISUSE: Cancelling connection for unused peripheral <UUID>.
    Did you forget to keep a reference to it?

The connect attempt is then dropped by CoreBluetooth.

This is reliably reproducible on iOS when the app is relaunched and tries
to reconnect to a previously known device by id (e.g. autoConnect after
process restart): the device is not in `discoveredPeripherals` yet, the
retrieve branch runs, and the subsequent connect prints the MISUSE warning.

## Fix

One line: insert the peripheral into `discoveredPeripherals` before
returning it, mirroring how the cache-hit branch and `didDiscover` already
do it.

## Test plan

- No Dart-level unit test added: the bug lives in Swift code that requires
  a real `CBCentralManager` and a real peripheral to trigger. Mocking
  `retrievePeripherals` at the Dart boundary wouldn't exercise the ARC
  path that causes the MISUSE.
- Manually verified on iOS: with the patched plugin, connecting to a
  previously known device after a cold app start no longer logs the
  MISUSE warning and `didConnect` fires normally.
- `dart format .`, `flutter analyze`, `flutter test`, `flutter test --platform chrome` all clean.