### PR TITLE
Windows: Harden BLE connection lifetime, async callbacks, and notification subscription handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Windows: Harden BLE connection lifetime, asynchronous callbacks, and notification subscription handling
+
 ## 2.1.1
 * Android: Fix BluetoothDevice null-safety compile error under Kotlin 2.x
 * Android: Make Android write-completion delivery thread-safe

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -333,7 +333,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.0"
+    version: "2.1.1"
   vector_math:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -333,7 +333,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.1.1"
+    version: "2.1.0"
   vector_math:
     dependency: transitive
     description:

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -40,6 +40,32 @@ static std::unique_ptr<UniversalBleCallbackChannel> callback_channel;
 std::unique_ptr<UniversalBlePeripheralCallback> peripheral_callback_channel_;
 
 namespace {
+template <typename Reply, typename Value>
+void safe_reply(const char *context, const Reply &reply, Value &&value) noexcept {
+  try {
+    reply(std::forward<Value>(value));
+  } catch (const hresult_error &err) {
+    try {
+      UniversalBleLogger::LogError(
+          std::string(context) + " reply hresult_error hr=" +
+          std::to_string(err.code()) + " msg=" + to_string(err.message()));
+    } catch (...) {
+    }
+  } catch (const std::exception &err) {
+    try {
+      UniversalBleLogger::LogError(std::string(context) +
+                                   " reply std::exception: " + err.what());
+    } catch (...) {
+    }
+  } catch (...) {
+    try {
+      UniversalBleLogger::LogError(std::string(context) +
+                                   " reply unknown exception");
+    } catch (...) {
+    }
+  }
+}
+
 std::string to_lower_case(std::string value) {
   std::transform(
       value.begin(), value.end(), value.begin(),
@@ -120,19 +146,32 @@ void UniversalBlePlugin::EnableBluetooth(
   bluetooth_radio_.SetStateAsync(RadioState::On)
       .Completed([result](const IAsyncOperation<RadioAccessStatus> &sender,
                           const AsyncStatus args) {
-        if (args != AsyncStatus::Completed) {
-          result(create_flutter_error(
-              UniversalBleErrorCode::kFailed,
-              args == AsyncStatus::Canceled ? "Enable bluetooth was cancelled"
-                                            : "Failed to enable bluetooth"));
-          return;
-        }
-        if (const auto radio_access_status = sender.GetResults();
-            radio_access_status == RadioAccessStatus::Allowed) {
-          result(true);
-        } else {
-          result(create_flutter_error(UniversalBleErrorCode::kFailed,
-                                      "Failed to enable bluetooth"));
+        try {
+          if (args != AsyncStatus::Completed) {
+            safe_reply(
+                "EnableBluetooth", result,
+                create_flutter_error(
+                    UniversalBleErrorCode::kFailed,
+                    args == AsyncStatus::Canceled
+                        ? "Enable bluetooth was cancelled"
+                        : "Failed to enable bluetooth"));
+            return;
+          }
+          if (const auto radio_access_status = sender.GetResults();
+              radio_access_status == RadioAccessStatus::Allowed) {
+            safe_reply("EnableBluetooth", result, true);
+          } else {
+            safe_reply("EnableBluetooth", result,
+                       create_flutter_error(UniversalBleErrorCode::kFailed,
+                                            "Failed to enable bluetooth"));
+          }
+        } catch (const hresult_error &err) {
+          safe_reply("EnableBluetooth", result,
+                     create_flutter_error(UniversalBleErrorCode::kFailed,
+                                          to_string(err.message()),
+                                          std::to_string(err.code())));
+        } catch (...) {
+          safe_reply("EnableBluetooth", result, create_flutter_unknown_error());
         }
       });
 }
@@ -153,19 +192,32 @@ void UniversalBlePlugin::DisableBluetooth(
   bluetooth_radio_.SetStateAsync(RadioState::Off)
       .Completed([result](IAsyncOperation<RadioAccessStatus> const &sender,
                           AsyncStatus const args) {
-        if (args != AsyncStatus::Completed) {
-          result(create_flutter_error(
-              UniversalBleErrorCode::kFailed,
-              args == AsyncStatus::Canceled ? "Disable bluetooth was cancelled"
-                                            : "Failed to disable bluetooth"));
-          return;
-        }
-        if (const auto radio_access_status = sender.GetResults();
-            radio_access_status == RadioAccessStatus::Allowed) {
-          result(true);
-        } else {
-          result(create_flutter_error(UniversalBleErrorCode::kFailed,
-                                      "Failed to disable bluetooth"));
+        try {
+          if (args != AsyncStatus::Completed) {
+            safe_reply(
+                "DisableBluetooth", result,
+                create_flutter_error(
+                    UniversalBleErrorCode::kFailed,
+                    args == AsyncStatus::Canceled
+                        ? "Disable bluetooth was cancelled"
+                        : "Failed to disable bluetooth"));
+            return;
+          }
+          if (const auto radio_access_status = sender.GetResults();
+              radio_access_status == RadioAccessStatus::Allowed) {
+            safe_reply("DisableBluetooth", result, true);
+          } else {
+            safe_reply("DisableBluetooth", result,
+                       create_flutter_error(UniversalBleErrorCode::kFailed,
+                                            "Failed to disable bluetooth"));
+          }
+        } catch (const hresult_error &err) {
+          safe_reply("DisableBluetooth", result,
+                     create_flutter_error(UniversalBleErrorCode::kFailed,
+                                          to_string(err.message()),
+                                          std::to_string(err.code())));
+        } catch (...) {
+          safe_reply("DisableBluetooth", result, create_flutter_unknown_error());
         }
       });
 }
@@ -300,13 +352,15 @@ UniversalBlePlugin::Connect(const std::string &device_id,
                             const ConnectionPlatformConfig *platform_config) {
   // Note: autoConnect is not directly supported on Windows platform
   // Note: platformConfig only carries Apple-specific options
-  ConnectAsync(str_to_mac_address(device_id));
+  const auto bluetooth_address = str_to_mac_address(device_id);
+  ConnectAsync(bluetooth_address, BeginConnectAttempt(bluetooth_address));
   return std::nullopt;
 };
 
 std::optional<FlutterError>
 UniversalBlePlugin::Disconnect(const std::string &device_id) {
   const auto device_address = str_to_mac_address(device_id);
+  InvalidateConnectAttempt(device_address);
   DisposeConnection(RemoveConnectedDevice(device_address));
   NotifyConnectionChanged(device_address, false, std::nullopt);
   return std::nullopt;
@@ -360,23 +414,39 @@ void UniversalBlePlugin::ReadValue(
         .Completed([device_id, service, characteristic, result](
                        IAsyncOperation<GattReadResult> const &sender,
                        AsyncStatus const args) {
-          if (args != AsyncStatus::Completed) {
-            result(create_flutter_error(
-                UniversalBleErrorCode::kFailed,
-                args == AsyncStatus::Canceled ? "Read was cancelled"
-                                              : "Read failed"));
-            return;
-          }
-          const auto read_value_result = sender.GetResults();
-          const auto status = read_value_result.Status();
-          if (status != GattCommunicationStatus::Success) {
+          try {
+            if (args != AsyncStatus::Completed) {
+              safe_reply(
+                  "ReadValue", result,
+                  create_flutter_error(
+                      UniversalBleErrorCode::kFailed,
+                      args == AsyncStatus::Canceled ? "Read was cancelled"
+                                                    : "Read failed"));
+              return;
+            }
+            const auto read_value_result = sender.GetResults();
+            const auto status = read_value_result.Status();
+            if (status != GattCommunicationStatus::Success) {
+              UniversalBleLogger::LogError(
+                  "READ_FAILED <- " + device_id + " " + service + " " +
+                  characteristic +
+                  " status=" + std::to_string(static_cast<int>(status)));
+              safe_reply("ReadValue", result,
+                         create_flutter_error_from_gatt_communication_status(
+                             status));
+            } else {
+              safe_reply("ReadValue", result,
+                         to_bytevc(read_value_result.Value()));
+            }
+          } catch (const hresult_error &err) {
+            safe_reply("ReadValue", result,
+                       create_flutter_error(UniversalBleErrorCode::kFailed,
+                                            to_string(err.message()),
+                                            std::to_string(err.code())));
+          } catch (...) {
             UniversalBleLogger::LogError(
-                "READ_FAILED <- " + device_id + " " + service + " " +
-                characteristic +
-                " status=" + std::to_string(static_cast<int>(status)));
-            result(create_flutter_error_from_gatt_communication_status(status));
-          } else {
-            result(to_bytevc(read_value_result.Value()));
+                "ReadValue completion unknown exception");
+            safe_reply("ReadValue", result, create_flutter_unknown_error());
           }
         });
   } catch (const FlutterError &err) {
@@ -435,23 +505,38 @@ void UniversalBlePlugin::WriteValue(
         .Completed([device_id, service, characteristic, result](
                        IAsyncOperation<GattCommunicationStatus> const &sender,
                        AsyncStatus const args) {
-          if (args != AsyncStatus::Completed) {
-            result(create_flutter_error(
-                UniversalBleErrorCode::kFailed,
-                args == AsyncStatus::Canceled ? "Write was cancelled"
-                                              : "Write failed"));
-            return;
-          }
+          try {
+            if (args != AsyncStatus::Completed) {
+              safe_reply(
+                  "WriteValue", result,
+                  create_flutter_error(
+                      UniversalBleErrorCode::kFailed,
+                      args == AsyncStatus::Canceled ? "Write was cancelled"
+                                                    : "Write failed"));
+              return;
+            }
 
-          const auto status = sender.GetResults();
-          if (status != GattCommunicationStatus::Success) {
+            const auto status = sender.GetResults();
+            if (status != GattCommunicationStatus::Success) {
+              UniversalBleLogger::LogError(
+                  "WRITE_FAILED <- " + device_id + " " + service + " " +
+                  characteristic +
+                  " status=" + std::to_string(static_cast<int>(status)));
+              safe_reply("WriteValue", result,
+                         create_flutter_error_from_gatt_communication_status(
+                             status));
+            } else {
+              safe_reply("WriteValue", result, std::nullopt);
+            }
+          } catch (const hresult_error &err) {
+            safe_reply("WriteValue", result,
+                       create_flutter_error(UniversalBleErrorCode::kFailed,
+                                            to_string(err.message()),
+                                            std::to_string(err.code())));
+          } catch (...) {
             UniversalBleLogger::LogError(
-                "WRITE_FAILED <- " + device_id + " " + service + " " +
-                characteristic +
-                " status=" + std::to_string(static_cast<int>(status)));
-            result(create_flutter_error_from_gatt_communication_status(status));
-          } else {
-            result(std::nullopt);
+                "WriteValue completion unknown exception");
+            safe_reply("WriteValue", result, create_flutter_unknown_error());
           }
         });
   } catch (const FlutterError &err) {
@@ -479,15 +564,30 @@ void UniversalBlePlugin::RequestMtu(
     GattSession::FromDeviceIdAsync(bluetooth_agent->device.BluetoothDeviceId())
         .Completed([result](IAsyncOperation<GattSession> const &sender,
                             AsyncStatus const args) {
-          if (args != AsyncStatus::Completed) {
-            result(create_flutter_error(
-                UniversalBleErrorCode::kFailed,
-                args == AsyncStatus::Canceled ? "MTU request was cancelled"
-                                              : "MTU request failed"));
-            return;
-          }
+          try {
+            if (args != AsyncStatus::Completed) {
+              safe_reply(
+                  "RequestMtu", result,
+                  create_flutter_error(
+                      UniversalBleErrorCode::kFailed,
+                      args == AsyncStatus::Canceled
+                          ? "MTU request was cancelled"
+                          : "MTU request failed"));
+              return;
+            }
 
-          result((int64_t)sender.GetResults().MaxPduSize());
+            safe_reply("RequestMtu", result,
+                       static_cast<int64_t>(sender.GetResults().MaxPduSize()));
+          } catch (const hresult_error &err) {
+            safe_reply("RequestMtu", result,
+                       create_flutter_error(UniversalBleErrorCode::kFailed,
+                                            to_string(err.message()),
+                                            std::to_string(err.code())));
+          } catch (...) {
+            UniversalBleLogger::LogError(
+                "RequestMtu completion unknown exception");
+            safe_reply("RequestMtu", result, create_flutter_unknown_error());
+          }
         });
   } catch (const FlutterError &err) {
     result(err);
@@ -1198,16 +1298,15 @@ void UniversalBlePlugin::NotifyConnectionException(
   }
 }
 
-fire_and_forget UniversalBlePlugin::ConnectAsync(uint64_t bluetooth_address) {
+fire_and_forget UniversalBlePlugin::ConnectAsync(
+    uint64_t bluetooth_address, uint64_t connect_generation) {
+  BluetoothLEDevice device{nullptr};
   try {
-    BluetoothLEDevice device =
-        co_await BluetoothLEDevice::FromBluetoothAddressAsync(
-            bluetooth_address);
+    device = co_await BluetoothLEDevice::FromBluetoothAddressAsync(
+        bluetooth_address);
     if (!device) {
-      UniversalBleLogger::LogError(
-          "ConnectionLog: ConnectionFailed: Failed to get device");
-      NotifyConnectionChanged(bluetooth_address, false,
-                              std::string("Failed to get device"));
+      NotifyConnectFailureIfCurrent(bluetooth_address, connect_generation,
+                                    "Failed to get device");
       co_return;
     }
     UniversalBleLogger::LogInfo("ConnectionLog: Device found");
@@ -1216,11 +1315,9 @@ fire_and_forget UniversalBlePlugin::ConnectAsync(uint64_t bluetooth_address) {
     auto services_result_error =
         gatt_communication_status_to_error(services_result.Status());
     if (services_result_error.has_value()) {
-      UniversalBleLogger::LogError(
-          "ConnectionFailed: Failed to get services: " +
-          services_result_error.value());
-      NotifyConnectionChanged(bluetooth_address, false,
-                              services_result_error.value());
+      NotifyConnectFailureIfCurrent(
+          bluetooth_address, connect_generation,
+          "Failed to get services: " + services_result_error.value());
       co_return;
     }
 
@@ -1271,22 +1368,41 @@ fire_and_forget UniversalBlePlugin::ConnectAsync(uint64_t bluetooth_address) {
              &UniversalBlePlugin::BluetoothLeDeviceConnectionStatusChanged});
     auto device_agent = std::make_shared<BluetoothDeviceAgent>(
         device, connection_status_changed_token, gatt_map);
-    DisposeConnection(
-        InstallConnectedDevice(bluetooth_address, std::move(device_agent)));
-    UniversalBleLogger::LogInfo("ConnectionLog: Connected");
-    NotifyConnectionChanged(bluetooth_address, true, std::nullopt);
+    std::shared_ptr<BluetoothDeviceAgent> previous_device_agent;
+    if (!InstallConnectedDevice(bluetooth_address, connect_generation,
+                                device_agent, previous_device_agent)) {
+      DisposeConnection(device_agent);
+      co_return;
+    }
+    DisposeConnection(previous_device_agent);
+    if (NotifyConnectedIfCurrent(bluetooth_address, connect_generation,
+                                 device)) {
+      UniversalBleLogger::LogInfo("ConnectionLog: Connected");
+    } else if (CleanConnection(bluetooth_address, &device)) {
+      NotifyConnectionChanged(bluetooth_address, false,
+                              std::string("Device disconnected while connecting"));
+    }
   } catch (const hresult_error &err) {
-    NotifyConnectionException(
-        bluetooth_address,
+    if (device) {
+      CleanConnection(bluetooth_address, &device);
+    }
+    NotifyConnectFailureIfCurrent(
+        bluetooth_address, connect_generation,
         "ConnectAsync hresult_error hr=" + std::to_string(err.code()) +
             " msg=" + to_string(err.message()));
   } catch (const std::exception &ex) {
-    NotifyConnectionException(bluetooth_address,
-                              std::string("ConnectAsync std::exception: ") +
-                                  ex.what());
+    if (device) {
+      CleanConnection(bluetooth_address, &device);
+    }
+    NotifyConnectFailureIfCurrent(
+        bluetooth_address, connect_generation,
+        std::string("ConnectAsync std::exception: ") + ex.what());
   } catch (...) {
-    NotifyConnectionException(bluetooth_address,
-                              "ConnectAsync unknown exception");
+    if (device) {
+      CleanConnection(bluetooth_address, &device);
+    }
+    NotifyConnectFailureIfCurrent(bluetooth_address, connect_generation,
+                                  "ConnectAsync unknown exception");
   }
 }
 
@@ -1320,6 +1436,21 @@ UniversalBlePlugin::GetConnectedDevice(const uint64_t bluetooth_address) {
   return it == connected_devices_.end() ? nullptr : it->second;
 }
 
+uint64_t
+UniversalBlePlugin::BeginConnectAttempt(const uint64_t bluetooth_address) {
+  std::lock_guard<std::mutex> lock(connected_devices_mutex_);
+  const auto generation = ++next_connect_generation_;
+  connect_generations_.insert_or_assign(bluetooth_address, generation);
+  return generation;
+}
+
+void UniversalBlePlugin::InvalidateConnectAttempt(
+  const uint64_t bluetooth_address) {
+  std::lock_guard<std::mutex> lock(connected_devices_mutex_);
+  connect_generations_.insert_or_assign(bluetooth_address,
+                                        ++next_connect_generation_);
+}
+
 std::shared_ptr<BluetoothDeviceAgent>
 UniversalBlePlugin::RemoveConnectedDevice(
     const uint64_t bluetooth_address,
@@ -1335,19 +1466,66 @@ UniversalBlePlugin::RemoveConnectedDevice(
   return device_agent;
 }
 
-std::shared_ptr<BluetoothDeviceAgent>
+bool
 UniversalBlePlugin::InstallConnectedDevice(
     const uint64_t bluetooth_address,
-    std::shared_ptr<BluetoothDeviceAgent> device_agent) {
+    const uint64_t connect_generation,
+    std::shared_ptr<BluetoothDeviceAgent> device_agent,
+    std::shared_ptr<BluetoothDeviceAgent> &previous_device_agent) {
   std::lock_guard<std::mutex> lock(connected_devices_mutex_);
-  std::shared_ptr<BluetoothDeviceAgent> previous;
+  const auto generation = connect_generations_.find(bluetooth_address);
+  if (generation == connect_generations_.end() ||
+      generation->second != connect_generation) {
+    return false;
+  }
   const auto it = connected_devices_.find(bluetooth_address);
   if (it != connected_devices_.end()) {
-    previous = it->second;
+    previous_device_agent = it->second;
   }
   connected_devices_.insert_or_assign(bluetooth_address,
                                       std::move(device_agent));
-  return previous;
+  return true;
+}
+
+bool UniversalBlePlugin::NotifyConnectedIfCurrent(
+    const uint64_t bluetooth_address, const uint64_t connect_generation,
+    const BluetoothLEDevice &expected_device) {
+  std::lock_guard<std::mutex> lock(connected_devices_mutex_);
+  const auto generation = connect_generations_.find(bluetooth_address);
+  const auto device_agent = connected_devices_.find(bluetooth_address);
+  if (generation == connect_generations_.end() ||
+      generation->second != connect_generation ||
+      device_agent == connected_devices_.end() ||
+      device_agent->second->device != expected_device ||
+      expected_device.ConnectionStatus() !=
+          BluetoothConnectionStatus::Connected) {
+    return false;
+  }
+  NotifyConnectionChanged(bluetooth_address, true, std::nullopt);
+  return true;
+}
+
+void UniversalBlePlugin::NotifyConnectFailureIfCurrent(
+    const uint64_t bluetooth_address, const uint64_t connect_generation,
+    const std::string &error_message) noexcept {
+  try {
+    UniversalBleLogger::LogError(error_message);
+    std::lock_guard<std::mutex> lock(connected_devices_mutex_);
+    const auto generation = connect_generations_.find(bluetooth_address);
+    if (generation != connect_generations_.end() &&
+        generation->second == connect_generation) {
+      NotifyConnectionChanged(bluetooth_address, false, error_message);
+    } else {
+      UniversalBleLogger::LogDebug(
+          "Ignoring failure from stale connection attempt");
+    }
+  } catch (...) {
+    try {
+      UniversalBleLogger::LogError(
+          "Failed to publish connection-attempt failure");
+    } catch (...) {
+    }
+  }
 }
 
 bool UniversalBlePlugin::CleanConnection(
@@ -1404,7 +1582,8 @@ void UniversalBlePlugin::DisposeServices(
   auto gatt_map = device_agent->TakeGattMap();
   for (auto &[service_id, service] : gatt_map) {
     for (auto &[char_id, characteristic] : service.characteristics) {
-      if (characteristic.subscription_token.has_value()) {
+      if (characteristic.subscription_token.has_value() &&
+          !characteristic.notification_operation_in_progress) {
         try {
           characteristic.obj.ValueChanged(
               characteristic.subscription_token.value());
@@ -1459,6 +1638,7 @@ void UniversalBlePlugin::ResetState() {
         device_agents.push_back(entry.second);
       }
       connected_devices_.clear();
+      connect_generations_.clear();
     }
     for (const auto &device_agent : device_agents) {
       DisposeConnection(device_agent);
@@ -1652,6 +1832,8 @@ fire_and_forget UniversalBlePlugin::SetNotifiableAsync(
       }
     }
   };
+  bool notification_operation_started = false;
+  std::shared_ptr<BluetoothDeviceAgent> device_agent;
   try {
     UniversalBleLogger::LogDebugWithTimestamp(
         "SET_NOTIFY -> " + device_id + " " + service + " " +
@@ -1659,7 +1841,7 @@ fire_and_forget UniversalBlePlugin::SetNotifiableAsync(
         std::to_string(static_cast<int>(ble_input_property)));
     stage = "lookup-device";
     const auto device_address = str_to_mac_address(device_id);
-    const auto device_agent = GetConnectedDevice(device_address);
+    device_agent = GetConnectedDevice(device_address);
     if (!device_agent) {
       reply(create_flutter_error(UniversalBleErrorCode::kDeviceNotFound,
                                  "Unknown devicesId:" + device_id));
@@ -1667,7 +1849,7 @@ fire_and_forget UniversalBlePlugin::SetNotifiableAsync(
     }
 
     stage = "lookup-characteristic";
-    const auto gatt_char =
+    auto gatt_char =
         device_agent->FetchCharacteristic(service, characteristic);
 
     const auto properties = gatt_char.obj.CharacteristicProperties();
@@ -1695,6 +1877,16 @@ fire_and_forget UniversalBlePlugin::SetNotifiableAsync(
       }
     }
 
+    if (!device_agent->BeginNotificationOperation(service, characteristic,
+                                                   gatt_char)) {
+      reply(create_flutter_error(
+          UniversalBleErrorCode::kFailed,
+          "Another notification operation is already running or the device "
+          "was disconnected"));
+      co_return;
+    }
+    notification_operation_started = true;
+
     const auto gatt_characteristic = gatt_char.obj;
     const auto uuid = to_uuidstr(gatt_characteristic.Uuid());
 
@@ -1710,6 +1902,8 @@ fire_and_forget UniversalBlePlugin::SetNotifiableAsync(
           "SET_NOTIFY exception hr=" + std::to_string(err.code()) +
           " msg=" + to_string(err.message()) + " device=" + device_id +
           " service=" + service + " char=" + characteristic);
+      device_agent->CancelNotificationOperation(service, characteristic);
+      notification_operation_started = false;
       reply(create_flutter_error(UniversalBleErrorCode::kFailed,
                                  "SetNotifiable exception: " +
                                      to_string(err.message()),
@@ -1721,35 +1915,50 @@ fire_and_forget UniversalBlePlugin::SetNotifiableAsync(
       UniversalBleLogger::LogError("SET_NOTIFY_FAILED <- " + device_id + " " +
                                    service + " " + characteristic + " status=" +
                                    std::to_string(static_cast<int>(status)));
+      device_agent->CancelNotificationOperation(service, characteristic);
+      notification_operation_started = false;
       reply(create_flutter_error_from_gatt_communication_status(status));
       co_return;
     }
 
     // Register/unregister the ValueChanged handler without retaining a
     // reference into the agent's GATT map across the co_await above.
-    std::optional<event_token> old_token;
+    const auto old_token = gatt_char.subscription_token;
     if (descriptor_value ==
         GattClientCharacteristicConfigurationDescriptorValue::None) {
-      stage = "store-unsubscribe-token";
-      if (!device_agent->ExchangeSubscriptionToken(
-              service, characteristic, std::nullopt, old_token)) {
-        reply(create_flutter_error(UniversalBleErrorCode::kDeviceDisconnected,
-                                   "Device disconnected while unsubscribing"));
-        co_return;
-      }
       if (old_token.has_value()) {
         stage = "remove-handler";
         gatt_characteristic.ValueChanged(old_token.value());
         UniversalBleLogger::LogInfo("Unsubscribed " +
                                     to_uuidstr(gatt_characteristic.Uuid()));
       }
+      stage = "store-unsubscribe-token";
+      if (!device_agent->FinishNotificationOperation(
+              service, characteristic, std::nullopt)) {
+        reply(create_flutter_error(UniversalBleErrorCode::kDeviceDisconnected,
+                                   "Device disconnected while unsubscribing"));
+        notification_operation_started = false;
+        co_return;
+      }
+      notification_operation_started = false;
     } else {
+      if (old_token.has_value()) {
+        stage = "remove-handler";
+        gatt_characteristic.ValueChanged(old_token.value());
+        if (!device_agent->UpdateNotificationOperationToken(
+                service, characteristic, std::nullopt)) {
+          reply(create_flutter_error(UniversalBleErrorCode::kDeviceDisconnected,
+                                     "Device disconnected while subscribing"));
+          notification_operation_started = false;
+          co_return;
+        }
+      }
       stage = "register-handler";
       const auto new_token = std::make_optional(
           gatt_characteristic.ValueChanged(
               {this, &UniversalBlePlugin::GattCharacteristicValueChanged}));
-      if (!device_agent->ExchangeSubscriptionToken(
-              service, characteristic, new_token, old_token)) {
+      if (!device_agent->FinishNotificationOperation(
+              service, characteristic, new_token)) {
         stage = "rollback-handler";
         try {
           gatt_characteristic.ValueChanged(new_token.value());
@@ -1764,22 +1973,23 @@ fire_and_forget UniversalBlePlugin::SetNotifiableAsync(
         }
         reply(create_flutter_error(UniversalBleErrorCode::kDeviceDisconnected,
                                    "Device disconnected while subscribing"));
+        notification_operation_started = false;
         co_return;
       }
-      if (old_token.has_value()) {
-        stage = "replace-handler";
-        UniversalBleLogger::LogWarning(
-            "A notification for the given characteristic is already in "
-            "progress. Swapping callbacks.");
-        gatt_characteristic.ValueChanged(old_token.value());
-      }
+      notification_operation_started = false;
     }
 
     stage = "reply-success";
     reply(std::nullopt);
   } catch (const FlutterError &err) {
+    if (notification_operation_started && device_agent) {
+      device_agent->CancelNotificationOperation(service, characteristic);
+    }
     reply(err);
   } catch (const hresult_error &err) {
+    if (notification_operation_started && device_agent) {
+      device_agent->CancelNotificationOperation(service, characteristic);
+    }
     UniversalBleLogger::LogError(
         "SetNotifiableLog hresult_error stage=" + std::string(stage) +
         " hr=" + std::to_string(err.code()) +
@@ -1789,6 +1999,9 @@ fire_and_forget UniversalBlePlugin::SetNotifiableAsync(
                                to_string(err.message()),
                                std::to_string(err.code())));
   } catch (const std::exception &err) {
+    if (notification_operation_started && device_agent) {
+      device_agent->CancelNotificationOperation(service, characteristic);
+    }
     UniversalBleLogger::LogError(
         "SetNotifiableLog std::exception stage=" + std::string(stage) +
         " msg=" + err.what() + " device=" + device_id +
@@ -1796,6 +2009,9 @@ fire_and_forget UniversalBlePlugin::SetNotifiableAsync(
     reply(create_flutter_error(UniversalBleErrorCode::kUnknownError,
                                err.what()));
   } catch (...) {
+    if (notification_operation_started && device_agent) {
+      device_agent->CancelNotificationOperation(service, characteristic);
+    }
     UniversalBleLogger::LogError(
         "SetNotifiableLog unknown exception stage=" + std::string(stage) +
         " device=" + device_id + " service=" + service +

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -1888,7 +1888,6 @@ fire_and_forget UniversalBlePlugin::SetNotifiableAsync(
     notification_operation_started = true;
 
     const auto gatt_characteristic = gatt_char.obj;
-    const auto uuid = to_uuidstr(gatt_characteristic.Uuid());
 
     // Write to the descriptor.
     GattCommunicationStatus status{};

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -13,6 +13,7 @@
 #include <regex>
 #include <sstream>
 #include <thread>
+#include <utility>
 
 #include "enum_parser.h"
 #include "generated/universal_ble.g.h"
@@ -117,8 +118,15 @@ void UniversalBlePlugin::EnableBluetooth(
   }
 
   bluetooth_radio_.SetStateAsync(RadioState::On)
-      .Completed([&, result](const IAsyncOperation<RadioAccessStatus> &sender,
-                             const AsyncStatus args) {
+      .Completed([result](const IAsyncOperation<RadioAccessStatus> &sender,
+                          const AsyncStatus args) {
+        if (args != AsyncStatus::Completed) {
+          result(create_flutter_error(
+              UniversalBleErrorCode::kFailed,
+              args == AsyncStatus::Canceled ? "Enable bluetooth was cancelled"
+                                            : "Failed to enable bluetooth"));
+          return;
+        }
         if (const auto radio_access_status = sender.GetResults();
             radio_access_status == RadioAccessStatus::Allowed) {
           result(true);
@@ -143,8 +151,15 @@ void UniversalBlePlugin::DisableBluetooth(
   }
 
   bluetooth_radio_.SetStateAsync(RadioState::Off)
-      .Completed([&, result](IAsyncOperation<RadioAccessStatus> const &sender,
-                             AsyncStatus const args) {
+      .Completed([result](IAsyncOperation<RadioAccessStatus> const &sender,
+                          AsyncStatus const args) {
+        if (args != AsyncStatus::Completed) {
+          result(create_flutter_error(
+              UniversalBleErrorCode::kFailed,
+              args == AsyncStatus::Canceled ? "Disable bluetooth was cancelled"
+                                            : "Failed to disable bluetooth"));
+          return;
+        }
         if (const auto radio_access_status = sender.GetResults();
             radio_access_status == RadioAccessStatus::Allowed) {
           result(true);
@@ -259,14 +274,13 @@ ErrorOr<bool> UniversalBlePlugin::IsScanning() {
 
 ErrorOr<BleConnectionState>
 UniversalBlePlugin::GetConnectionState(const std::string &device_id) {
-  const auto it = connected_devices_.find(str_to_mac_address(device_id));
-  if (it == connected_devices_.end()) {
+  const auto device_agent =
+      GetConnectedDevice(str_to_mac_address(device_id));
+  if (!device_agent) {
     return BleConnectionState::kDisconnected;
   }
 
-  const auto device_agent = *it->second;
-
-  if (device_agent.device.ConnectionStatus() ==
+  if (device_agent->device.ConnectionStatus() ==
       BluetoothConnectionStatus::Connected) {
     return BleConnectionState::kConnected;
   } else {
@@ -292,17 +306,9 @@ UniversalBlePlugin::Connect(const std::string &device_id,
 
 std::optional<FlutterError>
 UniversalBlePlugin::Disconnect(const std::string &device_id) {
-  auto device_address = str_to_mac_address(device_id);
-  const auto it = connected_devices_.find(device_address);
-  if (it != connected_devices_.end()) {
-    it->second->device.Close();
-    DisposeServices(it->second);
-  } else {
-    ui_thread_handler_.Post([device_id] {
-      callback_channel->OnConnectionChanged(device_id, false, nullptr,
-                                            SuccessCallback, ErrorCallback);
-    });
-  }
+  const auto device_address = str_to_mac_address(device_id);
+  DisposeConnection(RemoveConnectedDevice(device_address));
+  NotifyConnectionChanged(device_address, false, std::nullopt);
   return std::nullopt;
 }
 
@@ -328,16 +334,16 @@ void UniversalBlePlugin::ReadValue(
   UniversalBleLogger::LogDebugWithTimestamp("READ -> " + device_id + " " +
                                             service + " " + characteristic);
   try {
-    const auto it = connected_devices_.find(str_to_mac_address(device_id));
-    if (it == connected_devices_.end()) {
+    const auto bluetooth_agent =
+        GetConnectedDevice(str_to_mac_address(device_id));
+    if (!bluetooth_agent) {
       result(create_flutter_error(UniversalBleErrorCode::kDeviceNotFound,
                                   "Unknown devicesId:" + device_id));
       return;
     }
 
-    auto bluetooth_agent = *it->second;
-    const GattCharacteristicObject &gatt_characteristic_holder =
-        bluetooth_agent.FetchCharacteristic(service, characteristic);
+    const GattCharacteristicObject gatt_characteristic_holder =
+        bluetooth_agent->FetchCharacteristic(service, characteristic);
     const GattCharacteristic gatt_characteristic =
         gatt_characteristic_holder.obj;
 
@@ -351,8 +357,16 @@ void UniversalBlePlugin::ReadValue(
     }
 
     gatt_characteristic.ReadValueAsync(BluetoothCacheMode::Uncached)
-        .Completed([&, result](IAsyncOperation<GattReadResult> const &sender,
-                               AsyncStatus const args) {
+        .Completed([device_id, service, characteristic, result](
+                       IAsyncOperation<GattReadResult> const &sender,
+                       AsyncStatus const args) {
+          if (args != AsyncStatus::Completed) {
+            result(create_flutter_error(
+                UniversalBleErrorCode::kFailed,
+                args == AsyncStatus::Canceled ? "Read was cancelled"
+                                              : "Read failed"));
+            return;
+          }
           const auto read_value_result = sender.GetResults();
           const auto status = read_value_result.Status();
           if (status != GattCommunicationStatus::Success) {
@@ -383,15 +397,15 @@ void UniversalBlePlugin::WriteValue(
       " len=" + std::to_string(value.size()) +
       " property=" + std::to_string(static_cast<int>(ble_output_property)));
   try {
-    const auto it = connected_devices_.find(str_to_mac_address(device_id));
-    if (it == connected_devices_.end()) {
+    const auto bluetooth_agent =
+        GetConnectedDevice(str_to_mac_address(device_id));
+    if (!bluetooth_agent) {
       result(create_flutter_error(UniversalBleErrorCode::kDeviceNotFound,
                                   "Unknown devicesId:" + device_id));
       return;
     }
-    auto bluetooth_agent = *it->second;
-    const GattCharacteristicObject &gatt_characteristic_holder =
-        bluetooth_agent.FetchCharacteristic(service, characteristic);
+    const GattCharacteristicObject gatt_characteristic_holder =
+        bluetooth_agent->FetchCharacteristic(service, characteristic);
     const GattCharacteristic gatt_characteristic =
         gatt_characteristic_holder.obj;
     const auto properties = gatt_characteristic.CharacteristicProperties();
@@ -418,12 +432,14 @@ void UniversalBlePlugin::WriteValue(
     }
 
     gatt_characteristic.WriteValueAsync(from_bytevc(value), write_option)
-        .Completed([&, result](
+        .Completed([device_id, service, characteristic, result](
                        IAsyncOperation<GattCommunicationStatus> const &sender,
                        AsyncStatus const args) {
-          if (args == AsyncStatus::Error) {
-            result(create_flutter_error(UniversalBleErrorCode::kFailed,
-                                        "Encountered an error."));
+          if (args != AsyncStatus::Completed) {
+            result(create_flutter_error(
+                UniversalBleErrorCode::kFailed,
+                args == AsyncStatus::Canceled ? "Write was cancelled"
+                                              : "Write failed"));
             return;
           }
 
@@ -453,18 +469,21 @@ void UniversalBlePlugin::RequestMtu(
       "REQUEST_MTU -> " + device_id +
       " expected=" + std::to_string(expected_mtu));
   try {
-    const auto it = connected_devices_.find(str_to_mac_address(device_id));
-    if (it == connected_devices_.end()) {
+    const auto bluetooth_agent =
+        GetConnectedDevice(str_to_mac_address(device_id));
+    if (!bluetooth_agent) {
       result(create_flutter_error(UniversalBleErrorCode::kDeviceNotFound,
                                   "Unknown devicesId:" + device_id));
       return;
     }
-    const auto bluetooth_agent = *it->second;
-    GattSession::FromDeviceIdAsync(bluetooth_agent.device.BluetoothDeviceId())
-        .Completed([&, result](IAsyncOperation<GattSession> const &sender,
-                               AsyncStatus const args) {
-          if (args == AsyncStatus::Error) {
-            result(create_flutter_unknown_error());
+    GattSession::FromDeviceIdAsync(bluetooth_agent->device.BluetoothDeviceId())
+        .Completed([result](IAsyncOperation<GattSession> const &sender,
+                            AsyncStatus const args) {
+          if (args != AsyncStatus::Completed) {
+            result(create_flutter_error(
+                UniversalBleErrorCode::kFailed,
+                args == AsyncStatus::Canceled ? "MTU request was cancelled"
+                                              : "MTU request failed"));
             return;
           }
 
@@ -1163,11 +1182,19 @@ void UniversalBlePlugin::NotifyConnectionChanged(
 }
 
 void UniversalBlePlugin::NotifyConnectionException(
-    const uint64_t bluetooth_address, const std::string &error_message) {
+    const uint64_t bluetooth_address, const std::string &error_message,
+    const BluetoothLEDevice *expected_device) {
   UniversalBleLogger::LogError(error_message);
   if (bluetooth_address != 0) {
-    CleanConnection(bluetooth_address);
-    NotifyConnectionChanged(bluetooth_address, false, error_message);
+    if (expected_device == nullptr) {
+      CleanConnection(bluetooth_address);
+      NotifyConnectionChanged(bluetooth_address, false, error_message);
+    } else if (CleanConnection(bluetooth_address, expected_device)) {
+      NotifyConnectionChanged(bluetooth_address, false, error_message);
+    } else {
+      UniversalBleLogger::LogDebug(
+          "Ignoring exception from stale Bluetooth device instance");
+    }
   }
 }
 
@@ -1242,10 +1269,10 @@ fire_and_forget UniversalBlePlugin::ConnectAsync(uint64_t bluetooth_address) {
         device.ConnectionStatusChanged(
             {this,
              &UniversalBlePlugin::BluetoothLeDeviceConnectionStatusChanged});
-    auto device_agent = std::make_unique<BluetoothDeviceAgent>(
+    auto device_agent = std::make_shared<BluetoothDeviceAgent>(
         device, connection_status_changed_token, gatt_map);
-    auto pair = std::make_pair(bluetooth_address, std::move(device_agent));
-    connected_devices_.insert(std::move(pair));
+    DisposeConnection(
+        InstallConnectedDevice(bluetooth_address, std::move(device_agent)));
     UniversalBleLogger::LogInfo("ConnectionLog: Connected");
     NotifyConnectionChanged(bluetooth_address, true, std::nullopt);
   } catch (const hresult_error &err) {
@@ -1265,45 +1292,75 @@ fire_and_forget UniversalBlePlugin::ConnectAsync(uint64_t bluetooth_address) {
 
 void UniversalBlePlugin::BluetoothLeDeviceConnectionStatusChanged(
     const BluetoothLEDevice &sender, const IInspectable &) {
-  uint64_t bluetooth_address = 0;
   try {
-    bluetooth_address = sender.BluetoothAddress();
+    const auto bluetooth_address = sender.BluetoothAddress();
     if (sender.ConnectionStatus() == BluetoothConnectionStatus::Disconnected) {
-      CleanConnection(bluetooth_address);
-      NotifyConnectionChanged(bluetooth_address, false, std::nullopt);
+      if (CleanConnection(bluetooth_address, &sender)) {
+        NotifyConnectionChanged(bluetooth_address, false, std::nullopt);
+      } else {
+        UniversalBleLogger::LogDebug(
+            "Ignoring stale connection status callback");
+      }
     }
   } catch (const hresult_error &err) {
-    NotifyConnectionException(bluetooth_address,
-                              "ConnectionStatusChanged hresult_error hr=" +
-                                  std::to_string(err.code()) +
-                                  " msg=" + to_string(err.message()));
+    UniversalBleLogger::LogError(
+        "ConnectionStatusChanged hresult_error hr=" +
+        std::to_string(err.code()) + " msg=" + to_string(err.message()));
   } catch (const std::exception &ex) {
-    NotifyConnectionException(
-        bluetooth_address,
-        std::string("ConnectionStatusChanged std::exception: ") + ex.what());
+    log_and_swallow("ConnectionStatusChanged std::exception", ex);
   } catch (...) {
-    NotifyConnectionException(bluetooth_address,
-                              "ConnectionStatusChanged unknown exception");
+    log_and_swallow_unknown("ConnectionStatusChanged");
   }
 }
 
-void UniversalBlePlugin::CleanConnection(const uint64_t bluetooth_address) {
+std::shared_ptr<BluetoothDeviceAgent>
+UniversalBlePlugin::GetConnectedDevice(const uint64_t bluetooth_address) {
+  std::lock_guard<std::mutex> lock(connected_devices_mutex_);
+  const auto it = connected_devices_.find(bluetooth_address);
+  return it == connected_devices_.end() ? nullptr : it->second;
+}
+
+std::shared_ptr<BluetoothDeviceAgent>
+UniversalBlePlugin::RemoveConnectedDevice(
+    const uint64_t bluetooth_address,
+    const BluetoothLEDevice *expected_device) {
+  std::lock_guard<std::mutex> lock(connected_devices_mutex_);
+  const auto it = connected_devices_.find(bluetooth_address);
+  if (it == connected_devices_.end() ||
+      (expected_device != nullptr && it->second->device != *expected_device)) {
+    return nullptr;
+  }
+  const auto device_agent = it->second;
+  connected_devices_.erase(it);
+  return device_agent;
+}
+
+std::shared_ptr<BluetoothDeviceAgent>
+UniversalBlePlugin::InstallConnectedDevice(
+    const uint64_t bluetooth_address,
+    std::shared_ptr<BluetoothDeviceAgent> device_agent) {
+  std::lock_guard<std::mutex> lock(connected_devices_mutex_);
+  std::shared_ptr<BluetoothDeviceAgent> previous;
+  const auto it = connected_devices_.find(bluetooth_address);
+  if (it != connected_devices_.end()) {
+    previous = it->second;
+  }
+  connected_devices_.insert_or_assign(bluetooth_address,
+                                      std::move(device_agent));
+  return previous;
+}
+
+bool UniversalBlePlugin::CleanConnection(
+    const uint64_t bluetooth_address,
+    const BluetoothLEDevice *expected_device) {
   try {
-    const auto node = connected_devices_.extract(bluetooth_address);
-    if (!node.empty()) {
-      const auto device_agent = std::move(node.mapped());
-      try {
-        device_agent->device.ConnectionStatusChanged(
-            device_agent->connection_status_changed_token);
-      } catch (const hresult_error &err) {
-        UniversalBleLogger::LogError("CleanConnection hresult_error: " +
-                                     to_string(err.message()));
-      } catch (...) {
-        UniversalBleLogger::LogError(
-            "CleanConnection: failed to remove connection status handler");
-      }
-      DisposeServices(device_agent);
+    const auto device_agent =
+        RemoveConnectedDevice(bluetooth_address, expected_device);
+    if (!device_agent) {
+      return false;
     }
+    DisposeConnection(device_agent);
+    return true;
   } catch (const hresult_error &err) {
     UniversalBleLogger::LogError("CleanConnection outer hresult_error: " +
                                  to_string(err.message()));
@@ -1312,11 +1369,40 @@ void UniversalBlePlugin::CleanConnection(const uint64_t bluetooth_address) {
   } catch (...) {
     log_and_swallow_unknown("CleanConnection");
   }
+  return false;
+}
+
+void UniversalBlePlugin::DisposeConnection(
+    const std::shared_ptr<BluetoothDeviceAgent> &device_agent) {
+  if (!device_agent) {
+    return;
+  }
+  try {
+    device_agent->device.ConnectionStatusChanged(
+        device_agent->connection_status_changed_token);
+  } catch (const hresult_error &err) {
+    UniversalBleLogger::LogError("DisposeConnection hresult_error: " +
+                                 to_string(err.message()));
+  } catch (...) {
+    UniversalBleLogger::LogWarning(
+        "DisposeConnection: failed to remove connection status handler");
+  }
+  DisposeServices(device_agent);
+  try {
+    device_agent->device.Close();
+  } catch (const hresult_error &err) {
+    UniversalBleLogger::LogError("DisposeConnection close hresult_error: " +
+                                 to_string(err.message()));
+  } catch (...) {
+    UniversalBleLogger::LogWarning(
+        "DisposeConnection: failed to close Bluetooth device");
+  }
 }
 
 void UniversalBlePlugin::DisposeServices(
-    const std::unique_ptr<BluetoothDeviceAgent> &device_agent) {
-  for (auto &[service_id, service] : device_agent->gatt_map) {
+    const std::shared_ptr<BluetoothDeviceAgent> &device_agent) {
+  auto gatt_map = device_agent->TakeGattMap();
+  for (auto &[service_id, service] : gatt_map) {
     for (auto &[char_id, characteristic] : service.characteristics) {
       if (characteristic.subscription_token.has_value()) {
         try {
@@ -1334,7 +1420,6 @@ void UniversalBlePlugin::DisposeServices(
       }
     }
   }
-  device_agent->gatt_map.clear();
 }
 
 /**
@@ -1366,15 +1451,18 @@ void UniversalBlePlugin::ResetState() {
     device_watcher_id_to_mac_.clear();
 
     // Close all connected devices and clear map
-    std::vector<uint64_t> addrs;
-    addrs.reserve(connected_devices_.size());
-    for (const auto &p : connected_devices_) {
-      addrs.push_back(p.first);
+    std::vector<std::shared_ptr<BluetoothDeviceAgent>> device_agents;
+    {
+      std::lock_guard<std::mutex> lock(connected_devices_mutex_);
+      device_agents.reserve(connected_devices_.size());
+      for (const auto &entry : connected_devices_) {
+        device_agents.push_back(entry.second);
+      }
+      connected_devices_.clear();
     }
-    for (const auto addr : addrs) {
-      CleanConnection(addr);
+    for (const auto &device_agent : device_agents) {
+      DisposeConnection(device_agent);
     }
-    connected_devices_.clear();
 
     UniversalBleLogger::LogInfo("ResetState: completed clean slate");
   } catch (const hresult_error &err) {
@@ -1447,18 +1535,21 @@ fire_and_forget UniversalBlePlugin::DiscoverServicesAsync(
     const std::string &device_id, bool with_descriptors,
     std::function<void(ErrorOr<flutter::EncodableList> reply)> result) {
   try {
-    const auto it = connected_devices_.find(str_to_mac_address(device_id));
-    if (it == connected_devices_.end()) {
+    const auto device_agent =
+        GetConnectedDevice(str_to_mac_address(device_id));
+    if (!device_agent) {
       result(create_flutter_error(UniversalBleErrorCode::kDeviceNotFound,
                                   "Unknown devicesId:" + device_id));
       co_return;
     }
 
+    const auto gatt_map = device_agent->SnapshotGattMap();
     auto universal_services = flutter::EncodableList();
-    for (auto &[service_id, service] : it->second->gatt_map) {
+    for (const auto &[service_id, service] : gatt_map) {
       flutter::EncodableList universal_characteristics;
-      for (auto [char_id, characteristic] : service.characteristics) {
-        auto &c = characteristic.obj;
+      for (const auto &[char_id, characteristic] :
+           service.characteristics) {
+        const auto c = characteristic.obj;
         const auto properties_value = c.CharacteristicProperties();
         auto properties = properties_to_flutter_encodable(properties_value);
         auto descriptors = flutter::EncodableList();
@@ -1528,22 +1619,56 @@ fire_and_forget UniversalBlePlugin::IsPairedAsync(
 }
 
 fire_and_forget UniversalBlePlugin::SetNotifiableAsync(
-    const std::string &device_id, const std::string &service,
-    const std::string &characteristic,
-    const BleInputProperty &ble_input_property,
+    std::string device_id, std::string service,
+    std::string characteristic,
+    BleInputProperty ble_input_property,
     const std::function<void(std::optional<FlutterError> reply)> result) {
-  UniversalBleLogger::LogDebugWithTimestamp(
-      "SET_NOTIFY -> " + device_id + " " + service + " " + characteristic +
-      " input=" + std::to_string(static_cast<int>(ble_input_property)));
+  const char *stage = "entry";
+  const auto reply = [&result, &stage](
+                         std::optional<FlutterError> response) noexcept {
+    try {
+      result(std::move(response));
+    } catch (const hresult_error &err) {
+      try {
+        UniversalBleLogger::LogError(
+            "SET_NOTIFY reply failed at stage=" + std::string(stage) +
+            " hr=" + std::to_string(err.code()) +
+            " msg=" + to_string(err.message()));
+      } catch (...) {
+      }
+    } catch (const std::exception &err) {
+      try {
+        UniversalBleLogger::LogError(
+            "SET_NOTIFY reply failed at stage=" + std::string(stage) +
+            " exception=" + err.what());
+      } catch (...) {
+      }
+    } catch (...) {
+      try {
+        UniversalBleLogger::LogError(
+            "SET_NOTIFY reply failed at stage=" + std::string(stage) +
+            " with unknown exception");
+      } catch (...) {
+      }
+    }
+  };
   try {
-    const auto it = connected_devices_.find(str_to_mac_address(device_id));
-    if (it == connected_devices_.end()) {
-      result(create_flutter_error(UniversalBleErrorCode::kDeviceNotFound,
-                                  "Unknown devicesId:" + device_id));
+    UniversalBleLogger::LogDebugWithTimestamp(
+        "SET_NOTIFY -> " + device_id + " " + service + " " +
+        characteristic + " input=" +
+        std::to_string(static_cast<int>(ble_input_property)));
+    stage = "lookup-device";
+    const auto device_address = str_to_mac_address(device_id);
+    const auto device_agent = GetConnectedDevice(device_address);
+    if (!device_agent) {
+      reply(create_flutter_error(UniversalBleErrorCode::kDeviceNotFound,
+                                 "Unknown devicesId:" + device_id));
       co_return;
     }
 
-    auto &gatt_char = it->second->FetchCharacteristic(service, characteristic);
+    stage = "lookup-characteristic";
+    const auto gatt_char =
+        device_agent->FetchCharacteristic(service, characteristic);
 
     const auto properties = gatt_char.obj.CharacteristicProperties();
     auto descriptor_value =
@@ -1553,7 +1678,7 @@ fire_and_forget UniversalBlePlugin::SetNotifiableAsync(
           GattClientCharacteristicConfigurationDescriptorValue::Notify;
       if ((properties & GattCharacteristicProperties::Notify) ==
           GattCharacteristicProperties::None) {
-        result(create_flutter_error(
+        reply(create_flutter_error(
             UniversalBleErrorCode::kCharacteristicDoesNotSupportNotify,
             "Characteristic does not support notify"));
         co_return;
@@ -1563,7 +1688,7 @@ fire_and_forget UniversalBlePlugin::SetNotifiableAsync(
           GattClientCharacteristicConfigurationDescriptorValue::Indicate;
       if ((properties & GattCharacteristicProperties::Indicate) ==
           GattCharacteristicProperties::None) {
-        result(create_flutter_error(
+        reply(create_flutter_error(
             UniversalBleErrorCode::kCharacteristicDoesNotSupportIndicate,
             "Characteristic does not support indicate"));
         co_return;
@@ -1576,6 +1701,7 @@ fire_and_forget UniversalBlePlugin::SetNotifiableAsync(
     // Write to the descriptor.
     GattCommunicationStatus status{};
     try {
+      stage = "write-descriptor";
       status = co_await gatt_characteristic
                    .WriteClientCharacteristicConfigurationDescriptorAsync(
                        descriptor_value);
@@ -1584,67 +1710,113 @@ fire_and_forget UniversalBlePlugin::SetNotifiableAsync(
           "SET_NOTIFY exception hr=" + std::to_string(err.code()) +
           " msg=" + to_string(err.message()) + " device=" + device_id +
           " service=" + service + " char=" + characteristic);
-      result(create_flutter_error(UniversalBleErrorCode::kFailed,
-                                  "SetNotifiable exception: " +
-                                      to_string(err.message()),
-                                  "hr=" + std::to_string(err.code())));
+      reply(create_flutter_error(UniversalBleErrorCode::kFailed,
+                                 "SetNotifiable exception: " +
+                                     to_string(err.message()),
+                                 "hr=" + std::to_string(err.code())));
       co_return;
     }
+    stage = "descriptor-completed";
     if (status != GattCommunicationStatus::Success) {
       UniversalBleLogger::LogError("SET_NOTIFY_FAILED <- " + device_id + " " +
                                    service + " " + characteristic + " status=" +
                                    std::to_string(static_cast<int>(status)));
-      result(create_flutter_error_from_gatt_communication_status(status));
+      reply(create_flutter_error_from_gatt_communication_status(status));
       co_return;
     }
 
-    // Register/UnRegister handler for the ValueChanged event.
+    // Register/unregister the ValueChanged handler without retaining a
+    // reference into the agent's GATT map across the co_await above.
+    std::optional<event_token> old_token;
     if (descriptor_value ==
         GattClientCharacteristicConfigurationDescriptorValue::None) {
-      if (gatt_char.subscription_token.has_value()) {
-        gatt_characteristic.ValueChanged(gatt_char.subscription_token.value());
-        gatt_char.subscription_token = std::nullopt;
+      stage = "store-unsubscribe-token";
+      if (!device_agent->ExchangeSubscriptionToken(
+              service, characteristic, std::nullopt, old_token)) {
+        reply(create_flutter_error(UniversalBleErrorCode::kDeviceDisconnected,
+                                   "Device disconnected while unsubscribing"));
+        co_return;
+      }
+      if (old_token.has_value()) {
+        stage = "remove-handler";
+        gatt_characteristic.ValueChanged(old_token.value());
         UniversalBleLogger::LogInfo("Unsubscribed " +
                                     to_uuidstr(gatt_characteristic.Uuid()));
       }
     } else {
-      // If a notification for the given characteristic is already in progress,
-      // swap the callbacks.
-      if (gatt_char.subscription_token.has_value()) {
+      stage = "register-handler";
+      const auto new_token = std::make_optional(
+          gatt_characteristic.ValueChanged(
+              {this, &UniversalBlePlugin::GattCharacteristicValueChanged}));
+      if (!device_agent->ExchangeSubscriptionToken(
+              service, characteristic, new_token, old_token)) {
+        stage = "rollback-handler";
+        try {
+          gatt_characteristic.ValueChanged(new_token.value());
+        } catch (const hresult_error &err) {
+          UniversalBleLogger::LogError(
+              "SET_NOTIFY rollback failed hr=" +
+              std::to_string(err.code()) + " msg=" +
+              to_string(err.message()));
+        } catch (...) {
+          UniversalBleLogger::LogError(
+              "SET_NOTIFY rollback failed with unknown exception");
+        }
+        reply(create_flutter_error(UniversalBleErrorCode::kDeviceDisconnected,
+                                   "Device disconnected while subscribing"));
+        co_return;
+      }
+      if (old_token.has_value()) {
+        stage = "replace-handler";
         UniversalBleLogger::LogWarning(
             "A notification for the given characteristic is already in "
             "progress. Swapping callbacks.");
-        gatt_characteristic.ValueChanged(gatt_char.subscription_token.value());
-        gatt_char.subscription_token = std::nullopt;
+        gatt_characteristic.ValueChanged(old_token.value());
       }
-
-      gatt_char.subscription_token =
-          std::make_optional(gatt_characteristic.ValueChanged(
-              {this, &UniversalBlePlugin::GattCharacteristicValueChanged}));
     }
 
-    result(std::nullopt);
+    stage = "reply-success";
+    reply(std::nullopt);
   } catch (const FlutterError &err) {
-    result(err);
+    reply(err);
   } catch (const hresult_error &err) {
     UniversalBleLogger::LogError(
-        "SetNotifiableLog hresult_error: hr=" + std::to_string(err.code()) +
+        "SetNotifiableLog hresult_error stage=" + std::string(stage) +
+        " hr=" + std::to_string(err.code()) +
         " msg=" + to_string(err.message()) + " device=" + device_id +
         " service=" + service + " char=" + characteristic);
-    result(create_flutter_error(UniversalBleErrorCode::kFailed,
-                                to_string(err.message()),
-                                std::to_string(err.code())));
+    reply(create_flutter_error(UniversalBleErrorCode::kFailed,
+                               to_string(err.message()),
+                               std::to_string(err.code())));
+  } catch (const std::exception &err) {
+    UniversalBleLogger::LogError(
+        "SetNotifiableLog std::exception stage=" + std::string(stage) +
+        " msg=" + err.what() + " device=" + device_id +
+        " service=" + service + " char=" + characteristic);
+    reply(create_flutter_error(UniversalBleErrorCode::kUnknownError,
+                               err.what()));
   } catch (...) {
-    UniversalBleLogger::LogError("SetNotifiableLog: Unknown error");
-    result(create_flutter_unknown_error());
+    UniversalBleLogger::LogError(
+        "SetNotifiableLog unknown exception stage=" + std::string(stage) +
+        " device=" + device_id + " service=" + service +
+        " char=" + characteristic);
+    reply(create_flutter_unknown_error());
   }
 }
 
 void UniversalBlePlugin::GattCharacteristicValueChanged(
     const GattCharacteristic &sender, const GattValueChangedEventArgs &args) {
   uint64_t bluetooth_address = 0;
+  BluetoothLEDevice source_device{nullptr};
   try {
-    bluetooth_address = sender.Service().Device().BluetoothAddress();
+    source_device = sender.Service().Device();
+    bluetooth_address = source_device.BluetoothAddress();
+    const auto current = GetConnectedDevice(bluetooth_address);
+    if (!current || current->device != source_device) {
+      UniversalBleLogger::LogDebug(
+          "Ignoring notification from stale Bluetooth device instance");
+      return;
+    }
     const auto uuid = to_uuidstr(sender.Uuid());
     const auto bytes = to_bytevc(args.CharacteristicValue());
     const auto device_id = mac_address_to_str(bluetooth_address);
@@ -1662,15 +1834,18 @@ void UniversalBlePlugin::GattCharacteristicValueChanged(
     NotifyConnectionException(
         bluetooth_address, "GattCharacteristicValueChanged hresult_error hr=" +
                                std::to_string(err.code()) +
-                               " msg=" + to_string(err.message()));
+                               " msg=" + to_string(err.message()),
+        source_device ? &source_device : nullptr);
   } catch (const std::exception &ex) {
     NotifyConnectionException(
         bluetooth_address,
         std::string("GattCharacteristicValueChanged std::exception: ") +
-            ex.what());
+            ex.what(),
+        source_device ? &source_device : nullptr);
   } catch (...) {
     NotifyConnectionException(
-        bluetooth_address, "GattCharacteristicValueChanged unknown exception");
+        bluetooth_address, "GattCharacteristicValueChanged unknown exception",
+        source_device ? &source_device : nullptr);
   }
 }
 

--- a/windows/src/universal_ble_plugin.h
+++ b/windows/src/universal_ble_plugin.h
@@ -22,6 +22,7 @@
 #include "ui_thread_handler.hpp"
 #include "universal_ble_thread_safe.h"
 #include <memory>
+#include <mutex>
 #include <vector>
 
 namespace universal_ble {
@@ -61,6 +62,7 @@ struct BluetoothDeviceAgent {
   BluetoothLEDevice device;
   event_token connection_status_changed_token;
   std::unordered_map<std::string, GattServiceObject> gatt_map;
+  mutable std::mutex gatt_mutex;
 
   BluetoothDeviceAgent(
       const BluetoothLEDevice &device,
@@ -72,19 +74,54 @@ struct BluetoothDeviceAgent {
 
   ~BluetoothDeviceAgent() { device = nullptr; }
 
-  GattCharacteristicObject &
+  GattCharacteristicObject
   FetchCharacteristic(const std::string &service_uuid,
                       const std::string &characteristic_uuid) {
-    if (gatt_map.count(service_uuid) == 0) {
+    std::lock_guard<std::mutex> lock(gatt_mutex);
+    const auto service = gatt_map.find(service_uuid);
+    if (service == gatt_map.end()) {
       throw create_flutter_error(UniversalBleErrorCode::kServiceNotFound,
                                  "Service not found");
     }
-    if (gatt_map[service_uuid].characteristics.count(characteristic_uuid) ==
-        0) {
+    const auto characteristic =
+        service->second.characteristics.find(characteristic_uuid);
+    if (characteristic == service->second.characteristics.end()) {
       throw create_flutter_error(UniversalBleErrorCode::kCharacteristicNotFound,
                                  "Characteristic not found");
     }
-    return gatt_map[service_uuid].characteristics.at(characteristic_uuid);
+    return characteristic->second;
+  }
+
+  std::unordered_map<std::string, GattServiceObject> SnapshotGattMap() const {
+    std::lock_guard<std::mutex> lock(gatt_mutex);
+    return gatt_map;
+  }
+
+  std::unordered_map<std::string, GattServiceObject> TakeGattMap() {
+    std::lock_guard<std::mutex> lock(gatt_mutex);
+    std::unordered_map<std::string, GattServiceObject> result;
+    result.swap(gatt_map);
+    return result;
+  }
+
+  bool ExchangeSubscriptionToken(
+      const std::string &service_uuid,
+      const std::string &characteristic_uuid,
+      const std::optional<event_token> &new_token,
+      std::optional<event_token> &old_token) {
+    std::lock_guard<std::mutex> lock(gatt_mutex);
+    const auto service = gatt_map.find(service_uuid);
+    if (service == gatt_map.end()) {
+      return false;
+    }
+    const auto characteristic =
+        service->second.characteristics.find(characteristic_uuid);
+    if (characteristic == service->second.characteristics.end()) {
+      return false;
+    }
+    old_token = characteristic->second.subscription_token;
+    characteristic->second.subscription_token = new_token;
+    return true;
   }
 };
 
@@ -126,8 +163,9 @@ private:
   BluetoothLEAdvertisementWatcher bluetooth_le_watcher_{nullptr};
   DeviceWatcher device_watcher_{nullptr};
 
-  std::unordered_map<uint64_t, std::unique_ptr<BluetoothDeviceAgent>>
+  std::unordered_map<uint64_t, std::shared_ptr<BluetoothDeviceAgent>>
       connected_devices_{};
+  std::mutex connected_devices_mutex_;
   ThreadSafeMap<std::string, DeviceInformation> device_watcher_devices_{};
   ThreadSafeMap<std::string, UniversalBleScanResult> scan_results_{};
   // Maps DeviceInformation.Id() -> MAC address string used as key in
@@ -145,9 +183,9 @@ private:
   fire_and_forget InitializeAsync();
   fire_and_forget ConnectAsync(uint64_t bluetooth_address);
   fire_and_forget SetNotifiableAsync(
-      const std::string &device_id, const std::string &service,
-      const std::string &characteristic,
-      const BleInputProperty &ble_input_property,
+      std::string device_id, std::string service,
+      std::string characteristic,
+      BleInputProperty ble_input_property,
       std::function<void(std::optional<FlutterError> reply)> result);
   fire_and_forget PairAsync(const std::string &device_id,
                             std::function<void(ErrorOr<bool> reply)> result);
@@ -181,14 +219,27 @@ private:
   void OnDeviceInfoReceived(const DeviceInformation &device_info);
   void BluetoothLeDeviceConnectionStatusChanged(const BluetoothLEDevice &sender,
                                                 const IInspectable &args);
+  std::shared_ptr<BluetoothDeviceAgent>
+  GetConnectedDevice(uint64_t bluetooth_address);
+  std::shared_ptr<BluetoothDeviceAgent>
+  RemoveConnectedDevice(uint64_t bluetooth_address,
+                        const BluetoothLEDevice *expected_device = nullptr);
+  std::shared_ptr<BluetoothDeviceAgent> InstallConnectedDevice(
+      uint64_t bluetooth_address,
+      std::shared_ptr<BluetoothDeviceAgent> device_agent);
   void NotifyConnectionChanged(uint64_t bluetooth_address, bool connected,
                                std::optional<std::string> error = std::nullopt);
   void NotifyConnectionException(uint64_t bluetooth_address,
-                                 const std::string &error_message);
-  void CleanConnection(uint64_t bluetooth_address);
+                                 const std::string &error_message,
+                                 const BluetoothLEDevice *expected_device =
+                                     nullptr);
+  bool CleanConnection(uint64_t bluetooth_address,
+                       const BluetoothLEDevice *expected_device = nullptr);
+  void DisposeConnection(
+      const std::shared_ptr<BluetoothDeviceAgent> &device_agent);
   void ResetState();
-  void
-  DisposeServices(const std::unique_ptr<BluetoothDeviceAgent> &device_agent);
+  void DisposeServices(
+      const std::shared_ptr<BluetoothDeviceAgent> &device_agent);
 
   void GattCharacteristicValueChanged(const GattCharacteristic &sender,
                                       const GattValueChangedEventArgs &args);

--- a/windows/src/universal_ble_plugin.h
+++ b/windows/src/universal_ble_plugin.h
@@ -29,6 +29,7 @@ namespace universal_ble {
 struct GattCharacteristicObject {
   GattCharacteristic obj = nullptr;
   std::optional<event_token> subscription_token;
+  bool notification_operation_in_progress = false;
 };
 
 struct GattServiceObject {
@@ -104,24 +105,78 @@ struct BluetoothDeviceAgent {
     return result;
   }
 
-  bool ExchangeSubscriptionToken(
+  bool BeginNotificationOperation(
       const std::string &service_uuid,
       const std::string &characteristic_uuid,
-      const std::optional<event_token> &new_token,
-      std::optional<event_token> &old_token) {
+      GattCharacteristicObject &characteristic) {
     std::lock_guard<std::mutex> lock(gatt_mutex);
     const auto service = gatt_map.find(service_uuid);
     if (service == gatt_map.end()) {
       return false;
     }
-    const auto characteristic =
+    const auto found =
         service->second.characteristics.find(characteristic_uuid);
-    if (characteristic == service->second.characteristics.end()) {
+    if (found == service->second.characteristics.end() ||
+        found->second.notification_operation_in_progress) {
       return false;
     }
-    old_token = characteristic->second.subscription_token;
-    characteristic->second.subscription_token = new_token;
+    found->second.notification_operation_in_progress = true;
+    characteristic = found->second;
     return true;
+  }
+
+  bool UpdateNotificationOperationToken(
+      const std::string &service_uuid,
+      const std::string &characteristic_uuid,
+      const std::optional<event_token> &subscription_token) {
+    std::lock_guard<std::mutex> lock(gatt_mutex);
+    const auto service = gatt_map.find(service_uuid);
+    if (service == gatt_map.end()) {
+      return false;
+    }
+    const auto found =
+        service->second.characteristics.find(characteristic_uuid);
+    if (found == service->second.characteristics.end() ||
+        !found->second.notification_operation_in_progress) {
+      return false;
+    }
+    found->second.subscription_token = subscription_token;
+    return true;
+  }
+
+  bool FinishNotificationOperation(
+      const std::string &service_uuid,
+      const std::string &characteristic_uuid,
+      const std::optional<event_token> &subscription_token) {
+    std::lock_guard<std::mutex> lock(gatt_mutex);
+    const auto service = gatt_map.find(service_uuid);
+    if (service == gatt_map.end()) {
+      return false;
+    }
+    const auto found =
+        service->second.characteristics.find(characteristic_uuid);
+    if (found == service->second.characteristics.end() ||
+        !found->second.notification_operation_in_progress) {
+      return false;
+    }
+    found->second.subscription_token = subscription_token;
+    found->second.notification_operation_in_progress = false;
+    return true;
+  }
+
+  void CancelNotificationOperation(
+      const std::string &service_uuid,
+      const std::string &characteristic_uuid) {
+    std::lock_guard<std::mutex> lock(gatt_mutex);
+    const auto service = gatt_map.find(service_uuid);
+    if (service == gatt_map.end()) {
+      return;
+    }
+    const auto found =
+        service->second.characteristics.find(characteristic_uuid);
+    if (found != service->second.characteristics.end()) {
+      found->second.notification_operation_in_progress = false;
+    }
   }
 };
 
@@ -165,6 +220,8 @@ private:
 
   std::unordered_map<uint64_t, std::shared_ptr<BluetoothDeviceAgent>>
       connected_devices_{};
+  std::unordered_map<uint64_t, uint64_t> connect_generations_{};
+  uint64_t next_connect_generation_ = 0;
   std::mutex connected_devices_mutex_;
   ThreadSafeMap<std::string, DeviceInformation> device_watcher_devices_{};
   ThreadSafeMap<std::string, UniversalBleScanResult> scan_results_{};
@@ -181,7 +238,8 @@ private:
   event_revoker<IRadio> radio_state_changed_revoker_;
 
   fire_and_forget InitializeAsync();
-  fire_and_forget ConnectAsync(uint64_t bluetooth_address);
+  fire_and_forget ConnectAsync(uint64_t bluetooth_address,
+                               uint64_t connect_generation);
   fire_and_forget SetNotifiableAsync(
       std::string device_id, std::string service,
       std::string characteristic,
@@ -221,12 +279,21 @@ private:
                                                 const IInspectable &args);
   std::shared_ptr<BluetoothDeviceAgent>
   GetConnectedDevice(uint64_t bluetooth_address);
+  uint64_t BeginConnectAttempt(uint64_t bluetooth_address);
+  void InvalidateConnectAttempt(uint64_t bluetooth_address);
   std::shared_ptr<BluetoothDeviceAgent>
   RemoveConnectedDevice(uint64_t bluetooth_address,
                         const BluetoothLEDevice *expected_device = nullptr);
-  std::shared_ptr<BluetoothDeviceAgent> InstallConnectedDevice(
-      uint64_t bluetooth_address,
-      std::shared_ptr<BluetoothDeviceAgent> device_agent);
+  bool InstallConnectedDevice(
+      uint64_t bluetooth_address, uint64_t connect_generation,
+      std::shared_ptr<BluetoothDeviceAgent> device_agent,
+      std::shared_ptr<BluetoothDeviceAgent> &previous_device_agent);
+  bool NotifyConnectedIfCurrent(
+      uint64_t bluetooth_address, uint64_t connect_generation,
+      const BluetoothLEDevice &expected_device);
+  void NotifyConnectFailureIfCurrent(
+      uint64_t bluetooth_address, uint64_t connect_generation,
+      const std::string &error_message) noexcept;
   void NotifyConnectionChanged(uint64_t bluetooth_address, bool connected,
                                std::optional<std::string> error = std::nullopt);
   void NotifyConnectionException(uint64_t bluetooth_address,


### PR DESCRIPTION
## Summary

This PR hardens the Windows BLE implementation against connection lifecycle races, stale native callbacks, unsafe WinRT completion handling, and inconsistent notification subscription state.

It builds on the exception handling introduced in #217, focusing on cases where GATT operations, disconnects, reconnects, and asynchronous callbacks overlap.

## Problem

Connected-device state is accessed by Flutter method handlers, WinRT callbacks, and coroutine continuations. Without synchronized ownership and stale-operation protection, this can allow:

- disconnect cleanup to destroy state still used by an in-flight operation;
- an older connection attempt or callback to interfere with a newer connection;
- a pending connection to report success after it was disconnected;
- GATT service or subscription state to change while another operation uses it;
- failed or cancelled WinRT operations to call `GetResults()`;
- exceptions to escape native completion callbacks;
- subscription tokens to become inconsistent with registered native handlers;
- overlapping notification operations on the same characteristic.

## Changes

### Connection ownership and synchronization

- Store connected-device agents using `shared_ptr`.
- Synchronize connection lookup, installation, replacement, and removal.
- Retain device agents for operations that may outlive map ownership.
- Remove connections from shared storage before disposing native resources.
- Atomically replace existing connections and dispose the previous agent.

### Stale connection protection

- Assign a generation to each connection attempt.
- Allow only the current attempt to install a connection or publish its result.
- Invalidate pending attempts when disconnect is requested.
- Ignore callbacks and failures from superseded device instances.
- Prevent an older attempt from replacing or disconnecting a newer connection.

### Deterministic cleanup

- Unregister connection-status handlers before releasing services.
- Detach GATT state before disposing subscriptions.
- Close the native device after handlers and services are released.
- Publish consistent disconnected events for explicit disconnects.

### GATT and notification safety

- Protect GATT characteristics and subscription tokens with an agent-level mutex.
- Return copied characteristic handles instead of references into shared maps.
- Use GATT snapshots during asynchronous service discovery.
- Serialize notification changes per characteristic, not globally.
- Commit subscription-token changes only after native handler operations succeed.
- Roll back newly registered handlers if the device disconnects during subscription.
- Avoid conflicting cleanup while a notification operation owns the characteristic.

### WinRT completion safety

- Verify `AsyncStatus::Completed` before calling `GetResults()`.
- Report cancelled reads, writes, MTU requests, and Bluetooth operations separately.
- Capture asynchronous callback data by value instead of retaining stack references.
- Catch exceptions raised inside completion callbacks.
- Safely contain exceptions produced while returning results to Dart.

## Scope

The changes are limited to the Windows central/client implementation. Public Dart APIs and behavior on Android, Apple, Linux, and Web are unchanged.

## Verification

- flutter analyze and test
- Manual Windows testing with a physical BLE device
  - Device scanning
  - Connection and service discovery
  - Notification subscription and unsubscription
  - Repeated characteristic reads and writes
  - Intentional disconnect
