### PR TITLE
feat(ios): add CoreBluetooth state restoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* iOS: add CoreBluetooth state preservation/restoration so the app can be relaunched in the background by a connected peripheral and resume the live connection. Requires the `bluetooth-central` background mode in `Info.plist` (see README → Permissions → iOS / macOS).
+
 ## 2.0.3
 * iOS/macOS: defer `CBPeripheralManager` creation until peripheral APIs are used, fixing Bluetooth permission prompt on app launch
 * Windows: Fix null pointer crash when BLE device is unpaired during active scan

--- a/README.md
+++ b/README.md
@@ -998,14 +998,15 @@ Add the `Bluetooth` capability to the macOS app from Xcode.
 
 On iOS, the central manager is created with a `CBCentralManagerOptionRestoreIdentifierKey`, so CoreBluetooth can **relaunch your app in the background** when a connected peripheral has activity, and hand the live connection back to the plugin. This happens automatically — no API call is required.
 
-To benefit from it, your app must declare the Bluetooth central background mode in its `Info.plist`:
+To benefit from it, your app must declare the `Uses Bluetooth LE accessories` background mode. After enabling it, in `Info.plist` you should have:
 
 ```xml
 <key>UIBackgroundModes</key>
 <array>
+  ...
   <string>bluetooth-central</string>
+  ...
 </array>
-```
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -994,6 +994,25 @@ Add the `Bluetooth` capability to the macOS app from Xcode.
 
 **Permissions are automatically requested when calling `startScan()`.** You can also manually call `requestPermissions()` if needed.
 
+#### iOS background state restoration
+
+On iOS, the central manager is created with a `CBCentralManagerOptionRestoreIdentifierKey`, so CoreBluetooth can **relaunch your app in the background** when a connected peripheral has activity, and hand the live connection back to the plugin. This happens automatically — no API call is required.
+
+To benefit from it, your app must declare the Bluetooth central background mode in its `Info.plist`:
+
+```xml
+<key>UIBackgroundModes</key>
+<array>
+  <string>bluetooth-central</string>
+</array>
+```
+
+Notes:
+
+- Without the `bluetooth-central` background mode, iOS will not relaunch the app for Bluetooth events and state restoration is effectively disabled.
+- macOS does not support CoreBluetooth state restoration; this behavior is iOS-only.
+- On relaunch, the plugin re-adopts the restored peripherals and emits `onConnectionChanged` for any that are still connected, so your Dart code can resume where it left off.
+
 ### Windows
 
 Your Bluetooth adapter needs to support at least Bluetooth 4.0. If you have more than 1 adapters, the first one returned from the system will be picked.

--- a/README.md
+++ b/README.md
@@ -996,7 +996,7 @@ Add the `Bluetooth` capability to the macOS app from Xcode.
 
 #### iOS background state restoration
 
-On iOS, the central manager is created with a `CBCentralManagerOptionRestoreIdentifierKey`, so CoreBluetooth can **relaunch your app in the background** when a connected peripheral has activity, and hand the live connection back to the plugin. This happens automatically — no API call is required.
+On iOS, the central manager is created with a `CBCentralManagerOptionRestoreIdentifierKey`, so CoreBluetooth can [relaunch your app](https://developer.apple.com/documentation/technotes/tn3115-bluetooth-state-restoration-app-relaunch-rules) in the background when a connected peripheral has activity, and hand the live connection back to the plugin. This happens automatically — no API call is required.
 
 To benefit from it, your app must declare the `Uses Bluetooth LE accessories` background mode. After enabling it, in `Info.plist` you should have:
 

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
@@ -21,6 +21,14 @@ public class UniversalBlePlugin: NSObject, FlutterPlugin {
     let peripheralCallbackChannel = UniversalBlePeripheralCallback(binaryMessenger: messenger)
     let peripheralApi = UniversalBlePeripheralPlugin(callbackChannel: peripheralCallbackChannel)
     UniversalBlePlatformChannelSetup.setUp(binaryMessenger: messenger, api: api)
+    #if os(iOS)
+      // CoreBluetooth only delivers `willRestoreState:` if the central manager is
+      // (re)created with the same restore identifier during app launch. Plugin
+      // registration runs inside `didFinishLaunchingWithOptions`, so eagerly build
+      // the manager here. This is what lets iOS relaunch the app in the background
+      // when a managed peripheral reconnects and hand back the live connection.
+      api.activateStateRestoration()
+    #endif
     UniversalBlePeripheralChannelSetup.setUp(
       binaryMessenger: messenger,
       api: peripheralApi
@@ -35,9 +43,26 @@ private var discoveredPeripherals = [String: CBPeripheral]()
 private var advertisementNameCache = [String: String]()
 
 private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentralManagerDelegate, CBPeripheralDelegate {
+  // Stable identifier CoreBluetooth uses to preserve/restore this central manager
+  // across app relaunches (iOS background state restoration).
+  static let stateRestorationIdentifier = "com.universalble.central.restoration"
+
   var callbackChannel: UniversalBleCallbackChannel
   private var universalBleFilterUtil = UniversalBleFilterUtil()
-  private lazy var manager: CBCentralManager = .init(delegate: self, queue: nil)
+  #if os(iOS)
+    // On iOS, opt into state preservation/restoration by passing a restore
+    // identifier. The delegate's `willRestoreState:` is then invoked on relaunch.
+    private lazy var manager: CBCentralManager = .init(
+      delegate: self,
+      queue: nil,
+      options: [
+        CBCentralManagerOptionRestoreIdentifierKey: BleCentralDarwin.stateRestorationIdentifier,
+      ]
+    )
+  #else
+    // macOS does not support CoreBluetooth state restoration.
+    private lazy var manager: CBCentralManager = .init(delegate: self, queue: nil)
+  #endif
   private var availabilityStateUpdateHandlers: [(Result<AvailabilityState, Error>) -> Void] = []
   private var requestPermissionStateUpdateHandlers: [(Result<Void, Error>) -> Void] = []
   private var activeServiceDiscoveries: [String: UniversalBleAsyncServiceDiscovery] = [:]
@@ -53,6 +78,13 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
   init(callbackChannel: UniversalBleCallbackChannel) {
     self.callbackChannel = callbackChannel
     super.init()
+  }
+
+  /// Forces the lazy central manager to be created during app launch so that
+  /// CoreBluetooth can deliver `centralManager(_:willRestoreState:)` when the app
+  /// is relaunched in the background by a previously connected peripheral.
+  func activateStateRestoration() {
+    _ = manager
   }
 
   func getBluetoothAvailabilityState(completion: @escaping (Result<AvailabilityState, Error>) -> Void) {
@@ -429,6 +461,29 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
       )
     }))
   }
+
+  #if os(iOS)
+    public func centralManager(_: CBCentralManager, willRestoreState dict: [String: Any]) {
+      guard let peripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral] else {
+        return
+      }
+      // Re-adopt every peripheral CoreBluetooth handed back so the existing
+      // connection stays usable: restore the delegate, repopulate the lookup cache,
+      // and keep them in the auto-connect set so disconnects trigger reconnection.
+      for peripheral in peripherals {
+        peripheral.delegate = self
+        peripheral.saveCache()
+        let deviceId = peripheral.uuid.uuidString
+        autoConnectDevices.insert(deviceId)
+        // Best-effort: surface the live state to Dart. If the Flutter side isn't
+        // listening yet (cold background relaunch), the Dart layer re-subscribes
+        // on resume using the cached peripheral, so nothing is lost.
+        if peripheral.state == .connected {
+          callbackChannel.onConnectionChanged(deviceId: deviceId, connected: true, error: nil) { _ in }
+        }
+      }
+    }
+  #endif
 
   func centralManagerDidUpdateState(_ central: CBCentralManager) {
     let state = central.state.toAvailabilityState()

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
@@ -22,11 +22,8 @@ public class UniversalBlePlugin: NSObject, FlutterPlugin {
     let peripheralApi = UniversalBlePeripheralPlugin(callbackChannel: peripheralCallbackChannel)
     UniversalBlePlatformChannelSetup.setUp(binaryMessenger: messenger, api: api)
     #if os(iOS)
-      // CoreBluetooth only delivers `willRestoreState:` if the central manager is
-      // (re)created with the same restore identifier during app launch. Plugin
-      // registration runs inside `didFinishLaunchingWithOptions`, so eagerly build
-      // the manager here. This is what lets iOS relaunch the app in the background
-      // when a managed peripheral reconnects and hand back the live connection.
+      // Build the manager during launch so CoreBluetooth can deliver
+      // `willRestoreState:` after a background relaunch (see activateStateRestoration).
       api.activateStateRestoration()
     #endif
     UniversalBlePeripheralChannelSetup.setUp(
@@ -43,15 +40,13 @@ private var discoveredPeripherals = [String: CBPeripheral]()
 private var advertisementNameCache = [String: String]()
 
 private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentralManagerDelegate, CBPeripheralDelegate {
-  // Stable identifier CoreBluetooth uses to preserve/restore this central manager
-  // across app relaunches (iOS background state restoration).
+  // Identifier CoreBluetooth uses to restore this central across relaunches.
   static let stateRestorationIdentifier = "com.universalble.central.restoration"
 
   var callbackChannel: UniversalBleCallbackChannel
   private var universalBleFilterUtil = UniversalBleFilterUtil()
   #if os(iOS)
-    // On iOS, opt into state preservation/restoration by passing a restore
-    // identifier. The delegate's `willRestoreState:` is then invoked on relaunch.
+    // iOS: opt into state restoration so `willRestoreState:` fires on relaunch.
     private lazy var manager: CBCentralManager = .init(
       delegate: self,
       queue: nil,
@@ -80,9 +75,8 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
     super.init()
   }
 
-  /// Forces the lazy central manager to be created during app launch so that
-  /// CoreBluetooth can deliver `centralManager(_:willRestoreState:)` when the app
-  /// is relaunched in the background by a previously connected peripheral.
+  /// Eagerly creates the central manager at launch so CoreBluetooth can deliver
+  /// `willRestoreState:` when a managed peripheral relaunches the app.
   func activateStateRestoration() {
     _ = manager
   }
@@ -467,18 +461,14 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
       guard let peripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral] else {
         return
       }
-      // Re-adopt every peripheral CoreBluetooth handed back so the existing
-      // connection stays usable: restore the delegate and repopulate the lookup
-      // cache. We intentionally do NOT touch the auto-connect set here — CoreBluetooth
-      // restores peripherals regardless of how they were connected, so their
-      // auto-connect intent is whatever `connect(autoConnect:)` already recorded.
+      // Re-adopt restored peripherals: restore the delegate and repopulate the
+      // lookup cache so the existing connection stays usable.
       for peripheral in peripherals {
         peripheral.delegate = self
         peripheral.saveCache()
         let deviceId = peripheral.uuid.uuidString
-        // Best-effort: surface the live state to Dart. If the Flutter side isn't
-        // listening yet (cold background relaunch), the Dart layer re-subscribes
-        // on resume using the cached peripheral, so nothing is lost.
+        // Notify Dart if already connected; on a cold relaunch the Dart layer
+        // re-subscribes on resume using the cached peripheral.
         if peripheral.state == .connected {
           callbackChannel.onConnectionChanged(deviceId: deviceId, connected: true, error: nil) { _ in }
         }

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
@@ -468,13 +468,14 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
         return
       }
       // Re-adopt every peripheral CoreBluetooth handed back so the existing
-      // connection stays usable: restore the delegate, repopulate the lookup cache,
-      // and keep them in the auto-connect set so disconnects trigger reconnection.
+      // connection stays usable: restore the delegate and repopulate the lookup
+      // cache. We intentionally do NOT touch the auto-connect set here — CoreBluetooth
+      // restores peripherals regardless of how they were connected, so their
+      // auto-connect intent is whatever `connect(autoConnect:)` already recorded.
       for peripheral in peripherals {
         peripheral.delegate = self
         peripheral.saveCache()
         let deviceId = peripheral.uuid.uuidString
-        autoConnectDevices.insert(deviceId)
         // Best-effort: surface the live state to Dart. If the Flutter side isn't
         // listening yet (cold background relaunch), the Dart layer re-subscribes
         // on resume using the cached peripheral, so nothing is lost.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -333,7 +333,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.2"
+    version: "2.0.3"
   vector_math:
     dependency: transitive
     description:
@@ -375,5 +375,5 @@ packages:
     source: hosted
     version: "6.6.1"
 sdks:
-  dart: ">=3.11.4 <4.0.0"
+  dart: ">=3.12.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
Opt the central manager into state preservation/restoration via CBCentralManagerOptionRestoreIdentifierKey and implement centralManager(_:willRestoreState:) so iOS can relaunch the app in the background when a managed peripheral reconnects and hand the live connection back. The manager is eagerly created at plugin registration (inside didFinishLaunchingWithOptions) so willRestoreState can fire.