### PR TITLE
Handle service discovery failure on Apple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Windows: Harden BLE connection lifetime, asynchronous callbacks, and notification subscription handling
 * Android: instantly close the GATT client on disconnect
 * Android: complete only the oldest matching pending write on onCharacteristicWrite
+* iOS/macOS: Handle service discovery failure and timeout to prevent poisoning subsequent `discoverServices` calls
 
 ## 2.1.1
 * Android: Fix BluetoothDevice null-safety compile error under Kotlin 2.x

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBleAsyncServiceDiscovery.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBleAsyncServiceDiscovery.swift
@@ -17,7 +17,10 @@ class UniversalBleAsyncServiceDiscovery: NSObject {
     private var discoveredDescriptorsSet: Set<String> = []
     private var expectedCharacteristicsCountMap: [String: Int] = [:]
     private var isDiscoveryInProgress = false
+    private var hasCompleted = false
     private var withDescriptors: Bool
+    private var timeoutWorkItem: DispatchWorkItem?
+    private let timeoutSeconds: TimeInterval = 10.0
 
     init(peripheral: CBPeripheral, deviceId: String, withDescriptors: Bool, completion: @escaping (Result<[UniversalBleService], Error>) -> Void) {
         self.peripheral = peripheral
@@ -29,11 +32,19 @@ class UniversalBleAsyncServiceDiscovery: NSObject {
 
     /// Starts the service discovery process
     func startDiscovery() {
-        guard !isDiscoveryInProgress else {
+        guard !isDiscoveryInProgress, !hasCompleted else {
             UniversalBleLogger.shared.logWarning("Service discovery already in progress for device: \(deviceId)")
             return
         }
         isDiscoveryInProgress = true
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self = self, !self.hasCompleted else { return }
+            UniversalBleLogger.shared.logError("Service discovery timed out for device: \(self.deviceId)")
+            self.completeWith(result: .failure(createFlutterError(code: .failed, message: "Service discovery timed out for device: \(self.deviceId)")))
+        }
+        self.timeoutWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeoutSeconds, execute: workItem)
 
         // Check if services are already cached
         if let cachedServices = peripheral.services, !cachedServices.isEmpty {
@@ -43,12 +54,26 @@ class UniversalBleAsyncServiceDiscovery: NSObject {
         }
     }
 
+    /// Cancels the service discovery and fails completion
+    func cancel(error: Error) {
+        completeWith(result: .failure(error))
+    }
+
     /// Cleans up discovery state
     func cleanup() {
         isDiscoveryInProgress = false
+        timeoutWorkItem?.cancel()
+        timeoutWorkItem = nil
         discoveredServicesProgressMap.removeAll()
         discoveredDescriptorsSet.removeAll()
         expectedCharacteristicsCountMap.removeAll()
+    }
+
+    private func completeWith(result: Result<[UniversalBleService], Error>) {
+        guard !hasCompleted else { return }
+        hasCompleted = true
+        cleanup()
+        completion(result)
     }
 
     private func handleServicesDiscovered(_ services: [CBService]) {
@@ -176,8 +201,7 @@ class UniversalBleAsyncServiceDiscovery: NSObject {
         guard discoveredServicesProgressMap.allSatisfy({ $0.characteristics != nil }) else {
             return
         }
-        completion(.success(discoveredServicesProgressMap))
-        cleanup()
+        completeWith(result: .success(discoveredServicesProgressMap))
     }
 }
 
@@ -185,13 +209,11 @@ class UniversalBleAsyncServiceDiscovery: NSObject {
 extension UniversalBleAsyncServiceDiscovery {
     func handleDidDiscoverServices(_ peripheral: CBPeripheral, error: Error?) {
         guard error == nil else {
-            completion(.failure(error!))
-            cleanup()
+            completeWith(result: .failure(error!))
             return
         }
         guard let services = peripheral.services else {
-            completion(.success([]))
-            cleanup()
+            completeWith(result: .success([]))
             return
         }
         handleServicesDiscovered(services)
@@ -199,8 +221,7 @@ extension UniversalBleAsyncServiceDiscovery {
 
     func handleDidDiscoverCharacteristicsFor(_: CBPeripheral, service: CBService, error: Error?) {
         guard error == nil else {
-            completion(.failure(error!))
-            cleanup()
+            completeWith(result: .failure(error!))
             return
         }
         processCharacteristicsForService(service)
@@ -208,8 +229,7 @@ extension UniversalBleAsyncServiceDiscovery {
 
     func handleDidDiscoverDescriptorsFor(_: CBPeripheral, characteristic: CBCharacteristic, error: Error?) {
         guard error == nil else {
-            completion(.failure(error!))
-            cleanup()
+            completeWith(result: .failure(error!))
             return
         }
         handleDescriptorsDiscovered(for: characteristic)

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBleHelper.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBleHelper.swift
@@ -65,6 +65,23 @@ extension CBManagerState {
     }
 }
 
+extension CBPeripheralState {
+    var toBleConnectionState: BleConnectionState {
+        switch self {
+        case .connecting:
+            return .connecting
+        case .connected:
+            return .connected
+        case .disconnecting:
+            return .disconnecting
+        case .disconnected:
+            return .disconnected
+        @unknown default:
+            return .disconnected
+        }
+    }
+}
+
 /// Maps string error codes to UniversalBleErrorCode enum
 func mapErrorCodeToEnum(_ code: String) -> UniversalBleErrorCode {
     switch code.lowercased() {
@@ -138,9 +155,8 @@ public extension CBUUID {
 }
 
 public extension CBPeripheral {
-    // FIXME: https://forums.developer.apple.com/thread/84375
     var uuid: UUID {
-        value(forKey: "identifier") as! NSUUID as UUID
+        identifier
     }
 
     func getCharacteristic(_ characteristic: String, of service: String) -> CBCharacteristic? {
@@ -176,8 +192,25 @@ extension FlutterStandardTypedData {
     }
 }
 
-// Future classes
-class CharacteristicReadFuture {
+// Future protocol and implementations
+protocol DeviceFuture {
+    var deviceId: String { get }
+    func fail(with error: Error)
+}
+
+extension Array where Element: DeviceFuture {
+    mutating func failAndRemoveAll(matching deviceId: String, with error: Error) {
+        removeAll { future in
+            if future.deviceId.caseInsensitiveCompare(deviceId) == .orderedSame {
+                future.fail(with: error)
+                return true
+            }
+            return false
+        }
+    }
+}
+
+class CharacteristicReadFuture: DeviceFuture {
     let deviceId: String
     let characteristicId: String
     let serviceId: String?
@@ -189,9 +222,13 @@ class CharacteristicReadFuture {
         self.serviceId = serviceId
         self.result = result
     }
+
+    func fail(with error: Error) {
+        result(.failure(error))
+    }
 }
 
-class CharacteristicWriteFuture {
+class CharacteristicWriteFuture: DeviceFuture {
     let deviceId: String
     let characteristicId: String
     let serviceId: String?
@@ -203,9 +240,13 @@ class CharacteristicWriteFuture {
         self.serviceId = serviceId
         self.result = result
     }
+
+    func fail(with error: Error) {
+        result(.failure(error))
+    }
 }
 
-class CharacteristicNotifyFuture {
+class CharacteristicNotifyFuture: DeviceFuture {
     let deviceId: String
     let characteristicId: String
     let serviceId: String?
@@ -217,9 +258,13 @@ class CharacteristicNotifyFuture {
         self.serviceId = serviceId
         self.result = result
     }
+
+    func fail(with error: Error) {
+        result(.failure(error))
+    }
 }
 
-class DiscoverServicesFuture {
+class DiscoverServicesFuture: DeviceFuture {
     let deviceId: String
     let result: (Result<[UniversalBleService], Error>) -> Void
 
@@ -227,9 +272,13 @@ class DiscoverServicesFuture {
         self.deviceId = deviceId
         self.result = result
     }
+
+    func fail(with error: Error) {
+        result(.failure(error))
+    }
 }
 
-class RssiReadFuture {
+class RssiReadFuture: DeviceFuture {
     let deviceId: String
     let result: (Result<Int64, Error>) -> Void
 
@@ -237,9 +286,13 @@ class RssiReadFuture {
         self.deviceId = deviceId
         self.result = result
     }
+
+    func fail(with error: Error) {
+        result(.failure(error))
+    }
 }
 
-class DescriptorReadFuture {
+class DescriptorReadFuture: DeviceFuture {
     let deviceId: String
     let descriptorId: String
     let characteristicId: String
@@ -253,9 +306,13 @@ class DescriptorReadFuture {
         self.serviceId = serviceId
         self.result = result
     }
+
+    func fail(with error: Error) {
+        result(.failure(error))
+    }
 }
 
-class DescriptorWriteFuture {
+class DescriptorWriteFuture: DeviceFuture {
     let deviceId: String
     let descriptorId: String
     let characteristicId: String
@@ -268,5 +325,9 @@ class DescriptorWriteFuture {
         self.characteristicId = characteristicId
         self.serviceId = serviceId
         self.result = result
+    }
+
+    func fail(with error: Error) {
+        result(.failure(error))
     }
 }

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
@@ -289,10 +289,11 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
     rssiReadFutures.failAndRemoveAll(matching: deviceId, with: error)
 
     // Cancel and fail any active service discovery for this device
-    for (key, discovery) in activeServiceDiscoveries where key.caseInsensitiveCompare(deviceId) == .orderedSame {
+    let matchingKeys = activeServiceDiscoveries.keys.filter { $0.caseInsensitiveCompare(deviceId) == .orderedSame }
+    let discoveriesToCancel = matchingKeys.compactMap { activeServiceDiscoveries.removeValue(forKey: $0) }
+    for discovery in discoveriesToCancel {
       discovery.cancel(error: error)
     }
-    activeServiceDiscoveries = activeServiceDiscoveries.filter { $0.key.caseInsensitiveCompare(deviceId) != .orderedSame }
 
     discoverServicesFutures.failAndRemoveAll(matching: deviceId, with: error)
   }

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
@@ -274,95 +274,27 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
     guard let peripheral = deviceId.findPeripheral(manager: manager) else {
       return .disconnected
     }
-    switch peripheral.state {
-    case .connecting:
-      return .connecting
-    case .connected:
-      return .connected
-    case .disconnecting:
-      return .disconnecting
-    case .disconnected:
-      return .disconnected
-    @unknown default:
-      return .disconnected
-    }
+    return peripheral.state.toBleConnectionState
   }
 
   func cleanUpConnection(deviceId: String) {
-    let matchesDeviceId: (String) -> Bool = { targetId in
-      targetId.caseInsensitiveCompare(deviceId) == .orderedSame
-    }
+    let error = createFlutterError(code: .deviceDisconnected, message: "Device Disconnected")
 
-    characteristicReadFutures.removeAll { future in
-      if matchesDeviceId(future.deviceId) {
-        future.result(
-          Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
-        )
-        return true
-      }
-      return false
-    }
-    characteristicWriteFutures.removeAll { future in
-      if matchesDeviceId(future.deviceId) {
-        future.result(
-          Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
-        )
-        return true
-      }
-      return false
-    }
-    characteristicNotifyFutures.removeAll { future in
-      if matchesDeviceId(future.deviceId) {
-        future.result(
-          Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
-        )
-        return true
-      }
-      return false
-    }
-    descriptorReadFutures.removeAll { future in
-      if matchesDeviceId(future.deviceId) {
-        future.result(
-          Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
-        )
-        return true
-      }
-      return false
-    }
-    descriptorWriteFutures.removeAll { future in
-      if matchesDeviceId(future.deviceId) {
-        future.result(
-          Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
-        )
-        return true
-      }
-      return false
-    }
-    rssiReadFutures.removeAll { future in
-      if matchesDeviceId(future.deviceId) {
-        future.result(
-          Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
-        )
-        return true
-      }
-      return false
-    }
+    characteristicReadFutures.failAndRemoveAll(matching: deviceId, with: error)
+    characteristicWriteFutures.failAndRemoveAll(matching: deviceId, with: error)
+    characteristicWriteWithoutResponseFutures.failAndRemoveAll(matching: deviceId, with: error)
+    characteristicNotifyFutures.failAndRemoveAll(matching: deviceId, with: error)
+    descriptorReadFutures.failAndRemoveAll(matching: deviceId, with: error)
+    descriptorWriteFutures.failAndRemoveAll(matching: deviceId, with: error)
+    rssiReadFutures.failAndRemoveAll(matching: deviceId, with: error)
 
     // Cancel and fail any active service discovery for this device
-    for (key, discovery) in activeServiceDiscoveries where matchesDeviceId(key) {
-      discovery.cancel(error: createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
+    for (key, discovery) in activeServiceDiscoveries where key.caseInsensitiveCompare(deviceId) == .orderedSame {
+      discovery.cancel(error: error)
     }
-    activeServiceDiscoveries = activeServiceDiscoveries.filter { !matchesDeviceId($0.key) }
+    activeServiceDiscoveries = activeServiceDiscoveries.filter { $0.key.caseInsensitiveCompare(deviceId) != .orderedSame }
 
-    discoverServicesFutures.removeAll { future in
-      if matchesDeviceId(future.deviceId) {
-        future.result(
-          Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
-        )
-        return true
-      }
-      return false
-    }
+    discoverServicesFutures.failAndRemoveAll(matching: deviceId, with: error)
   }
 
   func discoverServices(deviceId: String, withDescriptors: Bool, completion: @escaping (Result<[UniversalBleService], Error>) -> Void) {

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
@@ -289,8 +289,12 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
   }
 
   func cleanUpConnection(deviceId: String) {
+    let matchesDeviceId: (String) -> Bool = { targetId in
+      targetId.caseInsensitiveCompare(deviceId) == .orderedSame
+    }
+
     characteristicReadFutures.removeAll { future in
-      if future.deviceId == deviceId {
+      if matchesDeviceId(future.deviceId) {
         future.result(
           Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
         )
@@ -299,7 +303,7 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
       return false
     }
     characteristicWriteFutures.removeAll { future in
-      if future.deviceId == deviceId {
+      if matchesDeviceId(future.deviceId) {
         future.result(
           Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
         )
@@ -308,7 +312,7 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
       return false
     }
     characteristicNotifyFutures.removeAll { future in
-      if future.deviceId == deviceId {
+      if matchesDeviceId(future.deviceId) {
         future.result(
           Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
         )
@@ -317,7 +321,7 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
       return false
     }
     descriptorReadFutures.removeAll { future in
-      if future.deviceId == deviceId {
+      if matchesDeviceId(future.deviceId) {
         future.result(
           Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
         )
@@ -326,16 +330,7 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
       return false
     }
     descriptorWriteFutures.removeAll { future in
-      if future.deviceId == deviceId {
-        future.result(
-          Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
-        )
-        return true
-      }
-      return false
-    }
-    discoverServicesFutures.removeAll { future in
-      if future.deviceId == deviceId {
+      if matchesDeviceId(future.deviceId) {
         future.result(
           Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
         )
@@ -344,7 +339,7 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
       return false
     }
     rssiReadFutures.removeAll { future in
-      if future.deviceId == deviceId {
+      if matchesDeviceId(future.deviceId) {
         future.result(
           Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
         )
@@ -352,8 +347,22 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
       }
       return false
     }
-    activeServiceDiscoveries[deviceId]?.cleanup()
-    activeServiceDiscoveries[deviceId] = nil
+
+    // Cancel and fail any active service discovery for this device
+    for (key, discovery) in activeServiceDiscoveries where matchesDeviceId(key) {
+      discovery.cancel(error: createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
+    }
+    activeServiceDiscoveries = activeServiceDiscoveries.filter { !matchesDeviceId($0.key) }
+
+    discoverServicesFutures.removeAll { future in
+      if matchesDeviceId(future.deviceId) {
+        future.result(
+          Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device Disconnected"))
+        )
+        return true
+      }
+      return false
+    }
   }
 
   func discoverServices(deviceId: String, withDescriptors: Bool, completion: @escaping (Result<[UniversalBleService], Error>) -> Void) {
@@ -364,33 +373,43 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
       return
     }
 
-    // Check if discovery is already in progress
-    if activeServiceDiscoveries[deviceId] != nil {
-      UniversalBleLogger.shared.logWarning("Services discovery already in progress for :\(deviceId), waiting for completion.")
-      discoverServicesFutures.append(DiscoverServicesFuture(deviceId: deviceId, result: completion))
+    guard peripheral.state == .connected else {
+      completion(
+        Result.failure(createFlutterError(code: .deviceDisconnected, message: "Device is not connected"))
+      )
       return
     }
 
-    let wrappedCompletion: (Result<[UniversalBleService], Error>) -> Void = { result in
+    let normalizedDeviceId = peripheral.uuid.uuidString
+
+    // Check if discovery is already in progress
+    if activeServiceDiscoveries[normalizedDeviceId] != nil {
+      UniversalBleLogger.shared.logWarning("Services discovery already in progress for :\(normalizedDeviceId), waiting for completion.")
+      discoverServicesFutures.append(DiscoverServicesFuture(deviceId: normalizedDeviceId, result: completion))
+      return
+    }
+
+    let wrappedCompletion: (Result<[UniversalBleService], Error>) -> Void = { [weak self] result in
+      guard let self = self else { return }
       completion(result)
       self.discoverServicesFutures.removeAll { future in
-        if future.deviceId == deviceId {
+        if future.deviceId.caseInsensitiveCompare(normalizedDeviceId) == .orderedSame {
           future.result(result)
           return true
         }
         return false
       }
-      self.activeServiceDiscoveries[deviceId] = nil
+      self.activeServiceDiscoveries.removeValue(forKey: normalizedDeviceId)
     }
 
     let discovery = UniversalBleAsyncServiceDiscovery(
       peripheral: peripheral,
-      deviceId: deviceId,
+      deviceId: normalizedDeviceId,
       withDescriptors: withDescriptors,
       completion: wrappedCompletion
     )
 
-    activeServiceDiscoveries[deviceId] = discovery
+    activeServiceDiscoveries[normalizedDeviceId] = discovery
     discovery.startDiscovery()
   }
 
@@ -703,6 +722,7 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
 
     if #available(iOS 17.0, macOS 14.0, watchOS 10.0, tvOS 17.0, *) {
       if isReconnecting {
+        cleanUpConnection(deviceId: deviceId)
         return
       }
     }
@@ -721,15 +741,18 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
   }
 
   public func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-    activeServiceDiscoveries[peripheral.identifier.uuidString]?.handleDidDiscoverServices(peripheral, error: error)
+    let deviceId = peripheral.uuid.uuidString
+    activeServiceDiscoveries[deviceId]?.handleDidDiscoverServices(peripheral, error: error)
   }
 
   public func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
-    activeServiceDiscoveries[peripheral.identifier.uuidString]?.handleDidDiscoverCharacteristicsFor(peripheral, service: service, error: error)
+    let deviceId = peripheral.uuid.uuidString
+    activeServiceDiscoveries[deviceId]?.handleDidDiscoverCharacteristicsFor(peripheral, service: service, error: error)
   }
 
   public func peripheral(_ peripheral: CBPeripheral, didDiscoverDescriptorsFor characteristic: CBCharacteristic, error: Error?) {
-    activeServiceDiscoveries[peripheral.identifier.uuidString]?.handleDidDiscoverDescriptorsFor(peripheral, characteristic: characteristic, error: error)
+    let deviceId = peripheral.uuid.uuidString
+    activeServiceDiscoveries[deviceId]?.handleDidDiscoverDescriptorsFor(peripheral, characteristic: characteristic, error: error)
   }
 
   public func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {


### PR DESCRIPTION
Fixes https://github.com/Navideck/universal_ble/issues/285

This pull request introduces several improvements and refactorings to the BLE (Bluetooth Low Energy) plugin for Darwin platforms, focusing on service discovery robustness, code maintainability, and error handling. The main changes include adding a timeout mechanism for service discovery, centralizing and simplifying future failure handling, normalizing device identifiers, and improving state mapping and cleanup logic.

**Service Discovery Improvements:**

- Added a timeout for service discovery in `UniversalBleAsyncServiceDiscovery`, ensuring that the process fails gracefully if it takes too long. Also added a `cancel(error:)` method to allow explicit cancellation and failure propagation. [[1]](diffhunk://#diff-5035b31f0c7cea10c3c2b3f909f45d4118defbb175a65b638bfcc609a562141dR20-R23) [[2]](diffhunk://#diff-5035b31f0c7cea10c3c2b3f909f45d4118defbb175a65b638bfcc609a562141dL32-R48) [[3]](diffhunk://#diff-5035b31f0c7cea10c3c2b3f909f45d4118defbb175a65b638bfcc609a562141dR57-R78)
- Ensured completion handlers are only called once per discovery by introducing a `hasCompleted` flag and centralizing completion logic in `completeWith(result:)`. [[1]](diffhunk://#diff-5035b31f0c7cea10c3c2b3f909f45d4118defbb175a65b638bfcc609a562141dR57-R78) [[2]](diffhunk://#diff-5035b31f0c7cea10c3c2b3f909f45d4118defbb175a65b638bfcc609a562141dL179-R232)

**Device Identifier Normalization:**

- Normalized usage of device identifiers to always use `peripheral.uuid.uuidString` instead of `peripheral.identifier.uuidString`, reducing subtle bugs and ensuring consistent keying in dictionaries. This change impacts service discovery, delegate callbacks, and future management. [[1]](diffhunk://#diff-ca0dd68e4d787a3e6f763de0e881bf8a32c380c675d51536414d1da584cb03c2L141-R159) [[2]](diffhunk://#diff-d5fb6ec688768d7e937b42a7630fc26851a0953499e8db57a12045e561a6ddd4R309-R345) [[3]](diffhunk://#diff-d5fb6ec688768d7e937b42a7630fc26851a0953499e8db57a12045e561a6ddd4L724-R688)

**Future Handling and Cleanup:**

- Introduced a `DeviceFuture` protocol and a generic `failAndRemoveAll(matching:with:)` extension for arrays of futures, greatly simplifying and centralizing the logic for failing and removing all futures associated with a device. All future classes now conform to this protocol. [[1]](diffhunk://#diff-ca0dd68e4d787a3e6f763de0e881bf8a32c380c675d51536414d1da584cb03c2L179-R213) [[2]](diffhunk://#diff-ca0dd68e4d787a3e6f763de0e881bf8a32c380c675d51536414d1da584cb03c2R225-R231) [[3]](diffhunk://#diff-ca0dd68e4d787a3e6f763de0e881bf8a32c380c675d51536414d1da584cb03c2R243-R249) [[4]](diffhunk://#diff-ca0dd68e4d787a3e6f763de0e881bf8a32c380c675d51536414d1da584cb03c2R261-R295) [[5]](diffhunk://#diff-ca0dd68e4d787a3e6f763de0e881bf8a32c380c675d51536414d1da584cb03c2R309-R315) [[6]](diffhunk://#diff-ca0dd68e4d787a3e6f763de0e881bf8a32c380c675d51536414d1da584cb03c2R329-R332) [[7]](diffhunk://#diff-d5fb6ec688768d7e937b42a7630fc26851a0953499e8db57a12045e561a6ddd4L277-R298)
- Refactored `cleanUpConnection(deviceId:)` to use the new future handling, and to properly cancel and fail any active service discoveries for the device.

**State Mapping Improvements:**

- Added an extension to map `CBPeripheralState` directly to the plugin's `BleConnectionState`, simplifying and centralizing state conversion logic. [[1]](diffhunk://#diff-ca0dd68e4d787a3e6f763de0e881bf8a32c380c675d51536414d1da584cb03c2R68-R84) [[2]](diffhunk://#diff-d5fb6ec688768d7e937b42a7630fc26851a0953499e8db57a12045e561a6ddd4L277-R298)

**Other Fixes and Cleanups:**

- Ensured service discovery only starts for connected peripherals, and improved logging and error reporting throughout the process.
- Minor code cleanups, such as removing an old `FIXME` and using the public `identifier` property for `CBPeripheral.uuid`.

These changes make the BLE plugin more robust, maintainable, and safer in the face of asynchronous errors and device disconnects.