### PR TITLE
Add legacy scan parameter on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.5
+* Android: stop forcing `setLegacy(false)` on scan so legacy BLE 4.x advertisements (e.g. ESP32) are discovered again; Android defaults to legacy advertising scan results
+
 ## 2.0.4
 * iOS: make Bluetooth state restoration optional by enabling it only when the `bluetooth-central` background mode is declared
 * iOS: when state restoration is enabled, init `CBCentralManager` at launch only if Bluetooth permission is granted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 2.1.0
-* Android: stop forcing `setLegacy(false)` on scan so legacy BLE 4.x advertisements (e.g. ESP32) are discovered by default; add `legacy` to `AndroidOptions` — set `legacy: false` to scan BLE 5 extended advertisements only (API 26+)
-* **Migration (Android API 26+):** If you relied on extended-advertisement scanning without `platformConfig`, pass `AndroidOptions(legacy: false)`.
+* Android: add `legacy` to `AndroidOptions` — set `legacy: true` to scan legacy BLE 4.x advertisements (e.g. ESP32) on API 26+; default (`null`/`false`) keeps extended-advertisement scanning unchanged from prior releases
 
 ## 2.0.4
 * iOS: make Bluetooth state restoration optional by enabling it only when the `bluetooth-central` background mode is declared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 2.0.5
-* Android: stop forcing `setLegacy(false)` on scan so legacy BLE 4.x advertisements (e.g. ESP32) are discovered again; Android defaults to legacy advertising scan results
+## 2.1.0
+* Android: stop forcing `setLegacy(false)` on scan so legacy BLE 4.x advertisements (e.g. ESP32) are discovered by default; add `legacy` to `AndroidOptions` — set `legacy: false` to scan BLE 5 extended advertisements only (API 26+)
+* **Migration (Android API 26+):** If you relied on extended-advertisement scanning without `platformConfig`, pass `AndroidOptions(legacy: false)`.
 
 ## 2.0.4
 * iOS: make Bluetooth state restoration optional by enabling it only when the `bluetooth-central` background mode is declared

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE
 - [Timeout](#timeout)
 - [Error Handling](#error-handling)
 - [UUID Format Agnostic](#uuid-format-agnostic)
-- [Permissions](#permissions)
+- [Platform-specific setup](#platform-specific-setup)
 - [Peripheral Mode](#peripheral-mode)
 
 ## API Support

--- a/README.md
+++ b/README.md
@@ -957,13 +957,13 @@ If your app uses peripheral advertising, add:
 
 #### Android scan options
 
-By default, legacy advertisements (BLE 4.x) are returned. Set `legacy: false` for BLE 5 extended advertisements only (API 26+).
+By default, BLE 5 extended advertisements are scanned (API 26+, unchanged from prior releases). Set `legacy: true` for legacy BLE 4.x devices (e.g. ESP32).
 
 ```dart
 UniversalBle.startScan(
   platformConfig: PlatformConfig(
     android: AndroidOptions(
-      legacy: false, // omit for legacy BLE 4.x (default)
+      legacy: true, // omit for extended BLE 5 (default)
       scanMode: AndroidScanMode.lowLatency,
       callbackType: [AndroidScanCallbackType.allMatches],
       requestLocationPermission: false,

--- a/README.md
+++ b/README.md
@@ -910,7 +910,7 @@ BleUuidParser.number(0x180A); // "0000180a-0000-1000-8000-00805f9b34fb"
 BleUuidParser.compare("180a","0000180A-0000-1000-8000-00805F9B34FB"); // true
 ```
 
-## Permissions
+## Platform-specific setup
 
 You need to perform the following setups:
 
@@ -953,6 +953,23 @@ If your app uses peripheral advertising, add:
 
 ```xml
 <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+```
+
+#### Android scan options
+
+By default, legacy advertisements (BLE 4.x) are returned. Set `legacy: false` for BLE 5 extended advertisements only (API 26+).
+
+```dart
+UniversalBle.startScan(
+  platformConfig: PlatformConfig(
+    android: AndroidOptions(
+      legacy: false, // omit for legacy BLE 4.x (default)
+      scanMode: AndroidScanMode.lowLatency,
+      callbackType: [AndroidScanCallbackType.allMatches],
+      requestLocationPermission: false,
+    ),
+  ),
+);
 ```
 
 #### Background Scanning (ForegroundTask)
@@ -1076,7 +1093,7 @@ UniversalBle.requestPermissions(
 );
 ```
 
-> **Note**: When calling `startScan()`, permissions are automatically requested. To configure location permission requests during scanning, use the `platformConfig` parameter:
+> **Note**: When calling `startScan()`, permissions are automatically requested. To configure location permission requests during scanning, use `requestLocationPermission` on `AndroidOptions` (see [Android scan options](#android-scan-options)):
 
 ```dart
 UniversalBle.startScan(

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBle.g.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBle.g.kt
@@ -739,9 +739,10 @@ data class BleConnectionParametersUpdated (
  * logged); see the [AndroidScanCallbackType] doc for per-value API levels.
  *
  * [legacy] controls whether only legacy advertisements (BLE 4.2 and below) are
- * returned. When `null` or `true`, the plugin leaves Android's default (legacy
- * advertisements). Set to `false` to scan for BLE 5 extended advertisements
- * only; on API 26+ the plugin also sets `PHY_LE_ALL_SUPPORTED` in that case.
+ * returned (API 26+). When `null` or `false`, the plugin scans for BLE 5
+ * extended advertisements only (the library default, unchanged from prior
+ * releases). Set to `true` for legacy BLE 4.x advertisements (e.g. ESP32); on
+ * API 26+ the plugin sets `setLegacy(true)` and does not set `PHY`.
  *
  * See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
  *

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBle.g.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBle.g.kt
@@ -738,6 +738,11 @@ data class BleConnectionParametersUpdated (
  * require a newer API than the device supports are silently dropped (and
  * logged); see the [AndroidScanCallbackType] doc for per-value API levels.
  *
+ * [legacy] controls whether only legacy advertisements (BLE 4.2 and below) are
+ * returned. When `null` or `true`, the plugin leaves Android's default (legacy
+ * advertisements). Set to `false` to scan for BLE 5 extended advertisements
+ * only; on API 26+ the plugin also sets `PHY_LE_ALL_SUPPORTED` in that case.
+ *
  * See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
  *
  * Generated class from Pigeon that represents data sent in messages.
@@ -748,7 +753,8 @@ data class AndroidOptions (
   val reportDelayMillis: Long? = null,
   val callbackType: List<AndroidScanCallbackType>? = null,
   val matchMode: AndroidScanMatchMode? = null,
-  val numOfMatches: AndroidScanNumOfMatches? = null
+  val numOfMatches: AndroidScanNumOfMatches? = null,
+  val legacy: Boolean? = null
 )
  {
   companion object {
@@ -759,7 +765,8 @@ data class AndroidOptions (
       val callbackType = pigeonVar_list[3] as List<AndroidScanCallbackType>?
       val matchMode = pigeonVar_list[4] as AndroidScanMatchMode?
       val numOfMatches = pigeonVar_list[5] as AndroidScanNumOfMatches?
-      return AndroidOptions(requestLocationPermission, scanMode, reportDelayMillis, callbackType, matchMode, numOfMatches)
+      val legacy = pigeonVar_list[6] as Boolean?
+      return AndroidOptions(requestLocationPermission, scanMode, reportDelayMillis, callbackType, matchMode, numOfMatches, legacy)
     }
   }
   fun toList(): List<Any?> {
@@ -770,6 +777,7 @@ data class AndroidOptions (
       callbackType,
       matchMode,
       numOfMatches,
+      legacy,
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -780,7 +788,7 @@ data class AndroidOptions (
       return true
     }
     val other = other as AndroidOptions
-    return UniversalBlePigeonUtils.deepEquals(this.requestLocationPermission, other.requestLocationPermission) && UniversalBlePigeonUtils.deepEquals(this.scanMode, other.scanMode) && UniversalBlePigeonUtils.deepEquals(this.reportDelayMillis, other.reportDelayMillis) && UniversalBlePigeonUtils.deepEquals(this.callbackType, other.callbackType) && UniversalBlePigeonUtils.deepEquals(this.matchMode, other.matchMode) && UniversalBlePigeonUtils.deepEquals(this.numOfMatches, other.numOfMatches)
+    return UniversalBlePigeonUtils.deepEquals(this.requestLocationPermission, other.requestLocationPermission) && UniversalBlePigeonUtils.deepEquals(this.scanMode, other.scanMode) && UniversalBlePigeonUtils.deepEquals(this.reportDelayMillis, other.reportDelayMillis) && UniversalBlePigeonUtils.deepEquals(this.callbackType, other.callbackType) && UniversalBlePigeonUtils.deepEquals(this.matchMode, other.matchMode) && UniversalBlePigeonUtils.deepEquals(this.numOfMatches, other.numOfMatches) && UniversalBlePigeonUtils.deepEquals(this.legacy, other.legacy)
   }
 
   override fun hashCode(): Int {
@@ -791,6 +799,7 @@ data class AndroidOptions (
     result = 31 * result + UniversalBlePigeonUtils.deepHash(this.callbackType)
     result = 31 * result + UniversalBlePigeonUtils.deepHash(this.matchMode)
     result = 31 * result + UniversalBlePigeonUtils.deepHash(this.numOfMatches)
+    result = 31 * result + UniversalBlePigeonUtils.deepHash(this.legacy)
     return result
   }
 }

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -181,10 +181,6 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
         )
 
         val builder = ScanSettings.Builder()
-        if (Build.VERSION.SDK_INT >= 26) {
-            builder.setPhy(ScanSettings.PHY_LE_ALL_SUPPORTED)
-            builder.setLegacy(false)
-        }
         config?.android?.let { androidConfig ->
             androidConfig.scanMode?.parse()?.let { scanMode ->
                 builder.setScanMode(scanMode)

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -181,17 +181,13 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
         )
 
         val builder = ScanSettings.Builder()
+        val legacy = config?.android?.legacy
         config?.android?.let { androidConfig ->
             androidConfig.scanMode?.parse()?.let { scanMode ->
                 builder.setScanMode(scanMode)
             }
             androidConfig.reportDelayMillis?.let { reportDelay ->
                 builder.setReportDelay(reportDelay)
-            }
-
-            if (Build.VERSION.SDK_INT >= 26 && androidConfig.legacy == false) {
-                builder.setPhy(ScanSettings.PHY_LE_ALL_SUPPORTED)
-                builder.setLegacy(false)
             }
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
@@ -201,6 +197,14 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
                 }
                 androidConfig.matchMode?.parse()?.let { builder.setMatchMode(it) }
                 androidConfig.numOfMatches?.parse()?.let { builder.setNumOfMatches(it) }
+            }
+        }
+        if (Build.VERSION.SDK_INT >= 26) {
+            if (legacy == true) {
+                builder.setLegacy(true)
+            } else {
+                builder.setPhy(ScanSettings.PHY_LE_ALL_SUPPORTED)
+                builder.setLegacy(false)
             }
         }
         val settings = builder.build()

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -189,6 +189,11 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
                 builder.setReportDelay(reportDelay)
             }
 
+            if (Build.VERSION.SDK_INT >= 26 && androidConfig.legacy == false) {
+                builder.setPhy(ScanSettings.PHY_LE_ALL_SUPPORTED)
+                builder.setLegacy(false)
+            }
+
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 androidConfig.callbackType?.let { types ->
                     val combined = types.mapNotNull { it.parse() }.fold(0) { acc, v -> acc or v }

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBle.g.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBle.g.swift
@@ -619,6 +619,11 @@ struct BleConnectionParametersUpdated: Hashable {
 /// require a newer API than the device supports are silently dropped (and
 /// logged); see the [AndroidScanCallbackType] doc for per-value API levels.
 ///
+/// [legacy] controls whether only legacy advertisements (BLE 4.2 and below) are
+/// returned. When `null` or `true`, the plugin leaves Android's default (legacy
+/// advertisements). Set to `false` to scan for BLE 5 extended advertisements
+/// only; on API 26+ the plugin also sets `PHY_LE_ALL_SUPPORTED` in that case.
+///
 /// See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
 ///
 /// Generated class from Pigeon that represents data sent in messages.
@@ -629,6 +634,7 @@ struct AndroidOptions: Hashable {
   var callbackType: [AndroidScanCallbackType]? = nil
   var matchMode: AndroidScanMatchMode? = nil
   var numOfMatches: AndroidScanNumOfMatches? = nil
+  var legacy: Bool? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -639,6 +645,7 @@ struct AndroidOptions: Hashable {
     let callbackType: [AndroidScanCallbackType]? = nilOrValue(pigeonVar_list[3])
     let matchMode: AndroidScanMatchMode? = nilOrValue(pigeonVar_list[4])
     let numOfMatches: AndroidScanNumOfMatches? = nilOrValue(pigeonVar_list[5])
+    let legacy: Bool? = nilOrValue(pigeonVar_list[6])
 
     return AndroidOptions(
       requestLocationPermission: requestLocationPermission,
@@ -646,7 +653,8 @@ struct AndroidOptions: Hashable {
       reportDelayMillis: reportDelayMillis,
       callbackType: callbackType,
       matchMode: matchMode,
-      numOfMatches: numOfMatches
+      numOfMatches: numOfMatches,
+      legacy: legacy
     )
   }
   func toList() -> [Any?] {
@@ -657,13 +665,14 @@ struct AndroidOptions: Hashable {
       callbackType,
       matchMode,
       numOfMatches,
+      legacy,
     ]
   }
   static func == (lhs: AndroidOptions, rhs: AndroidOptions) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsUniversalBle(lhs.requestLocationPermission, rhs.requestLocationPermission) && deepEqualsUniversalBle(lhs.scanMode, rhs.scanMode) && deepEqualsUniversalBle(lhs.reportDelayMillis, rhs.reportDelayMillis) && deepEqualsUniversalBle(lhs.callbackType, rhs.callbackType) && deepEqualsUniversalBle(lhs.matchMode, rhs.matchMode) && deepEqualsUniversalBle(lhs.numOfMatches, rhs.numOfMatches)
+    return deepEqualsUniversalBle(lhs.requestLocationPermission, rhs.requestLocationPermission) && deepEqualsUniversalBle(lhs.scanMode, rhs.scanMode) && deepEqualsUniversalBle(lhs.reportDelayMillis, rhs.reportDelayMillis) && deepEqualsUniversalBle(lhs.callbackType, rhs.callbackType) && deepEqualsUniversalBle(lhs.matchMode, rhs.matchMode) && deepEqualsUniversalBle(lhs.numOfMatches, rhs.numOfMatches) && deepEqualsUniversalBle(lhs.legacy, rhs.legacy)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -674,6 +683,7 @@ struct AndroidOptions: Hashable {
     deepHashUniversalBle(value: callbackType, hasher: &hasher)
     deepHashUniversalBle(value: matchMode, hasher: &hasher)
     deepHashUniversalBle(value: numOfMatches, hasher: &hasher)
+    deepHashUniversalBle(value: legacy, hasher: &hasher)
   }
 }
 

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBle.g.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBle.g.swift
@@ -620,9 +620,10 @@ struct BleConnectionParametersUpdated: Hashable {
 /// logged); see the [AndroidScanCallbackType] doc for per-value API levels.
 ///
 /// [legacy] controls whether only legacy advertisements (BLE 4.2 and below) are
-/// returned. When `null` or `true`, the plugin leaves Android's default (legacy
-/// advertisements). Set to `false` to scan for BLE 5 extended advertisements
-/// only; on API 26+ the plugin also sets `PHY_LE_ALL_SUPPORTED` in that case.
+/// returned (API 26+). When `null` or `false`, the plugin scans for BLE 5
+/// extended advertisements only (the library default, unchanged from prior
+/// releases). Set to `true` for legacy BLE 4.x advertisements (e.g. ESP32); on
+/// API 26+ the plugin sets `setLegacy(true)` and does not set `PHY`.
 ///
 /// See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
 ///

--- a/example/lib/home/widgets/android_scan_options_widget.dart
+++ b/example/lib/home/widgets/android_scan_options_widget.dart
@@ -131,8 +131,8 @@ class _AndroidScanOptionsWidgetState extends State<AndroidScanOptionsWidget> {
             const SizedBox(height: 16),
             _SectionTitle('legacy'),
             const Text(
-              'null/true: legacy BLE 4.x advertisements (Android default). '
-              'false: BLE 5 extended advertisements only (API 26+).',
+              'null/false: BLE 5 extended advertisements (library default). '
+              'true: legacy BLE 4.x advertisements (API 26+).',
             ),
             const SizedBox(height: 8),
             _SingleSelect<bool>(

--- a/example/lib/home/widgets/android_scan_options_widget.dart
+++ b/example/lib/home/widgets/android_scan_options_widget.dart
@@ -26,6 +26,7 @@ class _AndroidScanOptionsWidgetState extends State<AndroidScanOptionsWidget> {
   final Set<AndroidScanCallbackType> _callbackType = {};
   AndroidScanMatchMode? _matchMode;
   AndroidScanNumOfMatches? _numOfMatches;
+  bool? _legacy;
 
   @override
   void initState() {
@@ -37,6 +38,7 @@ class _AndroidScanOptionsWidgetState extends State<AndroidScanOptionsWidget> {
       _callbackType.addAll(initial.callbackType ?? const []);
       _matchMode = initial.matchMode;
       _numOfMatches = initial.numOfMatches;
+      _legacy = initial.legacy;
     }
   }
 
@@ -53,7 +55,8 @@ class _AndroidScanOptionsWidgetState extends State<AndroidScanOptionsWidget> {
         reportDelay != null ||
         _callbackType.isNotEmpty ||
         _matchMode != null ||
-        _numOfMatches != null;
+        _numOfMatches != null ||
+        _legacy != null;
     if (!hasAny) return null;
     return AndroidOptions(
       scanMode: _scanMode,
@@ -62,6 +65,7 @@ class _AndroidScanOptionsWidgetState extends State<AndroidScanOptionsWidget> {
           _callbackType.isEmpty ? null : _callbackType.toList(growable: false),
       matchMode: _matchMode,
       numOfMatches: _numOfMatches,
+      legacy: _legacy,
     );
   }
 
@@ -125,6 +129,19 @@ class _AndroidScanOptionsWidgetState extends State<AndroidScanOptionsWidget> {
                   .toList(growable: false),
             ),
             const SizedBox(height: 16),
+            _SectionTitle('legacy'),
+            const Text(
+              'null/true: legacy BLE 4.x advertisements (Android default). '
+              'false: BLE 5 extended advertisements only (API 26+).',
+            ),
+            const SizedBox(height: 8),
+            _SingleSelect<bool>(
+              values: const [true, false],
+              selected: _legacy,
+              label: (v) => v ? 'true' : 'false',
+              onChanged: (v) => setState(() => _legacy = v),
+            ),
+            const SizedBox(height: 16),
             _SectionTitle('matchMode'),
             _SingleSelect<AndroidScanMatchMode>(
               values: AndroidScanMatchMode.values,
@@ -153,6 +170,7 @@ class _AndroidScanOptionsWidgetState extends State<AndroidScanOptionsWidget> {
                         _callbackType.clear();
                         _matchMode = null;
                         _numOfMatches = null;
+                        _legacy = null;
                       });
                       widget.onChanged(null);
                     },

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -333,7 +333,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.3"
+    version: "2.1.0"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/universal_ble.g.dart
+++ b/lib/src/universal_ble.g.dart
@@ -562,9 +562,10 @@ class BleConnectionParametersUpdated {
 /// logged); see the [AndroidScanCallbackType] doc for per-value API levels.
 ///
 /// [legacy] controls whether only legacy advertisements (BLE 4.2 and below) are
-/// returned. When `null` or `true`, the plugin leaves Android's default (legacy
-/// advertisements). Set to `false` to scan for BLE 5 extended advertisements
-/// only; on API 26+ the plugin also sets `PHY_LE_ALL_SUPPORTED` in that case.
+/// returned (API 26+). When `null` or `false`, the plugin scans for BLE 5
+/// extended advertisements only (the library default, unchanged from prior
+/// releases). Set to `true` for legacy BLE 4.x advertisements (e.g. ESP32); on
+/// API 26+ the plugin sets `setLegacy(true)` and does not set `PHY`.
 ///
 /// See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
 class AndroidOptions {

--- a/lib/src/universal_ble.g.dart
+++ b/lib/src/universal_ble.g.dart
@@ -561,6 +561,11 @@ class BleConnectionParametersUpdated {
 /// require a newer API than the device supports are silently dropped (and
 /// logged); see the [AndroidScanCallbackType] doc for per-value API levels.
 ///
+/// [legacy] controls whether only legacy advertisements (BLE 4.2 and below) are
+/// returned. When `null` or `true`, the plugin leaves Android's default (legacy
+/// advertisements). Set to `false` to scan for BLE 5 extended advertisements
+/// only; on API 26+ the plugin also sets `PHY_LE_ALL_SUPPORTED` in that case.
+///
 /// See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
 class AndroidOptions {
   AndroidOptions({
@@ -570,6 +575,7 @@ class AndroidOptions {
     this.callbackType,
     this.matchMode,
     this.numOfMatches,
+    this.legacy,
   });
 
   bool? requestLocationPermission;
@@ -584,6 +590,8 @@ class AndroidOptions {
 
   AndroidScanNumOfMatches? numOfMatches;
 
+  bool? legacy;
+
   List<Object?> _toList() {
     return <Object?>[
       requestLocationPermission,
@@ -592,6 +600,7 @@ class AndroidOptions {
       callbackType,
       matchMode,
       numOfMatches,
+      legacy,
     ];
   }
 
@@ -609,6 +618,7 @@ class AndroidOptions {
           ?.cast<AndroidScanCallbackType>(),
       matchMode: result[4] as AndroidScanMatchMode?,
       numOfMatches: result[5] as AndroidScanNumOfMatches?,
+      legacy: result[6] as bool?,
     );
   }
 
@@ -629,7 +639,8 @@ class AndroidOptions {
         _deepEquals(reportDelayMillis, other.reportDelayMillis) &&
         _deepEquals(callbackType, other.callbackType) &&
         _deepEquals(matchMode, other.matchMode) &&
-        _deepEquals(numOfMatches, other.numOfMatches);
+        _deepEquals(numOfMatches, other.numOfMatches) &&
+        _deepEquals(legacy, other.legacy);
   }
 
   @override

--- a/pigeon/universal_ble.dart
+++ b/pigeon/universal_ble.dart
@@ -186,6 +186,11 @@ class BleConnectionParametersUpdated {
 /// require a newer API than the device supports are silently dropped (and
 /// logged); see the [AndroidScanCallbackType] doc for per-value API levels.
 ///
+/// [legacy] controls whether only legacy advertisements (BLE 4.2 and below) are
+/// returned. When `null` or `true`, the plugin leaves Android's default (legacy
+/// advertisements). Set to `false` to scan for BLE 5 extended advertisements
+/// only; on API 26+ the plugin also sets `PHY_LE_ALL_SUPPORTED` in that case.
+///
 /// See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
 class AndroidOptions {
   bool? requestLocationPermission;
@@ -194,6 +199,7 @@ class AndroidOptions {
   List<AndroidScanCallbackType>? callbackType;
   AndroidScanMatchMode? matchMode;
   AndroidScanNumOfMatches? numOfMatches;
+  bool? legacy;
   AndroidOptions({
     this.requestLocationPermission,
     this.scanMode,
@@ -201,6 +207,7 @@ class AndroidOptions {
     this.callbackType,
     this.matchMode,
     this.numOfMatches,
+    this.legacy,
   });
 }
 

--- a/pigeon/universal_ble.dart
+++ b/pigeon/universal_ble.dart
@@ -187,9 +187,10 @@ class BleConnectionParametersUpdated {
 /// logged); see the [AndroidScanCallbackType] doc for per-value API levels.
 ///
 /// [legacy] controls whether only legacy advertisements (BLE 4.2 and below) are
-/// returned. When `null` or `true`, the plugin leaves Android's default (legacy
-/// advertisements). Set to `false` to scan for BLE 5 extended advertisements
-/// only; on API 26+ the plugin also sets `PHY_LE_ALL_SUPPORTED` in that case.
+/// returned (API 26+). When `null` or `false`, the plugin scans for BLE 5
+/// extended advertisements only (the library default, unchanged from prior
+/// releases). Set to `true` for legacy BLE 4.x advertisements (e.g. ESP32); on
+/// API 26+ the plugin sets `setLegacy(true)` and does not set `PHY`.
 ///
 /// See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
 class AndroidOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: universal_ble
 description: A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE) plugin for Flutter
-version: 2.0.4
+version: 2.0.5
 homepage: https://navideck.com
 repository: https://github.com/Navideck/universal_ble
 issue_tracker: https://github.com/Navideck/universal_ble/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: universal_ble
 description: A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE) plugin for Flutter
-version: 2.0.5
+version: 2.1.0
 homepage: https://navideck.com
 repository: https://github.com/Navideck/universal_ble
 issue_tracker: https://github.com/Navideck/universal_ble/issues

--- a/test/android_options_test.dart
+++ b/test/android_options_test.dart
@@ -10,11 +10,13 @@ void main() {
         callbackType: [AndroidScanCallbackType.allMatches],
         matchMode: AndroidScanMatchMode.aggressive,
         numOfMatches: AndroidScanNumOfMatches.max,
+        legacy: false,
       );
 
       expect(options.callbackType, [AndroidScanCallbackType.allMatches]);
       expect(options.matchMode, AndroidScanMatchMode.aggressive);
       expect(options.numOfMatches, AndroidScanNumOfMatches.max);
+      expect(options.legacy, false);
     });
 
     test('round-trips a multi-value callbackType through the pigeon codec', () {
@@ -28,6 +30,7 @@ void main() {
         ],
         matchMode: AndroidScanMatchMode.sticky,
         numOfMatches: AndroidScanNumOfMatches.few,
+        legacy: true,
       );
 
       final decoded = AndroidOptions.decode(original.encode());
@@ -41,6 +44,7 @@ void main() {
       expect(decoded.scanMode, AndroidScanMode.lowLatency);
       expect(decoded.reportDelayMillis, 0);
       expect(decoded.requestLocationPermission, true);
+      expect(decoded.legacy, true);
     });
 
     test('leaves the new fields null by default', () {
@@ -49,6 +53,7 @@ void main() {
       expect(options.callbackType, isNull);
       expect(options.matchMode, isNull);
       expect(options.numOfMatches, isNull);
+      expect(options.legacy, isNull);
     });
   });
 }

--- a/windows/src/generated/universal_ble.g.cpp
+++ b/windows/src/generated/universal_ble.g.cpp
@@ -722,13 +722,15 @@ AndroidOptions::AndroidOptions(
   const int64_t* report_delay_millis,
   const EncodableList* callback_type,
   const AndroidScanMatchMode* match_mode,
-  const AndroidScanNumOfMatches* num_of_matches)
+  const AndroidScanNumOfMatches* num_of_matches,
+  const bool* legacy)
  : request_location_permission_(request_location_permission ? std::optional<bool>(*request_location_permission) : std::nullopt),
     scan_mode_(scan_mode ? std::optional<AndroidScanMode>(*scan_mode) : std::nullopt),
     report_delay_millis_(report_delay_millis ? std::optional<int64_t>(*report_delay_millis) : std::nullopt),
     callback_type_(callback_type ? std::optional<EncodableList>(*callback_type) : std::nullopt),
     match_mode_(match_mode ? std::optional<AndroidScanMatchMode>(*match_mode) : std::nullopt),
-    num_of_matches_(num_of_matches ? std::optional<AndroidScanNumOfMatches>(*num_of_matches) : std::nullopt) {}
+    num_of_matches_(num_of_matches ? std::optional<AndroidScanNumOfMatches>(*num_of_matches) : std::nullopt),
+    legacy_(legacy ? std::optional<bool>(*legacy) : std::nullopt) {}
 
 const bool* AndroidOptions::request_location_permission() const {
   return request_location_permission_ ? &(*request_location_permission_) : nullptr;
@@ -808,15 +810,29 @@ void AndroidOptions::set_num_of_matches(const AndroidScanNumOfMatches& value_arg
 }
 
 
+const bool* AndroidOptions::legacy() const {
+  return legacy_ ? &(*legacy_) : nullptr;
+}
+
+void AndroidOptions::set_legacy(const bool* value_arg) {
+  legacy_ = value_arg ? std::optional<bool>(*value_arg) : std::nullopt;
+}
+
+void AndroidOptions::set_legacy(bool value_arg) {
+  legacy_ = value_arg;
+}
+
+
 EncodableList AndroidOptions::ToEncodableList() const {
   EncodableList list;
-  list.reserve(6);
+  list.reserve(7);
   list.push_back(request_location_permission_ ? EncodableValue(*request_location_permission_) : EncodableValue());
   list.push_back(scan_mode_ ? CustomEncodableValue(*scan_mode_) : EncodableValue());
   list.push_back(report_delay_millis_ ? EncodableValue(*report_delay_millis_) : EncodableValue());
   list.push_back(callback_type_ ? EncodableValue(*callback_type_) : EncodableValue());
   list.push_back(match_mode_ ? CustomEncodableValue(*match_mode_) : EncodableValue());
   list.push_back(num_of_matches_ ? CustomEncodableValue(*num_of_matches_) : EncodableValue());
+  list.push_back(legacy_ ? EncodableValue(*legacy_) : EncodableValue());
   return list;
 }
 
@@ -846,11 +862,15 @@ AndroidOptions AndroidOptions::FromEncodableList(const EncodableList& list) {
   if (!encodable_num_of_matches.IsNull()) {
     decoded.set_num_of_matches(std::any_cast<const AndroidScanNumOfMatches&>(std::get<CustomEncodableValue>(encodable_num_of_matches)));
   }
+  auto& encodable_legacy = list[6];
+  if (!encodable_legacy.IsNull()) {
+    decoded.set_legacy(std::get<bool>(encodable_legacy));
+  }
   return decoded;
 }
 
 bool AndroidOptions::operator==(const AndroidOptions& other) const {
-  return PigeonInternalDeepEquals(request_location_permission_, other.request_location_permission_) && PigeonInternalDeepEquals(scan_mode_, other.scan_mode_) && PigeonInternalDeepEquals(report_delay_millis_, other.report_delay_millis_) && PigeonInternalDeepEquals(callback_type_, other.callback_type_) && PigeonInternalDeepEquals(match_mode_, other.match_mode_) && PigeonInternalDeepEquals(num_of_matches_, other.num_of_matches_);
+  return PigeonInternalDeepEquals(request_location_permission_, other.request_location_permission_) && PigeonInternalDeepEquals(scan_mode_, other.scan_mode_) && PigeonInternalDeepEquals(report_delay_millis_, other.report_delay_millis_) && PigeonInternalDeepEquals(callback_type_, other.callback_type_) && PigeonInternalDeepEquals(match_mode_, other.match_mode_) && PigeonInternalDeepEquals(num_of_matches_, other.num_of_matches_) && PigeonInternalDeepEquals(legacy_, other.legacy_);
 }
 
 bool AndroidOptions::operator!=(const AndroidOptions& other) const {
@@ -865,6 +885,7 @@ size_t AndroidOptions::Hash() const {
   result = result * 31 + PigeonInternalDeepHash(callback_type_);
   result = result * 31 + PigeonInternalDeepHash(match_mode_);
   result = result * 31 + PigeonInternalDeepHash(num_of_matches_);
+  result = result * 31 + PigeonInternalDeepHash(legacy_);
   return result;
 }
 

--- a/windows/src/generated/universal_ble.g.h
+++ b/windows/src/generated/universal_ble.g.h
@@ -495,6 +495,11 @@ class BleConnectionParametersUpdated {
 // require a newer API than the device supports are silently dropped (and
 // logged); see the [AndroidScanCallbackType] doc for per-value API levels.
 //
+// [legacy] controls whether only legacy advertisements (BLE 4.2 and below) are
+// returned. When `null` or `true`, the plugin leaves Android's default (legacy
+// advertisements). Set to `false` to scan for BLE 5 extended advertisements
+// only; on API 26+ the plugin also sets `PHY_LE_ALL_SUPPORTED` in that case.
+//
 // See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
 //
 // Generated class from Pigeon that represents data sent in messages.
@@ -510,7 +515,8 @@ class AndroidOptions {
     const int64_t* report_delay_millis,
     const ::flutter::EncodableList* callback_type,
     const AndroidScanMatchMode* match_mode,
-    const AndroidScanNumOfMatches* num_of_matches);
+    const AndroidScanNumOfMatches* num_of_matches,
+    const bool* legacy);
 
   const bool* request_location_permission() const;
   void set_request_location_permission(const bool* value_arg);
@@ -536,6 +542,10 @@ class AndroidOptions {
   void set_num_of_matches(const AndroidScanNumOfMatches* value_arg);
   void set_num_of_matches(const AndroidScanNumOfMatches& value_arg);
 
+  const bool* legacy() const;
+  void set_legacy(const bool* value_arg);
+  void set_legacy(bool value_arg);
+
   bool operator==(const AndroidOptions& other) const;
   bool operator!=(const AndroidOptions& other) const;
   /// Returns a hash code value for the object. This method is supported for the benefit of hash tables.
@@ -556,6 +566,7 @@ class AndroidOptions {
   std::optional<::flutter::EncodableList> callback_type_;
   std::optional<AndroidScanMatchMode> match_mode_;
   std::optional<AndroidScanNumOfMatches> num_of_matches_;
+  std::optional<bool> legacy_;
 };
 
 

--- a/windows/src/generated/universal_ble.g.h
+++ b/windows/src/generated/universal_ble.g.h
@@ -496,9 +496,10 @@ class BleConnectionParametersUpdated {
 // logged); see the [AndroidScanCallbackType] doc for per-value API levels.
 //
 // [legacy] controls whether only legacy advertisements (BLE 4.2 and below) are
-// returned. When `null` or `true`, the plugin leaves Android's default (legacy
-// advertisements). Set to `false` to scan for BLE 5 extended advertisements
-// only; on API 26+ the plugin also sets `PHY_LE_ALL_SUPPORTED` in that case.
+// returned (API 26+). When `null` or `false`, the plugin scans for BLE 5
+// extended advertisements only (the library default, unchanged from prior
+// releases). Set to `true` for legacy BLE 4.x advertisements (e.g. ESP32); on
+// API 26+ the plugin sets `setLegacy(true)` and does not set `PHY`.
 //
 // See https://developer.android.com/reference/android/bluetooth/le/ScanSettings
 //


### PR DESCRIPTION
Android now has a `legacy` parameter for scan which can be set to `true` so that legacy BLE 4.x advertisements can be discovered.