### PR TITLE
Add Windows support for requestConnectionPriority and onConnectionParametersChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE
 | enable/disable Bluetooth      |   ✔️    | ❌  |  ❌   |   ✔️    |  ✔️   | ❌  |
 | onAvailabilityChange          |   ✔️    | ✔️  |  ✔️   |   ✔️    |  ✔️   | ✔️  |
 | requestMtu                    |   ✔️    | ✔️  |  ✔️   |   ✔️    |  ✔️   | ❌  |
-| requestConnectionPriority     |   ✔️    | ❌  |  ❌   |   ❌    |  ❌   | ❌  |
+| requestConnectionPriority     |   ✔️    | ❌  |  ❌   |   ✔️    |  ❌   | ❌  |
 | onConnectionParametersChange  |   ✔️    | ❌  |  ❌   |   ❌    |  ❌   | ❌  |
 | readRssi                      |   ✔️    | ✔️  |  ✔️   |   ❌    |  🚧   | ❌  |
 | requestPermissions            |   ✔️    | ✔️  |  ✔️   |   ✔️    |  ✔️   | ✔️  |
@@ -500,7 +500,7 @@ When developing cross-platform BLE applications and devices:
 
 ### Requesting Connection Priority
 
-On Android, you can request a connection parameter update to tune the BLE connection interval. This can yield a 3–7× throughput improvement for data-intensive transfers.
+On Android and Windows, you can request a connection parameter update to tune the BLE connection interval. This can yield a 3–7× throughput improvement for data-intensive transfers.
 
 ```dart
 // Before starting high-throughput data transfer:
@@ -510,7 +510,7 @@ await UniversalBle.requestConnectionPriority(
 );
 ```
 
-> **Note:** Only supported on Android. On all other platforms this throws `UniversalBleException` with code `notSupported`.
+> **Note:** Supported on Android and Windows. On all other platforms this throws `UniversalBleException` with code `notSupported`.
 > Call this after connecting and after `requestMtu()`, before beginning data transfer.
 
 The OS may later change connection parameters without your app requesting it (e.g. for power saving), which can reduce throughput. On Android API 26+, set `UniversalBle.onConnectionParametersChange` and react if needed:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE
 | onAvailabilityChange          |   ✔️    | ✔️  |  ✔️   |   ✔️    |  ✔️   | ✔️  |
 | requestMtu                    |   ✔️    | ✔️  |  ✔️   |   ✔️    |  ✔️   | ❌  |
 | requestConnectionPriority     |   ✔️    | ❌  |  ❌   |   ✔️    |  ❌   | ❌  |
-| onConnectionParametersChange  |   ✔️    | ❌  |  ❌   |   ❌    |  ❌   | ❌  |
+| onConnectionParametersChange  |   ✔️    | ❌  |  ❌   |   ✔️    |  ❌   | ❌  |
 | readRssi                      |   ✔️    | ✔️  |  ✔️   |   ❌    |  🚧   | ❌  |
 | requestPermissions            |   ✔️    | ✔️  |  ✔️   |   ✔️    |  ✔️   | ✔️  |
 
@@ -513,7 +513,7 @@ await UniversalBle.requestConnectionPriority(
 > **Note:** Supported on Android and Windows. On all other platforms this throws `UniversalBleException` with code `notSupported`.
 > Call this after connecting and after `requestMtu()`, before beginning data transfer.
 
-The OS may later change connection parameters without your app requesting it (e.g. for power saving), which can reduce throughput. On Android API 26+, set `UniversalBle.onConnectionParametersChange` and react if needed:
+The OS may later change connection parameters without your app requesting it (e.g. for power saving), which can reduce throughput. Set `UniversalBle.onConnectionParametersChange` and react if needed. On Android this is event-driven (API 26+); on Windows it uses polling every 2 seconds.
 
 ```dart
 UniversalBle.onConnectionParametersChange = (update) {
@@ -528,7 +528,7 @@ UniversalBle.onConnectionParametersChange = (update) {
 };
 ```
 
-> **Note:** Re-requesting high priority on every update can fight the OS power manager — debounce in app code. Requires Android API 26+ (`BleCapabilities.supportsConnectionParametersUpdates`).
+> **Note:** Re-requesting high priority on every update can fight the OS power manager — debounce in app code. On Android, requires API 26+ (`BleCapabilities.supportsConnectionParametersUpdates`).
 
 ### Reading RSSI
 

--- a/lib/src/models/ble_capabilities.dart
+++ b/lib/src/models/ble_capabilities.dart
@@ -44,7 +44,9 @@ class BleCapabilities {
   static bool supportsRequestMtuApi = !_Platform.isWeb;
 
   static bool supportsConnectionPriorityApi =
-      !_Platform.isWeb && defaultTargetPlatform == TargetPlatform.android;
+      !_Platform.isWeb &&
+      (defaultTargetPlatform == TargetPlatform.android ||
+          defaultTargetPlatform == TargetPlatform.windows);
 
   /// Whether connection parameter update events are reported (Android API 26+).
   static bool supportsConnectionParametersUpdates =

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -358,7 +358,7 @@ class UniversalBle {
   /// - [BleConnectionPriority.highPerformance] - low latency, higher power (~7.5-15 ms interval).
   /// - [BleConnectionPriority.lowPower] - power-optimised (~100-125 ms interval).
   ///
-  /// Only supported on Android. On all other platforms this throws
+  /// Only supported on Android and Windows. On all other platforms this throws
   /// [UniversalBleException] with code [UniversalBleErrorCode.notSupported].
   ///
   /// Should be called after a successful connection and MTU negotiation, before

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -457,9 +457,43 @@ void UniversalBlePlugin::RequestMtu(
 void UniversalBlePlugin::RequestConnectionPriority(
     const std::string &device_id, const BleConnectionPriority &priority,
     std::function<void(std::optional<FlutterError> reply)> result) {
-  result(create_flutter_error(
-      UniversalBleErrorCode::kNotSupported,
-      "requestConnectionPriority is not supported on Windows platform"));
+  try {
+    auto it = connected_devices_.find(str_to_mac_address(device_id));
+    if (it == connected_devices_.end()) {
+      result(create_flutter_error(UniversalBleErrorCode::kDeviceNotFound,
+                                  "Unknown devicesId:" + device_id));
+      return;
+    }
+    auto bluetooth_agent = *it->second;
+    auto connected = bluetooth_agent.device.ConnectionStatus() ==
+                     BluetoothConnectionStatus::Connected;
+    if (connected) {
+      BluetoothLEPreferredConnectionParameters params{nullptr};
+      switch (priority) {
+        case BleConnectionPriority::kBalanced:
+          params = BluetoothLEPreferredConnectionParameters::Balanced();
+          break;
+        case BleConnectionPriority::kHighPerformance:
+          params =
+              BluetoothLEPreferredConnectionParameters::ThroughputOptimized();
+          break;
+        case BleConnectionPriority::kLowPower:
+          params = BluetoothLEPreferredConnectionParameters::PowerOptimized();
+          break;
+      }
+      bluetooth_agent.device.RequestPreferredConnectionParameters(params);
+    }
+    result(std::nullopt);
+  } catch (const FlutterError &err) {
+    result(err);
+  } catch (const winrt::hresult_error &err) {
+    result(create_flutter_error(
+        UniversalBleErrorCode::kFailed,
+        "requestConnectionPriority failed: " + to_string(err.message())));
+  } catch (...) {
+    result(create_flutter_error(UniversalBleErrorCode::kUnknownError,
+                                "Unknown error"));
+  }
 }
 
 void UniversalBlePlugin::ReadRssi(

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -63,9 +63,11 @@ UniversalBlePlugin::UniversalBlePlugin(
     flutter::PluginRegistrarWindows *registrar)
     : registrar_(registrar), ui_thread_handler_(registrar) {
   InitializeAsync();
+  StartConnectionParameterPolling();
 }
 
 UniversalBlePlugin::~UniversalBlePlugin() {
+  StopConnectionParameterPolling();
   ClearServices();
   peripheral_callback_channel_.reset();
 }
@@ -493,6 +495,51 @@ void UniversalBlePlugin::RequestConnectionPriority(
   } catch (...) {
     result(create_flutter_error(UniversalBleErrorCode::kUnknownError,
                                 "Unknown error"));
+  }
+}
+
+void UniversalBlePlugin::StartConnectionParameterPolling() {
+  if (polling_active_.exchange(true)) return;
+  polling_thread_ = std::thread([this] {
+    while (polling_active_) {
+      std::this_thread::sleep_for(std::chrono::seconds(2));
+      if (!polling_active_) break;
+      ui_thread_handler_.Post([this] {
+        for (const auto &[addr, agent] : connected_devices_) {
+          try {
+            if (agent->device.ConnectionStatus() !=
+                BluetoothConnectionStatus::Connected)
+              continue;
+            auto params = agent->device.GetConnectionParameters();
+            BleConnectionParametersUpdated update(
+                mac_address_to_str(addr),
+                static_cast<int64_t>(params.ConnectionInterval()),
+                static_cast<int64_t>(params.ConnectionLatency()),
+                static_cast<int64_t>(params.LinkTimeout()),
+                0);
+            auto it = last_connection_params_.find(addr);
+            if (it == last_connection_params_.end() ||
+                !it->second.has_value() ||
+                it->second->interval() != update.interval() ||
+                it->second->latency() != update.latency() ||
+                it->second->supervision_timeout() !=
+                    update.supervision_timeout()) {
+              last_connection_params_[addr] = update;
+              callback_channel->OnConnectionParametersUpdated(
+                  update, SuccessCallback, ErrorCallback);
+            }
+          } catch (...) {
+          }
+        }
+      });
+    }
+  });
+}
+
+void UniversalBlePlugin::StopConnectionParameterPolling() {
+  polling_active_ = false;
+  if (polling_thread_.joinable()) {
+    polling_thread_.join();
   }
 }
 

--- a/windows/src/universal_ble_plugin.h
+++ b/windows/src/universal_ble_plugin.h
@@ -21,7 +21,10 @@
 #include "helper/utils.h"
 #include "ui_thread_handler.hpp"
 #include "universal_ble_thread_safe.h"
+#include <atomic>
 #include <memory>
+#include <optional>
+#include <thread>
 #include <vector>
 
 namespace universal_ble {
@@ -142,6 +145,12 @@ private:
   event_token device_watcher_stopped_token_;
   event_revoker<IRadio> radio_state_changed_revoker_;
 
+  // Connection parameter polling
+  std::thread polling_thread_;
+  std::atomic<bool> polling_active_{false};
+  std::unordered_map<uint64_t, std::optional<BleConnectionParametersUpdated>>
+      last_connection_params_;
+
   fire_and_forget InitializeAsync();
   fire_and_forget ConnectAsync(uint64_t bluetooth_address);
   fire_and_forget SetNotifiableAsync(
@@ -163,6 +172,9 @@ private:
   fire_and_forget DiscoverServicesAsync(
       const std::string &device_id, bool with_descriptors,
       std::function<void(ErrorOr<flutter::EncodableList> reply)> result);
+
+  void StartConnectionParameterPolling();
+  void StopConnectionParameterPolling();
 
   void
   PairingRequestedHandler(DeviceInformationCustomPairing sender,


### PR DESCRIPTION
Related: #220, #221

Implements two connection parameter APIs on Windows that were previously
Android-only.

### requestConnectionPriority

Replaces the 
otSupported stub with
[BluetoothLEDevice::RequestPreferredConnectionParameters](
https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothledevice.requestpreferredconnectionparameters).
Maps BleConnectionPriority values to
[BluetoothLEPreferredConnectionParameters](
https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothlepreferredconnectionparameters)
(Balanced / ThroughputOptimized / PowerOptimized).

### onConnectionParametersChange

Windows has no event-driven API for connection parameter changes
(unlike Android's BluetoothGattCallback.onConnectionUpdated), so this
falls back to a background polling thread that calls
[BluetoothLEDevice::GetConnectionParameters](
https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.bluetoothledevice.getconnectionparameters)
every 2 seconds for connected devices. Callback fires only when values change
(deduplicated in both C++ and Dart).

This is the first polling-based callback in this library — every other
callback relies on native events. Feedback on the polling interval and
whether there is a better approach would be appreciated.