### PR TITLE
Add PeripheralAndroidOptions.addServicesInScanResponse

### DIFF
--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBle.g.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBle.g.kt
@@ -970,18 +970,29 @@ data class UniversalManufacturerData (
 
 /** Generated class from Pigeon that represents data sent in messages. */
 data class PeripheralAndroidOptions (
-  val addManufacturerDataInScanResponse: Boolean? = null
+  val addManufacturerDataInScanResponse: Boolean? = null,
+  /**
+   * Put advertised service UUIDs in the scan response instead of the primary
+   * advertisement. The Android primary advertisement is capped at 31 bytes;
+   * a 128-bit service UUID (18 bytes) plus a device name can overflow it
+   * ("ADVERTISE_FAILED_DATA_TOO_LARGE"). Moving the UUIDs to the scan
+   * response keeps them discoverable to active scanners while freeing the
+   * primary packet.
+   */
+  val addServicesInScanResponse: Boolean? = null
 )
  {
   companion object {
     fun fromList(pigeonVar_list: List<Any?>): PeripheralAndroidOptions {
       val addManufacturerDataInScanResponse = pigeonVar_list[0] as Boolean?
-      return PeripheralAndroidOptions(addManufacturerDataInScanResponse)
+      val addServicesInScanResponse = pigeonVar_list[1] as Boolean?
+      return PeripheralAndroidOptions(addManufacturerDataInScanResponse, addServicesInScanResponse)
     }
   }
   fun toList(): List<Any?> {
     return listOf(
       addManufacturerDataInScanResponse,
+      addServicesInScanResponse,
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -992,12 +1003,13 @@ data class PeripheralAndroidOptions (
       return true
     }
     val other = other as PeripheralAndroidOptions
-    return UniversalBlePigeonUtils.deepEquals(this.addManufacturerDataInScanResponse, other.addManufacturerDataInScanResponse)
+    return UniversalBlePigeonUtils.deepEquals(this.addManufacturerDataInScanResponse, other.addManufacturerDataInScanResponse) && UniversalBlePigeonUtils.deepEquals(this.addServicesInScanResponse, other.addServicesInScanResponse)
   }
 
   override fun hashCode(): Int {
     var result = javaClass.hashCode()
     result = 31 * result + UniversalBlePigeonUtils.deepHash(this.addManufacturerDataInScanResponse)
+    result = 31 * result + UniversalBlePigeonUtils.deepHash(this.addServicesInScanResponse)
     return result
   }
 }

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePeripheralPlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePeripheralPlugin.kt
@@ -151,10 +151,9 @@ class UniversalBlePeripheralPlugin(
                 .setIncludeDeviceName(localName != null)
             val scanResponseBuilder = AdvertiseData.Builder()
                 .setIncludeTxPowerLevel(false)
-                // When the scan response also carries the service UUIDs, keep the
-                // device name out of it: a name plus a 128-bit UUID can overflow
-                // the 31-byte scan response just like the primary advertisement.
-                .setIncludeDeviceName(localName != null && !addServicesInScanResponse)
+// Device name is already included in the primary advertisement when localName != null.
+// Keeping it out of the scan response saves space for manufacturer data / service UUIDs.
+.setIncludeDeviceName(false)
             val addManufacturerDataInScanResponse =
                 platformConfig?.android?.addManufacturerDataInScanResponse == true
 

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePeripheralPlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePeripheralPlugin.kt
@@ -144,12 +144,17 @@ class UniversalBlePeripheralPlugin(
                 .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
                 .build()
 
+            val addServicesInScanResponse =
+                platformConfig?.android?.addServicesInScanResponse == true
             val advertiseDataBuilder = AdvertiseData.Builder()
                 .setIncludeTxPowerLevel(false)
                 .setIncludeDeviceName(localName != null)
             val scanResponseBuilder = AdvertiseData.Builder()
                 .setIncludeTxPowerLevel(false)
-                .setIncludeDeviceName(localName != null)
+                // When the scan response also carries the service UUIDs, keep the
+                // device name out of it: a name plus a 128-bit UUID can overflow
+                // the 31-byte scan response just like the primary advertisement.
+                .setIncludeDeviceName(localName != null && !addServicesInScanResponse)
             val addManufacturerDataInScanResponse =
                 platformConfig?.android?.addManufacturerDataInScanResponse == true
 
@@ -166,7 +171,8 @@ class UniversalBlePeripheralPlugin(
                     )
                 }
             }
-            services.forEach { advertiseDataBuilder.addServiceUuid(ParcelUuid.fromString(it)) }
+            val servicesBuilder = if (addServicesInScanResponse) scanResponseBuilder else advertiseDataBuilder
+            services.forEach { servicesBuilder.addServiceUuid(ParcelUuid.fromString(it)) }
 
             bluetoothLeAdvertiser?.startAdvertising(
                 advertiseSettings,

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBle.g.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBle.g.swift
@@ -845,31 +845,42 @@ struct UniversalManufacturerData: Hashable {
 /// Generated class from Pigeon that represents data sent in messages.
 struct PeripheralAndroidOptions: Hashable {
   var addManufacturerDataInScanResponse: Bool? = nil
+  /// Put advertised service UUIDs in the scan response instead of the primary
+  /// advertisement. The Android primary advertisement is capped at 31 bytes;
+  /// a 128-bit service UUID (18 bytes) plus a device name can overflow it
+  /// ("ADVERTISE_FAILED_DATA_TOO_LARGE"). Moving the UUIDs to the scan
+  /// response keeps them discoverable to active scanners while freeing the
+  /// primary packet.
+  var addServicesInScanResponse: Bool? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> PeripheralAndroidOptions? {
     let addManufacturerDataInScanResponse: Bool? = nilOrValue(pigeonVar_list[0])
+    let addServicesInScanResponse: Bool? = nilOrValue(pigeonVar_list[1])
 
     return PeripheralAndroidOptions(
-      addManufacturerDataInScanResponse: addManufacturerDataInScanResponse
+      addManufacturerDataInScanResponse: addManufacturerDataInScanResponse,
+      addServicesInScanResponse: addServicesInScanResponse
     )
   }
   func toList() -> [Any?] {
     return [
-      addManufacturerDataInScanResponse
+      addManufacturerDataInScanResponse,
+      addServicesInScanResponse,
     ]
   }
   static func == (lhs: PeripheralAndroidOptions, rhs: PeripheralAndroidOptions) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsUniversalBle(lhs.addManufacturerDataInScanResponse, rhs.addManufacturerDataInScanResponse)
+    return deepEqualsUniversalBle(lhs.addManufacturerDataInScanResponse, rhs.addManufacturerDataInScanResponse) && deepEqualsUniversalBle(lhs.addServicesInScanResponse, rhs.addServicesInScanResponse)
   }
 
   func hash(into hasher: inout Hasher) {
     hasher.combine("PeripheralAndroidOptions")
     deepHashUniversalBle(value: addManufacturerDataInScanResponse, hasher: &hasher)
+    deepHashUniversalBle(value: addServicesInScanResponse, hasher: &hasher)
   }
 }
 

--- a/lib/src/universal_ble.g.dart
+++ b/lib/src/universal_ble.g.dart
@@ -834,12 +834,26 @@ class UniversalManufacturerData {
 }
 
 class PeripheralAndroidOptions {
-  PeripheralAndroidOptions({this.addManufacturerDataInScanResponse});
+  PeripheralAndroidOptions({
+    this.addManufacturerDataInScanResponse,
+    this.addServicesInScanResponse,
+  });
 
   bool? addManufacturerDataInScanResponse;
 
+  /// Put advertised service UUIDs in the scan response instead of the primary
+  /// advertisement. The Android primary advertisement is capped at 31 bytes;
+  /// a 128-bit service UUID (18 bytes) plus a device name can overflow it
+  /// ("ADVERTISE_FAILED_DATA_TOO_LARGE"). Moving the UUIDs to the scan
+  /// response keeps them discoverable to active scanners while freeing the
+  /// primary packet.
+  bool? addServicesInScanResponse;
+
   List<Object?> _toList() {
-    return <Object?>[addManufacturerDataInScanResponse];
+    return <Object?>[
+      addManufacturerDataInScanResponse,
+      addServicesInScanResponse,
+    ];
   }
 
   Object encode() {
@@ -850,6 +864,7 @@ class PeripheralAndroidOptions {
     result as List<Object?>;
     return PeripheralAndroidOptions(
       addManufacturerDataInScanResponse: result[0] as bool?,
+      addServicesInScanResponse: result[1] as bool?,
     );
   }
 
@@ -864,9 +879,10 @@ class PeripheralAndroidOptions {
       return true;
     }
     return _deepEquals(
-      addManufacturerDataInScanResponse,
-      other.addManufacturerDataInScanResponse,
-    );
+          addManufacturerDataInScanResponse,
+          other.addManufacturerDataInScanResponse,
+        ) &&
+        _deepEquals(addServicesInScanResponse, other.addServicesInScanResponse);
   }
 
   @override

--- a/pigeon/universal_ble.dart
+++ b/pigeon/universal_ble.dart
@@ -263,11 +263,11 @@ class PeripheralAndroidOptions {
   bool? addManufacturerDataInScanResponse;
 
   /// Put advertised service UUIDs in the scan response instead of the primary
-  /// advertisement. The Android primary advertisement is capped at 31 bytes;
-  /// a 128-bit service UUID (18 bytes) plus a device name can overflow it
-  /// ("ADVERTISE_FAILED_DATA_TOO_LARGE"). Moving the UUIDs to the scan
-  /// response keeps them discoverable to active scanners while freeing the
-  /// primary packet.
+  /// advertisement. The Android primary advertisement and scan response are
+  /// both capped at 31 bytes. A 128-bit service UUID (18 bytes) plus a
+  /// device name can overflow the primary packet.
+  /// Note: If this is enabled with `addManufacturerDataInScanResponse`, ensure
+  /// the combined data fits within the scan response's 31-byte limit.
   bool? addServicesInScanResponse;
   PeripheralAndroidOptions({
     this.addManufacturerDataInScanResponse,

--- a/pigeon/universal_ble.dart
+++ b/pigeon/universal_ble.dart
@@ -261,7 +261,18 @@ class UniversalManufacturerData {
 
 class PeripheralAndroidOptions {
   bool? addManufacturerDataInScanResponse;
-  PeripheralAndroidOptions({this.addManufacturerDataInScanResponse});
+
+  /// Put advertised service UUIDs in the scan response instead of the primary
+  /// advertisement. The Android primary advertisement is capped at 31 bytes;
+  /// a 128-bit service UUID (18 bytes) plus a device name can overflow it
+  /// ("ADVERTISE_FAILED_DATA_TOO_LARGE"). Moving the UUIDs to the scan
+  /// response keeps them discoverable to active scanners while freeing the
+  /// primary packet.
+  bool? addServicesInScanResponse;
+  PeripheralAndroidOptions({
+    this.addManufacturerDataInScanResponse,
+    this.addServicesInScanResponse,
+  });
 }
 
 class PeripheralPlatformConfig {

--- a/windows/src/generated/universal_ble.g.cpp
+++ b/windows/src/generated/universal_ble.g.cpp
@@ -1184,8 +1184,11 @@ size_t PigeonInternalDeepHash(const UniversalManufacturerData& v) {
 
 PeripheralAndroidOptions::PeripheralAndroidOptions() {}
 
-PeripheralAndroidOptions::PeripheralAndroidOptions(const bool* add_manufacturer_data_in_scan_response)
- : add_manufacturer_data_in_scan_response_(add_manufacturer_data_in_scan_response ? std::optional<bool>(*add_manufacturer_data_in_scan_response) : std::nullopt) {}
+PeripheralAndroidOptions::PeripheralAndroidOptions(
+  const bool* add_manufacturer_data_in_scan_response,
+  const bool* add_services_in_scan_response)
+ : add_manufacturer_data_in_scan_response_(add_manufacturer_data_in_scan_response ? std::optional<bool>(*add_manufacturer_data_in_scan_response) : std::nullopt),
+    add_services_in_scan_response_(add_services_in_scan_response ? std::optional<bool>(*add_services_in_scan_response) : std::nullopt) {}
 
 const bool* PeripheralAndroidOptions::add_manufacturer_data_in_scan_response() const {
   return add_manufacturer_data_in_scan_response_ ? &(*add_manufacturer_data_in_scan_response_) : nullptr;
@@ -1200,10 +1203,24 @@ void PeripheralAndroidOptions::set_add_manufacturer_data_in_scan_response(bool v
 }
 
 
+const bool* PeripheralAndroidOptions::add_services_in_scan_response() const {
+  return add_services_in_scan_response_ ? &(*add_services_in_scan_response_) : nullptr;
+}
+
+void PeripheralAndroidOptions::set_add_services_in_scan_response(const bool* value_arg) {
+  add_services_in_scan_response_ = value_arg ? std::optional<bool>(*value_arg) : std::nullopt;
+}
+
+void PeripheralAndroidOptions::set_add_services_in_scan_response(bool value_arg) {
+  add_services_in_scan_response_ = value_arg;
+}
+
+
 EncodableList PeripheralAndroidOptions::ToEncodableList() const {
   EncodableList list;
-  list.reserve(1);
+  list.reserve(2);
   list.push_back(add_manufacturer_data_in_scan_response_ ? EncodableValue(*add_manufacturer_data_in_scan_response_) : EncodableValue());
+  list.push_back(add_services_in_scan_response_ ? EncodableValue(*add_services_in_scan_response_) : EncodableValue());
   return list;
 }
 
@@ -1213,11 +1230,15 @@ PeripheralAndroidOptions PeripheralAndroidOptions::FromEncodableList(const Encod
   if (!encodable_add_manufacturer_data_in_scan_response.IsNull()) {
     decoded.set_add_manufacturer_data_in_scan_response(std::get<bool>(encodable_add_manufacturer_data_in_scan_response));
   }
+  auto& encodable_add_services_in_scan_response = list[1];
+  if (!encodable_add_services_in_scan_response.IsNull()) {
+    decoded.set_add_services_in_scan_response(std::get<bool>(encodable_add_services_in_scan_response));
+  }
   return decoded;
 }
 
 bool PeripheralAndroidOptions::operator==(const PeripheralAndroidOptions& other) const {
-  return PigeonInternalDeepEquals(add_manufacturer_data_in_scan_response_, other.add_manufacturer_data_in_scan_response_);
+  return PigeonInternalDeepEquals(add_manufacturer_data_in_scan_response_, other.add_manufacturer_data_in_scan_response_) && PigeonInternalDeepEquals(add_services_in_scan_response_, other.add_services_in_scan_response_);
 }
 
 bool PeripheralAndroidOptions::operator!=(const PeripheralAndroidOptions& other) const {
@@ -1227,6 +1248,7 @@ bool PeripheralAndroidOptions::operator!=(const PeripheralAndroidOptions& other)
 size_t PeripheralAndroidOptions::Hash() const {
   size_t result = 1;
   result = result * 31 + PigeonInternalDeepHash(add_manufacturer_data_in_scan_response_);
+  result = result * 31 + PigeonInternalDeepHash(add_services_in_scan_response_);
   return result;
 }
 

--- a/windows/src/generated/universal_ble.g.h
+++ b/windows/src/generated/universal_ble.g.h
@@ -729,11 +729,23 @@ class PeripheralAndroidOptions {
   PeripheralAndroidOptions();
 
   // Constructs an object setting all fields.
-  explicit PeripheralAndroidOptions(const bool* add_manufacturer_data_in_scan_response);
+  explicit PeripheralAndroidOptions(
+    const bool* add_manufacturer_data_in_scan_response,
+    const bool* add_services_in_scan_response);
 
   const bool* add_manufacturer_data_in_scan_response() const;
   void set_add_manufacturer_data_in_scan_response(const bool* value_arg);
   void set_add_manufacturer_data_in_scan_response(bool value_arg);
+
+  // Put advertised service UUIDs in the scan response instead of the primary
+  // advertisement. The Android primary advertisement is capped at 31 bytes;
+  // a 128-bit service UUID (18 bytes) plus a device name can overflow it
+  // ("ADVERTISE_FAILED_DATA_TOO_LARGE"). Moving the UUIDs to the scan
+  // response keeps them discoverable to active scanners while freeing the
+  // primary packet.
+  const bool* add_services_in_scan_response() const;
+  void set_add_services_in_scan_response(const bool* value_arg);
+  void set_add_services_in_scan_response(bool value_arg);
 
   bool operator==(const PeripheralAndroidOptions& other) const;
   bool operator!=(const PeripheralAndroidOptions& other) const;
@@ -750,6 +762,7 @@ class PeripheralAndroidOptions {
   friend class UniversalBlePeripheralCallback;
   friend class PigeonInternalCodecSerializer;
   std::optional<bool> add_manufacturer_data_in_scan_response_;
+  std::optional<bool> add_services_in_scan_response_;
 };
 
 


### PR DESCRIPTION
## Problem

On Android the primary BLE advertisement is capped at 31 bytes. A 128-bit service UUID (18 bytes) plus the device name overflows it, and `startAdvertising` fails with `ADVERTISE_FAILED_DATA_TOO_LARGE`. There is currently no way to move service UUIDs into the scan response — only `addManufacturerDataInScanResponse` exists — so a peripheral that advertises a 128-bit service UUID and a name cannot advertise at all.

## Change

Adds `PeripheralAndroidOptions.addServicesInScanResponse`. When `true`, advertised service UUIDs are placed in the scan response instead of the primary advertisement packet. The device name is also kept out of the scan response in that case, so a name + 128-bit UUID can't overflow the scan response either. Active scanners still receive every service UUID.

- Default `false` → unchanged behavior.
- Android-only; iOS/Windows manage the advertisement/scan-response split themselves and are unaffected.
- Pigeon regenerated (only the new field is added to the bindings).

## Testing

- `flutter analyze` clean.
- Existing `test/android_options_test.dart` round-trip passes with the new field.
- Verified against a real peripheral (Zwift/Rouvy controller emulation) that previously failed with "Data too large" and now advertises successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)