### PR TITLE
Fix null pointer crash when BLE device is unpaired during active scan

### DIFF
--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -918,16 +918,27 @@ void UniversalBlePlugin::OnDeviceInfoReceived(
   const auto properties = device_info.Properties();
 
   // Avoid devices if not connectable or if deviceAddressKey is not present
-  if (!(properties.HasKey(is_connectable_key) &&
-        (properties.Lookup(is_connectable_key).as<IPropertyValue>())
-            .GetBoolean()) ||
-      !properties.HasKey(device_address_key))
+  
+  auto isConnectableProp = properties.Lookup(is_connectable_key).try_as<IPropertyValue>();
+  if ( !isConnectableProp ) {
     return;
+  }
+  
+  if (!properties.HasKey(is_connectable_key) && isConnectableProp.GetBoolean() || !properties.HasKey(device_address_key)){
+    return;
+  }
+      
+  auto bluetooth_address_raw = properties.Lookup(device_address_key);
+  if (!bluetooth_address_raw) {
+    return;
+  }
 
-  const auto bluetooth_address_property_value =
-      properties.Lookup(device_address_key).as<IPropertyValue>();
-  const std::string device_address =
-      to_string(bluetooth_address_property_value.GetString());
+  auto bluetooth_address_property_value = bluetooth_address_raw.try_as<IPropertyValue>();
+  if (!bluetooth_address_property_value) {
+    return;
+  }
+
+  const std::string device_address = to_string(bluetooth_address_property_value.GetString());
 
   // Update device info if already discovered in advertisementWatcher
   if (scan_results_.get(device_address).has_value()) {

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -923,8 +923,10 @@ void UniversalBlePlugin::OnDeviceInfoReceived(
     return;
   }
 
-  auto isConnectableProp = properties.Lookup(is_connectable_key).try_as<IPropertyValue>();
-  if (!isConnectableProp || !isConnectableProp.GetBoolean()) {
+  const auto is_connectable_property_value =
+      properties.Lookup(is_connectable_key).try_as<IPropertyValue>();
+  if (!is_connectable_property_value ||
+      !is_connectable_property_value.GetBoolean()) {
     return;
   }
 

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -919,21 +919,16 @@ void UniversalBlePlugin::OnDeviceInfoReceived(
 
   // Avoid devices if not connectable or if deviceAddressKey is not present
   
-  auto isConnectableProp = properties.Lookup(is_connectable_key).try_as<IPropertyValue>();
-  if ( !isConnectableProp ) {
-    return;
-  }
-  
-  if (!properties.HasKey(is_connectable_key) && isConnectableProp.GetBoolean() || !properties.HasKey(device_address_key)){
-    return;
-  }
-      
-  auto bluetooth_address_raw = properties.Lookup(device_address_key);
-  if (!bluetooth_address_raw) {
+  if (!properties.HasKey(is_connectable_key) || !properties.HasKey(device_address_key)) {
     return;
   }
 
-  auto bluetooth_address_property_value = bluetooth_address_raw.try_as<IPropertyValue>();
+  auto isConnectableProp = properties.Lookup(is_connectable_key).try_as<IPropertyValue>();
+  if (!isConnectableProp || !isConnectableProp.GetBoolean()) {
+    return;
+  }
+
+  auto bluetooth_address_property_value = properties.Lookup(device_address_key).try_as<IPropertyValue>();
   if (!bluetooth_address_property_value) {
     return;
   }


### PR DESCRIPTION
**Problem**
On Windows, when a Bluetooth device is unpaired while a BLE scan is actively processing, "properties.Lookup(is_connectable_key).as<IPropertyValue>()" and "properties.Lookup(device_address_key).as<IPropertyValue>()" could return nullptr, causing a crash. The original code assumed these property lookups would always yield a valid IPropertyValue, which is not guaranteed under race-like conditions such as mid-scan unpairing.

**Fix**
Replaced all unsafe .as<IPropertyValue>() casts with .try_as<IPropertyValue>(), which returns a nullable wrapper that can be checked before use. Added explicit null guards at each step of the property lookup chain:

Early return if is_connectable cannot be cast to IPropertyValue
Corrected the boolean logic gate for the connectable + address key check
Early return if the raw device_address lookup or its IPropertyValue cast is null

**Testing**
Reproduced on Windows by initiating a BLE scan and unpairing the device through Windows Bluetooth settings mid-scan. Note that the crash may not trigger on the first attempt — it may require a few tries to reproduce due to the timing-dependent nature of the race condition. The patched code returns early cleanly in all cases.