### PR TITLE
Fix Dart primary constructor compatibility

### DIFF
--- a/example/lib/data/mock_universal_ble.dart
+++ b/example/lib/data/mock_universal_ble.dart
@@ -80,7 +80,7 @@ class MockUniversalBle extends UniversalBlePlatform {
     String deviceId,
     String service,
     String characteristic, {
-    final Duration? timeout,
+    Duration? timeout,
   }) async {
     await Future.delayed(const Duration(milliseconds: 500));
     return _serviceValue;

--- a/lib/src/interfaces/universal_ble_platform_interface.dart
+++ b/lib/src/interfaces/universal_ble_platform_interface.dart
@@ -85,7 +85,7 @@ abstract class UniversalBlePlatform {
     String deviceId,
     String service,
     String characteristic, {
-    final Duration? timeout,
+    Duration? timeout,
   });
 
   Future<void> writeValue(

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -285,7 +285,7 @@ class UniversalBle {
     String deviceId,
     String service,
     String characteristic, {
-    final Duration? timeout,
+    Duration? timeout,
   }) async {
     return await _bleCommandQueue.queueCommand(
       () => _platform.readValue(
@@ -594,7 +594,7 @@ class UniversalBle {
     String deviceId,
     String service,
     String characteristic, {
-    final Duration? timeout,
+    Duration? timeout,
   }) {
     return read(deviceId, service, characteristic, timeout: timeout);
   }

--- a/lib/src/universal_ble_linux/universal_ble_linux.dart
+++ b/lib/src/universal_ble_linux/universal_ble_linux.dart
@@ -318,7 +318,7 @@ class UniversalBleLinux extends UniversalBlePlatform {
     String deviceId,
     String service,
     String characteristic, {
-    final Duration? timeout,
+    Duration? timeout,
   }) async {
     UniversalLogger.logDebug(
       "READ -> $deviceId $service $characteristic",

--- a/lib/src/universal_ble_pigeon/universal_ble_pigeon_channel.dart
+++ b/lib/src/universal_ble_pigeon/universal_ble_pigeon_channel.dart
@@ -115,7 +115,7 @@ class UniversalBlePigeonChannel extends UniversalBlePlatform
     String deviceId,
     String service,
     String characteristic, {
-    final Duration? timeout,
+    Duration? timeout,
   }) {
     return _executeWithErrorHandling(
       () => _channel.readValue(deviceId, service, characteristic),

--- a/lib/src/universal_ble_web/universal_ble_web.dart
+++ b/lib/src/universal_ble_web/universal_ble_web.dart
@@ -259,7 +259,7 @@ class UniversalBleWeb extends UniversalBlePlatform {
     String deviceId,
     String service,
     String characteristic, {
-    final Duration? timeout,
+    Duration? timeout,
   }) async {
     UniversalLogger.logDebug(
       "READ -> $deviceId $service $characteristic",


### PR DESCRIPTION
## Summary

- Remove `final` keyword from `Duration? timeout` named parameters across all platform implementations
- Affected files: `universal_ble_platform_interface.dart`, `universal_ble.dart`, `universal_ble_linux.dart`, `universal_ble_pigeon_channel.dart`, `universal_ble_web.dart`, and the mock example
- Using `final` on named parameters is incompatible with Dart primary constructors in certain class hierarchies, causing compilation errors