### PR TITLE
fix: value-based equality and hashCode for BleCharacteristic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.1.1
 * Android: Fix BluetoothDevice null-safety compile error under Kotlin 2.x
+* Fix `BleCharacteristic` equality and `hashCode` to compare `properties` by value
 
 ## 2.1.0
 * Add optional `queueId` parameter to all APIs

--- a/lib/src/models/ble_service.dart
+++ b/lib/src/models/ble_service.dart
@@ -1,4 +1,4 @@
-import 'dart:typed_data';
+import 'package:flutter/foundation.dart';
 import 'package:universal_ble/src/universal_ble.g.dart';
 import 'package:universal_ble/universal_ble.dart';
 
@@ -71,14 +71,15 @@ class BleCharacteristic {
   bool operator ==(Object other) {
     if (other is! BleCharacteristic) return false;
     if (other.uuid != uuid) return false;
-    if (other.properties != properties) return false;
+    if (!listEquals(other.properties, properties)) return false;
     if (other.metaData?.deviceId != metaData?.deviceId) return false;
     if (other.metaData?.serviceId != metaData?.serviceId) return false;
     return true;
   }
 
   @override
-  int get hashCode => uuid.hashCode ^ properties.hashCode ^ metaData.hashCode;
+  int get hashCode =>
+      uuid.hashCode ^ Object.hashAll(properties) ^ metaData.hashCode;
 }
 
 class BleDescriptor {

--- a/lib/src/models/ble_service.dart
+++ b/lib/src/models/ble_service.dart
@@ -78,8 +78,11 @@ class BleCharacteristic {
   }
 
   @override
-  int get hashCode =>
-      uuid.hashCode ^ Object.hashAll(properties) ^ metaData.hashCode;
+  int get hashCode => Object.hash(
+        uuid,
+        Object.hashAll(properties),
+        metaData,
+      );
 }
 
 class BleDescriptor {

--- a/test/ble_characteristic_equality_test.dart
+++ b/test/ble_characteristic_equality_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+void main() {
+  group('BleCharacteristic equality', () {
+    test('equal when uuid and properties have equal content', () {
+      // Two separate list instances with the same content.
+      final a = BleCharacteristic('2a00', [
+        CharacteristicProperty.read,
+        CharacteristicProperty.notify,
+      ], []);
+      final b = BleCharacteristic('2a00', [
+        CharacteristicProperty.read,
+        CharacteristicProperty.notify,
+      ], []);
+
+      expect(a == b, isTrue);
+      // Equal objects MUST have equal hashCodes (equality contract).
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('not equal when properties differ', () {
+      final a = BleCharacteristic('2a00', [CharacteristicProperty.read], []);
+      final b = BleCharacteristic('2a00', [CharacteristicProperty.write], []);
+
+      expect(a == b, isFalse);
+    });
+
+    test('not equal when uuid differs', () {
+      final a = BleCharacteristic('2a00', [CharacteristicProperty.read], []);
+      final b = BleCharacteristic('2a01', [CharacteristicProperty.read], []);
+
+      expect(a == b, isFalse);
+    });
+
+    test('usable as Set/Map key with equal-content instances', () {
+      final a = BleCharacteristic('2a00', [
+        CharacteristicProperty.read,
+        CharacteristicProperty.notify,
+      ], []);
+      final b = BleCharacteristic('2a00', [
+        CharacteristicProperty.read,
+        CharacteristicProperty.notify,
+      ], []);
+
+      final set = {a};
+      expect(set.contains(b), isTrue);
+    });
+  });
+}

--- a/test/ble_characteristic_equality_test.dart
+++ b/test/ble_characteristic_equality_test.dart
@@ -45,6 +45,9 @@ void main() {
 
       final set = {a};
       expect(set.contains(b), isTrue);
+
+      final map = {a: true};
+      expect(map.containsKey(b), isTrue);
     });
   });
 }


### PR DESCRIPTION
## Problem

`BleCharacteristic.operator==` compares the `properties` list with `!=`, which is List *identity* comparison in Dart, and `hashCode` uses `properties.hashCode`, which is also identity-based. As a result, two characteristics with identical content are never equal unless they share the exact same list instance:

```dart
final a = BleCharacteristic("180A", [CharacteristicProperty.read]);
final b = BleCharacteristic("180A", [CharacteristicProperty.read]);
print(a == b); // false — but they are logically equal
```

This breaks the `==`/`hashCode` contract and makes `BleCharacteristic` unreliable as a `Set` element or `Map` key (e.g. deduplicating characteristics across discovery runs).

## Fix

- `operator==` now compares `properties` with `listEquals`.
- `hashCode` now uses `Object.hashAll(properties)`.

This matches the pattern already used by `ManufacturerData` in this package.

## Testing

- Added `test/ble_characteristic_equality_test.dart` covering: equal content ⇒ equal + same hash, differing properties ⇒ unequal, differing uuid ⇒ unequal, and Set/Map key usage.
- Ran `flutter test test/ble_characteristic_equality_test.dart` locally (Flutter 3.44.1 / Dart 3.12.1): 4 tests, all passing.

## Changelog

Added an entry under the unreleased `2.1.1` section in `CHANGELOG.md`.
