### PR TITLE
Fix Darwin writeWithoutResponse queue completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Android: Make Android write-completion delivery thread-safe
 * Fix `BleCharacteristic` equality and `hashCode` to compare `properties` by value
 * Handle device IDs case-insensitively
+* iOS/macOS: Fix `write` without response hanging / degrading under `QueueType.global` and `perDevice` by completing when CoreBluetooth accepts the write (`canSendWriteWithoutResponse`), instead of waiting for `peripheralIsReady` after every write (#271)
 
 ## 2.1.0
 * Add optional `queueId` parameter to all APIs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.1
+## 2.1.2
 * Android: Fix BluetoothDevice null-safety compile error under Kotlin 2.x
 * Android: Make Android write-completion delivery thread-safe
 * Fix `BleCharacteristic` equality and `hashCode` to compare `properties` by value

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBleHelper.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBleHelper.swift
@@ -197,6 +197,22 @@ class CharacteristicWriteFuture {
     }
 }
 
+/// Write-without-response request waiting for CoreBluetooth buffer space.
+/// Completed once `writeValue` is accepted (`canSendWriteWithoutResponse`), not via ATT response.
+class PendingWriteWithoutResponse {
+    let deviceId: String
+    let characteristic: CBCharacteristic
+    let data: Data
+    let result: (Result<Void, Error>) -> Void
+
+    init(deviceId: String, characteristic: CBCharacteristic, data: Data, result: @escaping (Result<Void, Error>) -> Void) {
+        self.deviceId = deviceId
+        self.characteristic = characteristic
+        self.data = data
+        self.result = result
+    }
+}
+
 class CharacteristicNotifyFuture {
     let deviceId: String
     let characteristicId: String

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
@@ -95,7 +95,7 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
   private var activeServiceDiscoveries: [String: UniversalBleAsyncServiceDiscovery] = [:]
   private var characteristicReadFutures = [CharacteristicReadFuture]()
   private var characteristicWriteFutures = [CharacteristicWriteFuture]()
-  private var characteristicWriteWithoutResponseFutures = [CharacteristicWriteFuture]()
+  private var pendingWriteWithoutResponse = [PendingWriteWithoutResponse]()
   private var characteristicNotifyFutures = [CharacteristicNotifyFuture]()
   private var discoverServicesFutures = [DiscoverServicesFuture]()
   private var rssiReadFutures = [RssiReadFuture]()
@@ -305,6 +305,15 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
       }
       return false
     }
+    pendingWriteWithoutResponse.removeAll { pending in
+      if pending.deviceId == deviceId {
+        pending.result(
+          Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
+        )
+        return true
+      }
+      return false
+    }
     characteristicNotifyFutures.removeAll { future in
       if future.deviceId == deviceId {
         future.result(
@@ -437,20 +446,39 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
         completion(Result.failure(createFlutterError(code: .characteristicDoesNotSupportWrite, message: "Characteristic does not support write withResponse")))
         return
       }
-    } else if type == CBCharacteristicWriteType.withoutResponse {
-      if !gattCharacteristic.properties.contains(.writeWithoutResponse) {
-        completion(Result.failure(createFlutterError(code: .characteristicDoesNotSupportWriteWithoutResponse, message: "Characteristic does not support write withoutResponse")))
-        return
-      }
+      peripheral.writeValue(value.data, for: gattCharacteristic, type: type)
+      characteristicWriteFutures.append(
+        CharacteristicWriteFuture(
+          deviceId: deviceId,
+          characteristicId: gattCharacteristic.uuid.uuidStr,
+          serviceId: gattCharacteristic.service?.uuid.uuidStr,
+          result: completion
+        )
+      )
+      return
     }
-    peripheral.writeValue(value.data, for: gattCharacteristic, type: type)
 
-    // Wait for future response
-    let future = CharacteristicWriteFuture(deviceId: deviceId, characteristicId: gattCharacteristic.uuid.uuidStr, serviceId: gattCharacteristic.service?.uuid.uuidStr, result: completion)
-    if type == CBCharacteristicWriteType.withResponse {
-      characteristicWriteFutures.append(future)
+    if !gattCharacteristic.properties.contains(.writeWithoutResponse) {
+      completion(Result.failure(createFlutterError(code: .characteristicDoesNotSupportWriteWithoutResponse, message: "Characteristic does not support write withoutResponse")))
+      return
+    }
+
+    // Complete when CoreBluetooth accepts the write into its buffer — same
+    // "local stack accepted" semantics as Android/Windows/Web/Linux.
+    // `peripheralIsReady` only fires after a failed without-response write,
+    // so parking every write on that callback hangs the Dart command queue.
+    if peripheral.canSendWriteWithoutResponse {
+      peripheral.writeValue(value.data, for: gattCharacteristic, type: .withoutResponse)
+      completion(Result.success(()))
     } else {
-      characteristicWriteWithoutResponseFutures.append(future)
+      pendingWriteWithoutResponse.append(
+        PendingWriteWithoutResponse(
+          deviceId: deviceId,
+          characteristic: gattCharacteristic,
+          data: value.data,
+          result: completion
+        )
+      )
     }
   }
 
@@ -652,12 +680,14 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
   }
 
   public func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
-    characteristicWriteWithoutResponseFutures.removeAll { future in
-      if future.deviceId == peripheral.uuid.uuidString {
-        future.result(Result.success({}()))
-        return true
+    let deviceId = peripheral.uuid.uuidString
+    while peripheral.canSendWriteWithoutResponse {
+      guard let index = pendingWriteWithoutResponse.firstIndex(where: { $0.deviceId == deviceId }) else {
+        return
       }
-      return false
+      let pending = pendingWriteWithoutResponse.remove(at: index)
+      peripheral.writeValue(pending.data, for: pending.characteristic, type: .withoutResponse)
+      pending.result(Result.success(()))
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: universal_ble
 description: A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE) plugin for Flutter
-version: 2.1.1
+version: 2.1.2
 homepage: https://navideck.com
 repository: https://github.com/Navideck/universal_ble
 issue_tracker: https://github.com/Navideck/universal_ble/issues


### PR DESCRIPTION
## Summary
- fix iOS/macOS `withoutResponse` write flow to complete when CoreBluetooth accepts writes (`canSendWriteWithoutResponse`) instead of waiting on `peripheralIsReady` for every write
- queue and flush pending Darwin without-response writes only when the peripheral is ready, and fail pending writes on disconnect cleanup
- bump release metadata to `2.1.2` in `pubspec.yaml` and `CHANGELOG.md`

## Test plan
- [x] `flutter test test/ble_command_queue_test.dart test/queue_test.dart`
- [ ] Validate on macOS/iOS with `QueueType.global` and `QueueType.perDevice` using `withoutResponse: true` writes
- [ ] Verify no progressive write latency growth and no queue timeouts under sustained writes

Made with [Cursor](https://cursor.com)