### PR TITLE
Make Android write-completion delivery thread-safe

### DIFF
--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -724,8 +724,12 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
                 callback
             )
 
-            // Wait for the result
-            writeResultFutureList.add(writeFuture)
+            // Wait for the result. The list is mutated both here (main thread)
+            // and in onCharacteristicWrite / cleanUpConnection (Bluetooth
+            // binder threads), so every access must hold the lock.
+            synchronized(writeResultFutureList) {
+                writeResultFutureList.add(writeFuture)
+            }
 
             val result = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 gatt.writeCharacteristic(gattCharacteristic, value, writeType)
@@ -739,7 +743,9 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
             }
 
             if (result != BluetoothGatt.GATT_SUCCESS) {
-                writeResultFutureList.remove(writeFuture)
+                synchronized(writeResultFutureList) {
+                    writeResultFutureList.remove(writeFuture)
+                }
                 callback(
                     Result.failure(
                         createFlutterError(
@@ -760,30 +766,44 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
         characteristic: BluetoothGattCharacteristic,
         status: Int,
     ) {
-        writeResultFutureList.removeAll {
-            if (it.deviceId == gatt?.device?.address &&
-                it.characteristicId == characteristic.uuid.toString() &&
-                it.serviceId == characteristic.service.uuid.toString()
-            ) {
-                if (status == BluetoothGatt.GATT_SUCCESS) {
-                    it.result(Result.success(Unit))
-                } else {
-                    UniversalBleLogger.logError(
-                        "WRITE_FAILED <- ${gatt?.device?.address} ${characteristic.uuid} status=$status"
-                    )
-                    it.result(
-                        Result.failure(
-                            createFlutterError(
-                                gattStatusToUniversalBleErrorCode(status),
-                                "Failed to write",
-                                status.toString()
+        // Runs on a binder thread: snapshot and remove matches under the lock,
+        // then complete each future on the main thread (platform-channel
+        // replies must be sent there). Completing outside the removal loop,
+        // with each completion individually contained, means one bad callback
+        // can neither corrupt the list nor block later completions.
+        val matches: List<WriteResultFuture>
+        synchronized(writeResultFutureList) {
+            matches = writeResultFutureList.filter {
+                it.deviceId == gatt?.device?.address &&
+                    it.characteristicId == characteristic.uuid.toString() &&
+                    it.serviceId == characteristic.service.uuid.toString()
+            }
+            writeResultFutureList.removeAll(matches)
+        }
+        if (status != BluetoothGatt.GATT_SUCCESS) {
+            UniversalBleLogger.logError(
+                "WRITE_FAILED <- ${gatt?.device?.address} ${characteristic.uuid} status=$status"
+            )
+        }
+        for (future in matches) {
+            mainThreadHandler?.post {
+                try {
+                    if (status == BluetoothGatt.GATT_SUCCESS) {
+                        future.result(Result.success(Unit))
+                    } else {
+                        future.result(
+                            Result.failure(
+                                createFlutterError(
+                                    gattStatusToUniversalBleErrorCode(status),
+                                    "Failed to write",
+                                    status.toString()
+                                )
                             )
                         )
-                    )
+                    }
+                } catch (e: Exception) {
+                    UniversalBleLogger.logError("Write completion delivery failed: $e")
                 }
-                true
-            } else {
-                false
             }
         }
     }
@@ -1104,12 +1124,18 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
                 false
             }
         }
-        writeResultFutureList.removeAll {
-            if (it.deviceId == deviceId) {
-                it.result(Result.failure(deviceDisconnectedError))
-                true
-            } else {
-                false
+        val pendingWrites: List<WriteResultFuture>
+        synchronized(writeResultFutureList) {
+            pendingWrites = writeResultFutureList.filter { it.deviceId == deviceId }
+            writeResultFutureList.removeAll(pendingWrites)
+        }
+        for (future in pendingWrites) {
+            mainThreadHandler?.post {
+                try {
+                    future.result(Result.failure(deviceDisconnectedError))
+                } catch (e: Exception) {
+                    UniversalBleLogger.logError("Write completion delivery failed: $e")
+                }
             }
         }
         subscriptionResultFutureList.removeAll {

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -42,6 +42,12 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
     private val advertisePermissionRequestCode = 2342616
     private var permissionHandler: PermissionHandler? = null
     private var callbackChannel: UniversalBleCallbackChannel? = null
+
+    // Read on Bluetooth binder threads (from GATT callbacks) but assigned on the
+    // main thread in onAttachedToEngine/onDetachedFromEngine; @Volatile makes
+    // those writes visible so a binder thread never sees a stale null and drops
+    // a completion.
+    @Volatile
     private var mainThreadHandler: Handler? = null
     private lateinit var context: Context
     private var activity: Activity? = null
@@ -776,7 +782,7 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
             matches = writeResultFutureList.filter {
                 it.deviceId == gatt?.device?.address &&
                     it.characteristicId == characteristic.uuid.toString() &&
-                    it.serviceId == characteristic.service.uuid.toString()
+                    it.serviceId == characteristic.service?.uuid?.toString()
             }
             writeResultFutureList.removeAll(matches)
         }

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -767,6 +767,16 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
         }
     }
 
+    // Deliver on the main looper. Platform-channel replies must be sent there,
+    // and because matching futures are removed from their list before delivery,
+    // a completion must never be dropped just because the cached handler was
+    // cleared (a GATT callback racing onDetachedFromEngine) — that would leak
+    // the pending Dart await. Fall back to a fresh main-looper handler so the
+    // completion is always attempted.
+    private fun postToMainLooper(action: () -> Unit) {
+        (mainThreadHandler ?: Handler(Looper.getMainLooper())).post(action)
+    }
+
     override fun onCharacteristicWrite(
         gatt: BluetoothGatt?,
         characteristic: BluetoothGattCharacteristic,
@@ -792,7 +802,7 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
             )
         }
         for (future in matches) {
-            mainThreadHandler?.post {
+            postToMainLooper {
                 try {
                     if (status == BluetoothGatt.GATT_SUCCESS) {
                         future.result(Result.success(Unit))
@@ -1136,7 +1146,7 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
             writeResultFutureList.removeAll(pendingWrites)
         }
         for (future in pendingWrites) {
-            mainThreadHandler?.post {
+            postToMainLooper {
                 try {
                     future.result(Result.failure(deviceDisconnectedError))
                 } catch (e: Exception) {


### PR DESCRIPTION
Field logs showed writes completing fast (<100ms) or never (timeouts at both 100ms and 1s deadlines, zero GATT-busy errors), sometimes latching into 100% loss until the session ended. The write-completion plumbing can lose acks between onCharacteristicWrite and Dart:

1. writeResultFutureList is an unsynchronized ArrayList mutated from the main thread (writeValue) and Bluetooth binder threads (onCharacteristicWrite / cleanUpConnection) - connectGatt registers no Handler, so callbacks arrive on binder threads. Concurrent add/removeAll can silently drop a pending completion.
2. Pigeon replies were invoked directly on the binder thread; platform channel replies must be sent from the main thread.
3. removeAll invoked completion callbacks inside its predicate: one throwing completion aborts the loop mid-iteration, leaves its entry in the list (double-completed on the next ack), and permanently blocks all later completions - the latched failure mode.

Fix: guard every writeResultFutureList access with synchronized; in onCharacteristicWrite and cleanUpConnection, snapshot+remove matches under the lock, then post each completion to the main thread individually wrapped in try/catch. Write-await semantics are unchanged.