### PR TITLE
Android: close the GATT client on disconnect

### DIFF
--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -1189,9 +1189,23 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
     }
 
     private fun cleanConnection(gatt: BluetoothGatt) {
+        val deviceId = gatt.device.address
         gatt.removeCache()
         gatt.disconnect()
-        cleanUpConnection(gatt.device.address)
+        // Release the GATT client interface. disconnect() tears down the link but never frees the
+        // client that connectGatt() registered - only close() does. When the connection was never
+        // established (still CONNECTING when the caller gives up, e.g. on a client-side connect
+        // timeout) Android delivers no STATE_DISCONNECTED callback at all, so the close() in
+        // onConnectionStateChange never runs and the client leaks for the lifetime of the process.
+        // Once the per-app pool is exhausted, registerClient fails and every subsequent
+        // connectGatt returns status 257 (GATT_FAILURE) for every device until the app restarts.
+        gatt.close()
+        cleanUpConnection(deviceId)
+        // close() suppresses the STATE_DISCONNECTED callback that would otherwise report this,
+        // so surface the disconnect here - mirrors the gatt == null branch of disconnect().
+        mainThreadHandler?.post {
+            callbackChannel?.onConnectionChanged(deviceId, false, null) {}
+        }
     }
 
     private fun onBondStateUpdate(deviceId: String, bonded: Boolean, error: String? = null) {


### PR DESCRIPTION
On Android, `cleanConnection` only called `gatt.disconnect()`. That tears down the link but does not release the client interface registered by `connectGatt()` — only `close()` does.

`gatt.close()` is reachable from exactly one place in the plugin: `onConnectionStateChange` on `STATE_DISCONNECTED`. A connect that never completes — still `CONNECTING` when the caller gives up, e.g. on a client-side connect timeout — produces no `STATE_DISCONNECTED` callback at all, so that path never runs and the client is leaked for the lifetime of the process.

`cleanConnection` also drops the gatt from `knownGatts` via `removeCache()` before disconnecting, so nothing retains a handle afterwards and the leak cannot be recovered in-process: Android exposes no API to enumerate or release a process`s own GATT clients. Only process death frees them.

Once the per-app client pool is exhausted, `registerClient` fails and **every** subsequent `connectGatt` returns status **257** (`GATT_FAILURE`) for **every** device, so all BLE in the app is dead until it is restarted.

### Reproduction

Huawei COL-L29 (EMUI, Android 10), two BLE peripherals whose connects kept failing at a 20s client-side timeout:

| | before | after |
|---|---|---|
| duration | ~10 min | 19 min |
| discovery failures | 39 | 39 |
| **status 257** | **44** (first after 3m30s) | **0** |
| other devices | all blocked, ~10 min with no BLE at all | discovered normally throughout |

Before the fix a single persistently-failing peripheral took down BLE for every other device within minutes; after it, failures stay isolated to the peripheral that actually has a problem. Restarting the app was the only recovery, every time.

### The change

```kotlin
private fun cleanConnection(gatt: BluetoothGatt) {
    val deviceId = gatt.device.address
    gatt.removeCache()
    gatt.disconnect()
    gatt.close()
    cleanUpConnection(deviceId)
    mainThreadHandler?.post {
        callbackChannel?.onConnectionChanged(deviceId, false, null) {}
    }
}
```

`close()` suppresses the `STATE_DISCONNECTED` callback that would otherwise report the disconnect, so the callback is emitted explicitly. That also makes the two branches of `disconnect()` symmetric — the `gatt == null` branch already did exactly this.

Notes:

- `cleanConnection` has a single call site, inside `disconnect()`.
- On the Dart side `updateConnection` re-emits on a broadcast stream and resets an already-reset cache, so if the real callback still lands in a race the duplicate `false` is harmless.
- Android only; no change to the iOS/macOS/Windows/Linux/web implementations.