### PR TITLE
On Android, call gatt.close() upon disconnection to release the GATT …

### DIFF
--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -1144,6 +1144,7 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
     private fun cleanConnection(gatt: BluetoothGatt) {
         gatt.removeCache()
         gatt.disconnect()
+        gatt.close()
         cleanUpConnection(gatt.device.address)
     }
 


### PR DESCRIPTION
On Android, call gatt.close() upon disconnection to release the GATT service for faster subsequent discovery.