### PR TITLE
Expose precise BLE scan timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 2.2.0
+* Expose microsecond scan timestamps captured before Flutter event dispatch
 * Lower minimum Dart SDK to 3.3 (Flutter 3.19+) to restore compatibility with older stable Flutter releases
 * Add `BleCommandQueue` support to `UniversalBlePeripheral` (`queueType`, `timeout`, `clearQueue`, and `onQueueUpdate`)
 * iOS/macOS: Handle CoreBluetooth peripheral transmit queue exhaustion and error handling in `updateCharacteristicValue`

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBle.g.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBle.g.kt
@@ -489,7 +489,8 @@ data class UniversalBleScanResult (
   val manufacturerDataList: List<UniversalManufacturerData>? = null,
   val serviceData: Map<String, ByteArray>? = null,
   val services: List<String>? = null,
-  val timestamp: Long? = null
+  val timestamp: Long? = null,
+  val timestampMicroseconds: Long? = null
 )
  {
   companion object {
@@ -502,7 +503,8 @@ data class UniversalBleScanResult (
       val serviceData = pigeonVar_list[5] as Map<String, ByteArray>?
       val services = pigeonVar_list[6] as List<String>?
       val timestamp = pigeonVar_list[7] as Long?
-      return UniversalBleScanResult(deviceId, name, isPaired, rssi, manufacturerDataList, serviceData, services, timestamp)
+      val timestampMicroseconds = pigeonVar_list[8] as Long?
+      return UniversalBleScanResult(deviceId, name, isPaired, rssi, manufacturerDataList, serviceData, services, timestamp, timestampMicroseconds)
     }
   }
   fun toList(): List<Any?> {
@@ -515,6 +517,7 @@ data class UniversalBleScanResult (
       serviceData,
       services,
       timestamp,
+      timestampMicroseconds,
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -525,7 +528,7 @@ data class UniversalBleScanResult (
       return true
     }
     val other = other as UniversalBleScanResult
-    return UniversalBlePigeonUtils.deepEquals(this.deviceId, other.deviceId) && UniversalBlePigeonUtils.deepEquals(this.name, other.name) && UniversalBlePigeonUtils.deepEquals(this.isPaired, other.isPaired) && UniversalBlePigeonUtils.deepEquals(this.rssi, other.rssi) && UniversalBlePigeonUtils.deepEquals(this.manufacturerDataList, other.manufacturerDataList) && UniversalBlePigeonUtils.deepEquals(this.serviceData, other.serviceData) && UniversalBlePigeonUtils.deepEquals(this.services, other.services) && UniversalBlePigeonUtils.deepEquals(this.timestamp, other.timestamp)
+    return UniversalBlePigeonUtils.deepEquals(this.deviceId, other.deviceId) && UniversalBlePigeonUtils.deepEquals(this.name, other.name) && UniversalBlePigeonUtils.deepEquals(this.isPaired, other.isPaired) && UniversalBlePigeonUtils.deepEquals(this.rssi, other.rssi) && UniversalBlePigeonUtils.deepEquals(this.manufacturerDataList, other.manufacturerDataList) && UniversalBlePigeonUtils.deepEquals(this.serviceData, other.serviceData) && UniversalBlePigeonUtils.deepEquals(this.services, other.services) && UniversalBlePigeonUtils.deepEquals(this.timestamp, other.timestamp) && UniversalBlePigeonUtils.deepEquals(this.timestampMicroseconds, other.timestampMicroseconds)
   }
 
   override fun hashCode(): Int {
@@ -538,6 +541,7 @@ data class UniversalBleScanResult (
     result = 31 * result + UniversalBlePigeonUtils.deepHash(this.serviceData)
     result = 31 * result + UniversalBlePigeonUtils.deepHash(this.services)
     result = 31 * result + UniversalBlePigeonUtils.deepHash(this.timestamp)
+    result = 31 * result + UniversalBlePigeonUtils.deepHash(this.timestampMicroseconds)
     return result
   }
 }

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -22,6 +22,7 @@ import android.content.IntentFilter
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import android.os.SystemClock
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -1207,6 +1208,7 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
         callback(
             Result.success(
                 devices.map {
+                    val timestampMicroseconds = System.currentTimeMillis() * 1000
                     UniversalBleScanResult(
                         name = it.name,
                         deviceId = it.address,
@@ -1214,7 +1216,8 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
                         manufacturerDataList = null,
                         serviceData = null,
                         rssi = null,
-                        timestamp = System.currentTimeMillis()
+                        timestamp = timestampMicroseconds / 1000,
+                        timestampMicroseconds = timestampMicroseconds
                     )
                 }
             )
@@ -1509,6 +1512,11 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
             val name = result.resolvedDeviceName
             val manufacturerDataList = result.manufacturerDataList
             val serviceData = result.serviceData
+            // ScanResult.timestampNanos is captured by Android at packet
+            // reception. Convert that monotonic value to epoch microseconds
+            // before posting to Flutter so main-thread delay is excluded.
+            val timestampMicroseconds = System.currentTimeMillis() * 1000 -
+                (SystemClock.elapsedRealtimeNanos() - result.timestampNanos) / 1000
 
             if (!universalBleFilterUtil.filterDevice(
                     name,
@@ -1528,7 +1536,8 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
                         serviceData = serviceData,
                         rssi = result.rssi.toLong(),
                         services = serviceUuids.map { it.toString() }.toList(),
-                        timestamp = System.currentTimeMillis()
+                        timestamp = timestampMicroseconds / 1000,
+                        timestampMicroseconds = timestampMicroseconds
                     )
                 ) {}
             }

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBle.g.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBle.g.swift
@@ -377,6 +377,7 @@ struct UniversalBleScanResult: Hashable {
   var serviceData: [String: FlutterStandardTypedData]? = nil
   var services: [String]? = nil
   var timestamp: Int64? = nil
+  var timestampMicroseconds: Int64? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -389,6 +390,7 @@ struct UniversalBleScanResult: Hashable {
     let serviceData: [String: FlutterStandardTypedData]? = nilOrValue(pigeonVar_list[5])
     let services: [String]? = nilOrValue(pigeonVar_list[6])
     let timestamp: Int64? = nilOrValue(pigeonVar_list[7])
+    let timestampMicroseconds: Int64? = nilOrValue(pigeonVar_list[8])
 
     return UniversalBleScanResult(
       deviceId: deviceId,
@@ -398,7 +400,8 @@ struct UniversalBleScanResult: Hashable {
       manufacturerDataList: manufacturerDataList,
       serviceData: serviceData,
       services: services,
-      timestamp: timestamp
+      timestamp: timestamp,
+      timestampMicroseconds: timestampMicroseconds
     )
   }
   func toList() -> [Any?] {
@@ -411,13 +414,14 @@ struct UniversalBleScanResult: Hashable {
       serviceData,
       services,
       timestamp,
+      timestampMicroseconds,
     ]
   }
   static func == (lhs: UniversalBleScanResult, rhs: UniversalBleScanResult) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsUniversalBle(lhs.deviceId, rhs.deviceId) && deepEqualsUniversalBle(lhs.name, rhs.name) && deepEqualsUniversalBle(lhs.isPaired, rhs.isPaired) && deepEqualsUniversalBle(lhs.rssi, rhs.rssi) && deepEqualsUniversalBle(lhs.manufacturerDataList, rhs.manufacturerDataList) && deepEqualsUniversalBle(lhs.serviceData, rhs.serviceData) && deepEqualsUniversalBle(lhs.services, rhs.services) && deepEqualsUniversalBle(lhs.timestamp, rhs.timestamp)
+    return deepEqualsUniversalBle(lhs.deviceId, rhs.deviceId) && deepEqualsUniversalBle(lhs.name, rhs.name) && deepEqualsUniversalBle(lhs.isPaired, rhs.isPaired) && deepEqualsUniversalBle(lhs.rssi, rhs.rssi) && deepEqualsUniversalBle(lhs.manufacturerDataList, rhs.manufacturerDataList) && deepEqualsUniversalBle(lhs.serviceData, rhs.serviceData) && deepEqualsUniversalBle(lhs.services, rhs.services) && deepEqualsUniversalBle(lhs.timestamp, rhs.timestamp) && deepEqualsUniversalBle(lhs.timestampMicroseconds, rhs.timestampMicroseconds)
   }
 
   func hash(into hasher: inout Hasher) {
@@ -430,6 +434,7 @@ struct UniversalBleScanResult: Hashable {
     deepHashUniversalBle(value: serviceData, hasher: &hasher)
     deepHashUniversalBle(value: services, hasher: &hasher)
     deepHashUniversalBle(value: timestamp, hasher: &hasher)
+    deepHashUniversalBle(value: timestampMicroseconds, hasher: &hasher)
   }
 }
 

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBlePlugin.swift
@@ -591,11 +591,13 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
     completion(Result.success(bleDevices.map { peripheral in
       let id = peripheral.uuid.uuidString
       let name = advertisementNameCache[id] ?? discoveredPeripherals[id]?.name ?? peripheral.name ?? ""
+      let timestampMicroseconds = Int64(Date().timeIntervalSince1970 * 1_000_000)
       return UniversalBleScanResult(
         deviceId: id,
         name: name,
         serviceData: nil,
-        timestamp: Int64(Date().timeIntervalSince1970 * 1000)
+        timestamp: timestampMicroseconds / 1000,
+        timestampMicroseconds: timestampMicroseconds
       )
     }))
   }
@@ -670,6 +672,7 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
       return
     }
 
+    let timestampMicroseconds = Int64(Date().timeIntervalSince1970 * 1_000_000)
     callbackChannel.onScanResult(result: UniversalBleScanResult(
       deviceId: peripheral.uuid.uuidString,
       name: displayName,
@@ -678,7 +681,8 @@ private class BleCentralDarwin: NSObject, UniversalBlePlatformChannel, CBCentral
       manufacturerDataList: manufacturerDataList,
       serviceData: serviceData,
       services: services?.map { $0.uuidStr },
-      timestamp: Int64(Date().timeIntervalSince1970 * 1000)
+      timestamp: timestampMicroseconds / 1000,
+      timestampMicroseconds: timestampMicroseconds
     )) { _ in }
   }
 

--- a/lib/src/models/ble_device.dart
+++ b/lib/src/models/ble_device.dart
@@ -9,6 +9,7 @@ class BleDevice {
   int? rssi;
   bool? paired;
   int? timestamp;
+  int? timestampMicroseconds;
 
   /// List of services advertised by the device.
   List<String> services;
@@ -55,12 +56,17 @@ class BleDevice {
     this.manufacturerDataList = const [],
     Map<String, Uint8List> serviceData = const {},
     this.timestamp,
+    this.timestampMicroseconds,
   })  : serviceData = _validateServiceData(serviceData),
         rawName = name,
         name = name?.replaceAll(RegExp(r'[^ -~]'), '').trim();
 
   DateTime? get timestampDateTime => timestamp != null
       ? DateTime.fromMillisecondsSinceEpoch(timestamp!)
+      : null;
+
+  DateTime? get timestampMicrosecondsDateTime => timestampMicroseconds != null
+      ? DateTime.fromMicrosecondsSinceEpoch(timestampMicroseconds!)
       : null;
 
   static Map<String, Uint8List> _validateServiceData(
@@ -85,6 +91,7 @@ class BleDevice {
         'services: $services, '
         'isSystemDevice: $isSystemDevice, '
         'timestamp: $timestamp, '
+        'timestampMicroseconds: $timestampMicroseconds, '
         'manufacturerDataList: $manufacturerDataList, '
         'serviceData: $serviceData';
   }

--- a/lib/src/universal_ble.g.dart
+++ b/lib/src/universal_ble.g.dart
@@ -34,11 +34,8 @@ Object? _extractReplyValueOrThrow(
   return replyList.firstOrNull;
 }
 
-List<Object?> wrapResponse({
-  Object? result,
-  PlatformException? error,
-  bool empty = false,
-}) {
+List<Object?> wrapResponse(
+    {Object? result, PlatformException? error, bool empty = false}) {
   if (empty) {
     return <Object?>[];
   }
@@ -60,9 +57,8 @@ bool _deepEquals(Object? a, Object? b) {
   }
   if (a is List && b is List) {
     return a.length == b.length &&
-        a.indexed.every(
-          ((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]),
-        );
+        a.indexed
+            .every(((int, dynamic) item) => _deepEquals(item.$2, b[item.$1]));
   }
   if (a is Map && b is Map) {
     if (a.length != b.length) {
@@ -111,7 +107,14 @@ int _deepHash(Object? value) {
   return value.hashCode;
 }
 
-enum BleLogLevel { none, error, warning, info, debug, verbose }
+enum BleLogLevel {
+  none,
+  error,
+  warning,
+  info,
+  debug,
+  verbose,
+}
 
 enum AvailabilityState {
   unknown,
@@ -122,11 +125,23 @@ enum AvailabilityState {
   poweredOn,
 }
 
-enum BleConnectionState { connected, disconnected, connecting, disconnecting }
+enum BleConnectionState {
+  connected,
+  disconnected,
+  connecting,
+  disconnecting,
+}
 
-enum BleInputProperty { disabled, notification, indication }
+enum BleInputProperty {
+  disabled,
+  notification,
+  indication,
+}
 
-enum BleOutputProperty { withResponse, withoutResponse }
+enum BleOutputProperty {
+  withResponse,
+  withoutResponse,
+}
 
 /// Connection priority hint passed to [requestConnectionPriority].
 ///
@@ -142,7 +157,12 @@ enum BleConnectionPriority {
   lowPower,
 }
 
-enum AndroidScanMode { balanced, lowLatency, lowPower, opportunistic }
+enum AndroidScanMode {
+  balanced,
+  lowLatency,
+  lowPower,
+  opportunistic,
+}
 
 /// Mirrors `android.bluetooth.le.ScanSettings#setCallbackType`. Pass any
 /// combination via `AndroidOptions.callbackType` (the plugin OR-folds the list
@@ -164,10 +184,17 @@ enum AndroidScanCallbackType {
 }
 
 /// Mirrors `android.bluetooth.le.ScanSettings#setMatchMode`.
-enum AndroidScanMatchMode { aggressive, sticky }
+enum AndroidScanMatchMode {
+  aggressive,
+  sticky,
+}
 
 /// Mirrors `android.bluetooth.le.ScanSettings#setNumOfMatches`.
-enum AndroidScanNumOfMatches { one, few, max }
+enum AndroidScanNumOfMatches {
+  one,
+  few,
+  max,
+}
 
 enum CharacteristicProperty {
   broadcast,
@@ -195,7 +222,13 @@ enum PeripheralAttributePermission {
   writeEncryptionRequired,
 }
 
-enum PeripheralAdvertisingState { idle, starting, advertising, stopping, error }
+enum PeripheralAdvertisingState {
+  idle,
+  starting,
+  advertising,
+  stopping,
+  error,
+}
 
 /// Unified error codes for all platforms
 enum UniversalBleErrorCode {
@@ -274,6 +307,7 @@ class UniversalBleScanResult {
     this.serviceData,
     this.services,
     this.timestamp,
+    this.timestampMicroseconds,
   });
 
   String deviceId;
@@ -292,6 +326,8 @@ class UniversalBleScanResult {
 
   int? timestamp;
 
+  int? timestampMicroseconds;
+
   List<Object?> _toList() {
     return <Object?>[
       deviceId,
@@ -302,6 +338,7 @@ class UniversalBleScanResult {
       serviceData,
       services,
       timestamp,
+      timestampMicroseconds,
     ];
   }
 
@@ -316,12 +353,13 @@ class UniversalBleScanResult {
       name: result[1] as String?,
       isPaired: result[2] as bool?,
       rssi: result[3] as int?,
-      manufacturerDataList: (result[4] as List<Object?>?)
-          ?.cast<UniversalManufacturerData>(),
-      serviceData: (result[5] as Map<Object?, Object?>?)
-          ?.cast<String, Uint8List>(),
+      manufacturerDataList:
+          (result[4] as List<Object?>?)?.cast<UniversalManufacturerData>(),
+      serviceData:
+          (result[5] as Map<Object?, Object?>?)?.cast<String, Uint8List>(),
       services: (result[6] as List<Object?>?)?.cast<String>(),
       timestamp: result[7] as int?,
+      timestampMicroseconds: result[8] as int?,
     );
   }
 
@@ -341,7 +379,8 @@ class UniversalBleScanResult {
         _deepEquals(manufacturerDataList, other.manufacturerDataList) &&
         _deepEquals(serviceData, other.serviceData) &&
         _deepEquals(services, other.services) &&
-        _deepEquals(timestamp, other.timestamp);
+        _deepEquals(timestamp, other.timestamp) &&
+        _deepEquals(timestampMicroseconds, other.timestampMicroseconds);
   }
 
   @override
@@ -351,14 +390,20 @@ class UniversalBleScanResult {
 
 /// Central/GATT models
 class UniversalBleService {
-  UniversalBleService({required this.uuid, this.characteristics});
+  UniversalBleService({
+    required this.uuid,
+    this.characteristics,
+  });
 
   String uuid;
 
   List<UniversalBleCharacteristic>? characteristics;
 
   List<Object?> _toList() {
-    return <Object?>[uuid, characteristics];
+    return <Object?>[
+      uuid,
+      characteristics,
+    ];
   }
 
   Object encode() {
@@ -369,8 +414,8 @@ class UniversalBleService {
     result as List<Object?>;
     return UniversalBleService(
       uuid: result[0]! as String,
-      characteristics: (result[1] as List<Object?>?)
-          ?.cast<UniversalBleCharacteristic>(),
+      characteristics:
+          (result[1] as List<Object?>?)?.cast<UniversalBleCharacteristic>(),
     );
   }
 
@@ -406,7 +451,11 @@ class UniversalBleCharacteristic {
   List<UniversalBleDescriptor> descriptors;
 
   List<Object?> _toList() {
-    return <Object?>[uuid, properties, descriptors];
+    return <Object?>[
+      uuid,
+      properties,
+      descriptors,
+    ];
   }
 
   Object encode() {
@@ -443,12 +492,16 @@ class UniversalBleCharacteristic {
 }
 
 class UniversalBleDescriptor {
-  UniversalBleDescriptor({required this.uuid});
+  UniversalBleDescriptor({
+    required this.uuid,
+  });
 
   String uuid;
 
   List<Object?> _toList() {
-    return <Object?>[uuid];
+    return <Object?>[
+      uuid,
+    ];
   }
 
   Object encode() {
@@ -457,7 +510,9 @@ class UniversalBleDescriptor {
 
   static UniversalBleDescriptor decode(Object result) {
     result as List<Object?>;
-    return UniversalBleDescriptor(uuid: result[0]! as String);
+    return UniversalBleDescriptor(
+      uuid: result[0]! as String,
+    );
   }
 
   @override
@@ -501,7 +556,13 @@ class BleConnectionParametersUpdated {
   int status;
 
   List<Object?> _toList() {
-    return <Object?>[deviceId, interval, latency, supervisionTimeout, status];
+    return <Object?>[
+      deviceId,
+      interval,
+      latency,
+      supervisionTimeout,
+      status,
+    ];
   }
 
   Object encode() {
@@ -615,8 +676,8 @@ class AndroidOptions {
       requestLocationPermission: result[0] as bool?,
       scanMode: result[1] as AndroidScanMode?,
       reportDelayMillis: result[2] as int?,
-      callbackType: (result[3] as List<Object?>?)
-          ?.cast<AndroidScanCallbackType>(),
+      callbackType:
+          (result[3] as List<Object?>?)?.cast<AndroidScanCallbackType>(),
       matchMode: result[4] as AndroidScanMatchMode?,
       numOfMatches: result[5] as AndroidScanNumOfMatches?,
       legacy: result[6] as bool?,
@@ -633,9 +694,7 @@ class AndroidOptions {
       return true;
     }
     return _deepEquals(
-          requestLocationPermission,
-          other.requestLocationPermission,
-        ) &&
+            requestLocationPermission, other.requestLocationPermission) &&
         _deepEquals(scanMode, other.scanMode) &&
         _deepEquals(reportDelayMillis, other.reportDelayMillis) &&
         _deepEquals(callbackType, other.callbackType) &&
@@ -650,12 +709,16 @@ class AndroidOptions {
 }
 
 class UniversalScanConfig {
-  UniversalScanConfig({this.android});
+  UniversalScanConfig({
+    this.android,
+  });
 
   AndroidOptions? android;
 
   List<Object?> _toList() {
-    return <Object?>[android];
+    return <Object?>[
+      android,
+    ];
   }
 
   Object encode() {
@@ -664,7 +727,9 @@ class UniversalScanConfig {
 
   static UniversalScanConfig decode(Object result) {
     result as List<Object?>;
-    return UniversalScanConfig(android: result[0] as AndroidOptions?);
+    return UniversalScanConfig(
+      android: result[0] as AndroidOptions?,
+    );
   }
 
   @override
@@ -698,7 +763,11 @@ class UniversalScanFilter {
   List<ManufacturerDataFilter> withManufacturerData;
 
   List<Object?> _toList() {
-    return <Object?>[withServices, withNamePrefix, withManufacturerData];
+    return <Object?>[
+      withServices,
+      withNamePrefix,
+      withManufacturerData,
+    ];
   }
 
   Object encode() {
@@ -710,8 +779,8 @@ class UniversalScanFilter {
     return UniversalScanFilter(
       withServices: (result[0]! as List<Object?>).cast<String>(),
       withNamePrefix: (result[1]! as List<Object?>).cast<String>(),
-      withManufacturerData: (result[2]! as List<Object?>)
-          .cast<ManufacturerDataFilter>(),
+      withManufacturerData:
+          (result[2]! as List<Object?>).cast<ManufacturerDataFilter>(),
     );
   }
 
@@ -753,7 +822,11 @@ class ManufacturerDataFilter {
   Uint8List? payloadMask;
 
   List<Object?> _toList() {
-    return <Object?>[companyIdentifier, payloadPrefix, payloadMask];
+    return <Object?>[
+      companyIdentifier,
+      payloadPrefix,
+      payloadMask,
+    ];
   }
 
   Object encode() {
@@ -799,7 +872,10 @@ class UniversalManufacturerData {
   Uint8List data;
 
   List<Object?> _toList() {
-    return <Object?>[companyIdentifier, data];
+    return <Object?>[
+      companyIdentifier,
+      data,
+    ];
   }
 
   Object encode() {
@@ -906,12 +982,16 @@ class AppleConnectionOptions {
 }
 
 class ConnectionPlatformConfig {
-  ConnectionPlatformConfig({this.apple});
+  ConnectionPlatformConfig({
+    this.apple,
+  });
 
   AppleConnectionOptions? apple;
 
   List<Object?> _toList() {
-    return <Object?>[apple];
+    return <Object?>[
+      apple,
+    ];
   }
 
   Object encode() {
@@ -988,10 +1068,8 @@ class PeripheralAndroidOptions {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(
-          addManufacturerDataInScanResponse,
-          other.addManufacturerDataInScanResponse,
-        ) &&
+    return _deepEquals(addManufacturerDataInScanResponse,
+            other.addManufacturerDataInScanResponse) &&
         _deepEquals(addServicesInScanResponse, other.addServicesInScanResponse);
   }
 
@@ -1001,12 +1079,16 @@ class PeripheralAndroidOptions {
 }
 
 class PeripheralPlatformConfig {
-  PeripheralPlatformConfig({this.android});
+  PeripheralPlatformConfig({
+    this.android,
+  });
 
   PeripheralAndroidOptions? android;
 
   List<Object?> _toList() {
-    return <Object?>[android];
+    return <Object?>[
+      android,
+    ];
   }
 
   Object encode() {
@@ -1053,7 +1135,11 @@ class PeripheralService {
   List<PeripheralCharacteristic> characteristics;
 
   List<Object?> _toList() {
-    return <Object?>[uuid, primary, characteristics];
+    return <Object?>[
+      uuid,
+      primary,
+      characteristics,
+    ];
   }
 
   Object encode() {
@@ -1065,8 +1151,8 @@ class PeripheralService {
     return PeripheralService(
       uuid: result[0]! as String,
       primary: result[1]! as bool,
-      characteristics: (result[2]! as List<Object?>)
-          .cast<PeripheralCharacteristic>(),
+      characteristics:
+          (result[2]! as List<Object?>).cast<PeripheralCharacteristic>(),
     );
   }
 
@@ -1109,7 +1195,13 @@ class PeripheralCharacteristic {
   Uint8List? value;
 
   List<Object?> _toList() {
-    return <Object?>[uuid, properties, permissions, descriptors, value];
+    return <Object?>[
+      uuid,
+      properties,
+      permissions,
+      descriptors,
+      value,
+    ];
   }
 
   Object encode() {
@@ -1121,8 +1213,8 @@ class PeripheralCharacteristic {
     return PeripheralCharacteristic(
       uuid: result[0]! as String,
       properties: (result[1]! as List<Object?>).cast<CharacteristicProperty>(),
-      permissions: (result[2]! as List<Object?>)
-          .cast<PeripheralAttributePermission>(),
+      permissions:
+          (result[2]! as List<Object?>).cast<PeripheralAttributePermission>(),
       descriptors: (result[3] as List<Object?>?)?.cast<PeripheralDescriptor>(),
       value: result[4] as Uint8List?,
     );
@@ -1151,7 +1243,11 @@ class PeripheralCharacteristic {
 }
 
 class PeripheralDescriptor {
-  PeripheralDescriptor({required this.uuid, this.value, this.permissions});
+  PeripheralDescriptor({
+    required this.uuid,
+    this.value,
+    this.permissions,
+  });
 
   String uuid;
 
@@ -1160,7 +1256,11 @@ class PeripheralDescriptor {
   List<PeripheralAttributePermission>? permissions;
 
   List<Object?> _toList() {
-    return <Object?>[uuid, value, permissions];
+    return <Object?>[
+      uuid,
+      value,
+      permissions,
+    ];
   }
 
   Object encode() {
@@ -1172,8 +1272,8 @@ class PeripheralDescriptor {
     return PeripheralDescriptor(
       uuid: result[0]! as String,
       value: result[1] as Uint8List?,
-      permissions: (result[2] as List<Object?>?)
-          ?.cast<PeripheralAttributePermission>(),
+      permissions:
+          (result[2] as List<Object?>?)?.cast<PeripheralAttributePermission>(),
     );
   }
 
@@ -1197,7 +1297,11 @@ class PeripheralDescriptor {
 }
 
 class PeripheralReadRequestResult {
-  PeripheralReadRequestResult({required this.value, this.offset, this.status});
+  PeripheralReadRequestResult({
+    required this.value,
+    this.offset,
+    this.status,
+  });
 
   Uint8List value;
 
@@ -1206,7 +1310,11 @@ class PeripheralReadRequestResult {
   int? status;
 
   List<Object?> _toList() {
-    return <Object?>[value, offset, status];
+    return <Object?>[
+      value,
+      offset,
+      status,
+    ];
   }
 
   Object encode() {
@@ -1243,7 +1351,11 @@ class PeripheralReadRequestResult {
 }
 
 class PeripheralWriteRequestResult {
-  PeripheralWriteRequestResult({this.value, this.offset, this.status});
+  PeripheralWriteRequestResult({
+    this.value,
+    this.offset,
+    this.status,
+  });
 
   Uint8List? value;
 
@@ -1252,7 +1364,11 @@ class PeripheralWriteRequestResult {
   int? status;
 
   List<Object?> _toList() {
-    return <Object?>[value, offset, status];
+    return <Object?>[
+      value,
+      offset,
+      status,
+    ];
   }
 
   Object encode() {
@@ -1503,13 +1619,11 @@ class UniversalBlePlatformChannel {
   /// Constructor for [UniversalBlePlatformChannel].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  UniversalBlePlatformChannel({
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) : pigeonVar_binaryMessenger = binaryMessenger,
-       pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty
-           ? '.$messageChannelSuffix'
-           : '';
+  UniversalBlePlatformChannel(
+      {BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
+      : pigeonVar_binaryMessenger = binaryMessenger,
+        pigeonVar_messageChannelSuffix =
+            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -1543,9 +1657,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[withAndroidFineLocation],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[withAndroidFineLocation]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1564,9 +1677,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[withAndroidFineLocation],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[withAndroidFineLocation]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
@@ -1615,9 +1727,7 @@ class UniversalBlePlatformChannel {
   }
 
   Future<void> startScan(
-    UniversalScanFilter? filter,
-    UniversalScanConfig? config,
-  ) async {
+      UniversalScanFilter? filter, UniversalScanConfig? config) async {
     final pigeonVar_channelName =
         'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.startScan$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
@@ -1625,9 +1735,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[filter, config],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[filter, config]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
@@ -1686,9 +1795,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[deviceId, autoConnect, platformConfig],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel
+        .send(<Object?>[deviceId, autoConnect, platformConfig]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
@@ -1706,9 +1814,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[deviceId],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[deviceId]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
@@ -1718,12 +1825,8 @@ class UniversalBlePlatformChannel {
     );
   }
 
-  Future<void> setNotifiable(
-    String deviceId,
-    String service,
-    String characteristic,
-    BleInputProperty bleInputProperty,
-  ) async {
+  Future<void> setNotifiable(String deviceId, String service,
+      String characteristic, BleInputProperty bleInputProperty) async {
     final pigeonVar_channelName =
         'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.setNotifiable$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
@@ -1731,9 +1834,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[deviceId, service, characteristic, bleInputProperty],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel
+        .send(<Object?>[deviceId, service, characteristic, bleInputProperty]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
@@ -1744,9 +1846,7 @@ class UniversalBlePlatformChannel {
   }
 
   Future<List<UniversalBleService>> discoverServices(
-    String deviceId,
-    bool withDescriptors,
-  ) async {
+      String deviceId, bool withDescriptors) async {
     final pigeonVar_channelName =
         'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.discoverServices$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
@@ -1754,9 +1854,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[deviceId, withDescriptors],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[deviceId, withDescriptors]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1768,10 +1867,7 @@ class UniversalBlePlatformChannel {
   }
 
   Future<Uint8List> readValue(
-    String deviceId,
-    String service,
-    String characteristic,
-  ) async {
+      String deviceId, String service, String characteristic) async {
     final pigeonVar_channelName =
         'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.readValue$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
@@ -1779,9 +1875,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[deviceId, service, characteristic],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[deviceId, service, characteristic]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1792,12 +1887,8 @@ class UniversalBlePlatformChannel {
     return pigeonVar_replyValue! as Uint8List;
   }
 
-  Future<Uint8List> readDescriptorValue(
-    String deviceId,
-    String service,
-    String characteristic,
-    String descriptor,
-  ) async {
+  Future<Uint8List> readDescriptorValue(String deviceId, String service,
+      String characteristic, String descriptor) async {
     final pigeonVar_channelName =
         'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.readDescriptorValue$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
@@ -1805,9 +1896,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[deviceId, service, characteristic, descriptor],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel
+        .send(<Object?>[deviceId, service, characteristic, descriptor]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1826,9 +1916,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[deviceId, expectedMtu],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[deviceId, expectedMtu]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1840,12 +1929,11 @@ class UniversalBlePlatformChannel {
   }
 
   Future<void> writeValue(
-    String deviceId,
-    String service,
-    String characteristic,
-    Uint8List value,
-    BleOutputProperty bleOutputProperty,
-  ) async {
+      String deviceId,
+      String service,
+      String characteristic,
+      Uint8List value,
+      BleOutputProperty bleOutputProperty) async {
     final pigeonVar_channelName =
         'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.writeValue$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
@@ -1854,8 +1942,7 @@ class UniversalBlePlatformChannel {
       binaryMessenger: pigeonVar_binaryMessenger,
     );
     final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[deviceId, service, characteristic, value, bleOutputProperty],
-    );
+        <Object?>[deviceId, service, characteristic, value, bleOutputProperty]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
@@ -1865,13 +1952,8 @@ class UniversalBlePlatformChannel {
     );
   }
 
-  Future<void> writeDescriptorValue(
-    String deviceId,
-    String service,
-    String characteristic,
-    String descriptor,
-    Uint8List value,
-  ) async {
+  Future<void> writeDescriptorValue(String deviceId, String service,
+      String characteristic, String descriptor, Uint8List value) async {
     final pigeonVar_channelName =
         'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.writeDescriptorValue$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
@@ -1879,9 +1961,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[deviceId, service, characteristic, descriptor, value],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel
+        .send(<Object?>[deviceId, service, characteristic, descriptor, value]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
@@ -1899,9 +1980,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[deviceId],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[deviceId]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1920,9 +2000,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[deviceId],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[deviceId]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1941,9 +2020,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[deviceId],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[deviceId]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
@@ -1954,8 +2032,7 @@ class UniversalBlePlatformChannel {
   }
 
   Future<List<UniversalBleScanResult>> getSystemDevices(
-    List<String> withServices,
-  ) async {
+      List<String> withServices) async {
     final pigeonVar_channelName =
         'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.getSystemDevices$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
@@ -1963,9 +2040,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[withServices],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[withServices]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -1985,9 +2061,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[deviceId],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[deviceId]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -2006,9 +2081,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[deviceId],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[deviceId]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -2020,9 +2094,7 @@ class UniversalBlePlatformChannel {
   }
 
   Future<void> requestConnectionPriority(
-    String deviceId,
-    BleConnectionPriority priority,
-  ) async {
+      String deviceId, BleConnectionPriority priority) async {
     final pigeonVar_channelName =
         'dev.flutter.pigeon.universal_ble.UniversalBlePlatformChannel.requestConnectionPriority$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
@@ -2030,9 +2102,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[deviceId, priority],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[deviceId, priority]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
@@ -2050,9 +2121,8 @@ class UniversalBlePlatformChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[logLevel],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[logLevel]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
@@ -2073,12 +2143,8 @@ abstract class UniversalBleCallbackChannel {
 
   void onScanResult(UniversalBleScanResult result);
 
-  void onValueChanged(
-    String deviceId,
-    String characteristicId,
-    Uint8List value,
-    int? timestamp,
-  );
+  void onValueChanged(String deviceId, String characteristicId, Uint8List value,
+      int? timestamp);
 
   void onConnectionChanged(String deviceId, bool connected, String? error);
 
@@ -2089,15 +2155,13 @@ abstract class UniversalBleCallbackChannel {
     BinaryMessenger? binaryMessenger,
     String messageChannelSuffix = '',
   }) {
-    messageChannelSuffix = messageChannelSuffix.isNotEmpty
-        ? '.$messageChannelSuffix'
-        : '';
+    messageChannelSuffix =
+        messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onAvailabilityChanged$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onAvailabilityChanged$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2111,18 +2175,16 @@ abstract class UniversalBleCallbackChannel {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onPairStateChange$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onPairStateChange$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2138,18 +2200,16 @@ abstract class UniversalBleCallbackChannel {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onScanResult$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onScanResult$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2164,18 +2224,16 @@ abstract class UniversalBleCallbackChannel {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onValueChanged$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onValueChanged$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2187,28 +2245,22 @@ abstract class UniversalBleCallbackChannel {
           final int? arg_timestamp = args[3] as int?;
           try {
             api.onValueChanged(
-              arg_deviceId,
-              arg_characteristicId,
-              arg_value,
-              arg_timestamp,
-            );
+                arg_deviceId, arg_characteristicId, arg_value, arg_timestamp);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onConnectionChanged$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onConnectionChanged$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2224,18 +2276,16 @@ abstract class UniversalBleCallbackChannel {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onConnectionParametersUpdated$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.universal_ble.UniversalBleCallbackChannel.onConnectionParametersUpdated$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2250,8 +2300,7 @@ abstract class UniversalBleCallbackChannel {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -2264,13 +2313,11 @@ class UniversalBlePeripheralChannel {
   /// Constructor for [UniversalBlePeripheralChannel].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  UniversalBlePeripheralChannel({
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) : pigeonVar_binaryMessenger = binaryMessenger,
-       pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty
-           ? '.$messageChannelSuffix'
-           : '';
+  UniversalBlePeripheralChannel(
+      {BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
+      : pigeonVar_binaryMessenger = binaryMessenger,
+        pigeonVar_messageChannelSuffix =
+            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -2341,9 +2388,8 @@ class UniversalBlePeripheralChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[service],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[service]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
@@ -2361,9 +2407,8 @@ class UniversalBlePeripheralChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[serviceId],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[serviceId]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
@@ -2411,12 +2456,11 @@ class UniversalBlePeripheralChannel {
   }
 
   Future<void> startAdvertising(
-    List<String> services,
-    String? localName,
-    int? timeout,
-    UniversalManufacturerData? manufacturerData,
-    PeripheralPlatformConfig? platformConfig,
-  ) async {
+      List<String> services,
+      String? localName,
+      int? timeout,
+      UniversalManufacturerData? manufacturerData,
+      PeripheralPlatformConfig? platformConfig) async {
     final pigeonVar_channelName =
         'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralChannel.startAdvertising$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
@@ -2424,9 +2468,14 @@ class UniversalBlePeripheralChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[services, localName, timeout, manufacturerData, platformConfig],
-    );
+    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel
+        .send(<Object?>[
+      services,
+      localName,
+      timeout,
+      manufacturerData,
+      platformConfig
+    ]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
@@ -2437,10 +2486,7 @@ class UniversalBlePeripheralChannel {
   }
 
   Future<void> updateCharacteristic(
-    String characteristicId,
-    Uint8List value,
-    String? deviceId,
-  ) async {
+      String characteristicId, Uint8List value, String? deviceId) async {
     final pigeonVar_channelName =
         'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralChannel.updateCharacteristic$pigeonVar_messageChannelSuffix';
     final pigeonVar_channel = BasicMessageChannel<Object?>(
@@ -2448,9 +2494,8 @@ class UniversalBlePeripheralChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[characteristicId, value, deviceId],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[characteristicId, value, deviceId]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     _extractReplyValueOrThrow(
@@ -2470,9 +2515,8 @@ class UniversalBlePeripheralChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[characteristicId],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[characteristicId]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -2492,9 +2536,8 @@ class UniversalBlePeripheralChannel {
       pigeonChannelCodec,
       binaryMessenger: pigeonVar_binaryMessenger,
     );
-    final Future<Object?> pigeonVar_sendFuture = pigeonVar_channel.send(
-      <Object?>[deviceId],
-    );
+    final Future<Object?> pigeonVar_sendFuture =
+        pigeonVar_channel.send(<Object?>[deviceId]);
     final pigeonVar_replyList = await pigeonVar_sendFuture as List<Object?>?;
 
     final Object? pigeonVar_replyValue = _extractReplyValueOrThrow(
@@ -2511,13 +2554,11 @@ class UniversalBleAndroidChannel {
   /// Constructor for [UniversalBleAndroidChannel].  The [binaryMessenger] named argument is
   /// available for dependency injection.  If it is left null, the default
   /// BinaryMessenger will be used which routes to the host platform.
-  UniversalBleAndroidChannel({
-    BinaryMessenger? binaryMessenger,
-    String messageChannelSuffix = '',
-  }) : pigeonVar_binaryMessenger = binaryMessenger,
-       pigeonVar_messageChannelSuffix = messageChannelSuffix.isNotEmpty
-           ? '.$messageChannelSuffix'
-           : '';
+  UniversalBleAndroidChannel(
+      {BinaryMessenger? binaryMessenger, String messageChannelSuffix = ''})
+      : pigeonVar_binaryMessenger = binaryMessenger,
+        pigeonVar_messageChannelSuffix =
+            messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
   final BinaryMessenger? pigeonVar_binaryMessenger;
 
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
@@ -2568,46 +2609,30 @@ abstract class UniversalBlePeripheralCallback {
   static const MessageCodec<Object?> pigeonChannelCodec = _PigeonCodec();
 
   PeripheralReadRequestResult? onReadRequest(
-    String deviceId,
-    String characteristicId,
-    int offset,
-    Uint8List? value,
-  );
+      String deviceId, String characteristicId, int offset, Uint8List? value);
 
   PeripheralWriteRequestResult? onWriteRequest(
-    String deviceId,
-    String characteristicId,
-    int offset,
-    Uint8List? value,
-  );
+      String deviceId, String characteristicId, int offset, Uint8List? value);
 
   PeripheralReadRequestResult? onDescriptorReadRequest(
-    String deviceId,
-    String characteristicId,
-    String descriptorId,
-    int offset,
-    Uint8List? value,
-  );
+      String deviceId,
+      String characteristicId,
+      String descriptorId,
+      int offset,
+      Uint8List? value);
 
   PeripheralWriteRequestResult? onDescriptorWriteRequest(
-    String deviceId,
-    String characteristicId,
-    String descriptorId,
-    int offset,
-    Uint8List? value,
-  );
+      String deviceId,
+      String characteristicId,
+      String descriptorId,
+      int offset,
+      Uint8List? value);
 
-  void onCharacteristicSubscriptionChange(
-    String deviceId,
-    String characteristicId,
-    bool isSubscribed,
-    String? name,
-  );
+  void onCharacteristicSubscriptionChange(String deviceId,
+      String characteristicId, bool isSubscribed, String? name);
 
   void onAdvertisingStateChange(
-    PeripheralAdvertisingState state,
-    String? error,
-  );
+      PeripheralAdvertisingState state, String? error);
 
   void onServiceAdded(String serviceId, String? error);
 
@@ -2620,15 +2645,13 @@ abstract class UniversalBlePeripheralCallback {
     BinaryMessenger? binaryMessenger,
     String messageChannelSuffix = '',
   }) {
-    messageChannelSuffix = messageChannelSuffix.isNotEmpty
-        ? '.$messageChannelSuffix'
-        : '';
+    messageChannelSuffix =
+        messageChannelSuffix.isNotEmpty ? '.$messageChannelSuffix' : '';
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onReadRequest$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onReadRequest$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2640,28 +2663,22 @@ abstract class UniversalBlePeripheralCallback {
           final Uint8List? arg_value = args[3] as Uint8List?;
           try {
             final PeripheralReadRequestResult? output = api.onReadRequest(
-              arg_deviceId,
-              arg_characteristicId,
-              arg_offset,
-              arg_value,
-            );
+                arg_deviceId, arg_characteristicId, arg_offset, arg_value);
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onWriteRequest$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onWriteRequest$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2673,28 +2690,22 @@ abstract class UniversalBlePeripheralCallback {
           final Uint8List? arg_value = args[3] as Uint8List?;
           try {
             final PeripheralWriteRequestResult? output = api.onWriteRequest(
-              arg_deviceId,
-              arg_characteristicId,
-              arg_offset,
-              arg_value,
-            );
+                arg_deviceId, arg_characteristicId, arg_offset, arg_value);
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onDescriptorReadRequest$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onDescriptorReadRequest$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2706,31 +2717,24 @@ abstract class UniversalBlePeripheralCallback {
           final int arg_offset = args[3]! as int;
           final Uint8List? arg_value = args[4] as Uint8List?;
           try {
-            final PeripheralReadRequestResult? output = api
-                .onDescriptorReadRequest(
-                  arg_deviceId,
-                  arg_characteristicId,
-                  arg_descriptorId,
-                  arg_offset,
-                  arg_value,
-                );
+            final PeripheralReadRequestResult? output =
+                api.onDescriptorReadRequest(arg_deviceId, arg_characteristicId,
+                    arg_descriptorId, arg_offset, arg_value);
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onDescriptorWriteRequest$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onDescriptorWriteRequest$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2742,31 +2746,24 @@ abstract class UniversalBlePeripheralCallback {
           final int arg_offset = args[3]! as int;
           final Uint8List? arg_value = args[4] as Uint8List?;
           try {
-            final PeripheralWriteRequestResult? output = api
-                .onDescriptorWriteRequest(
-                  arg_deviceId,
-                  arg_characteristicId,
-                  arg_descriptorId,
-                  arg_offset,
-                  arg_value,
-                );
+            final PeripheralWriteRequestResult? output =
+                api.onDescriptorWriteRequest(arg_deviceId, arg_characteristicId,
+                    arg_descriptorId, arg_offset, arg_value);
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onCharacteristicSubscriptionChange$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onCharacteristicSubscriptionChange$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2778,28 +2775,22 @@ abstract class UniversalBlePeripheralCallback {
           final String? arg_name = args[3] as String?;
           try {
             api.onCharacteristicSubscriptionChange(
-              arg_deviceId,
-              arg_characteristicId,
-              arg_isSubscribed,
-              arg_name,
-            );
+                arg_deviceId, arg_characteristicId, arg_isSubscribed, arg_name);
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onAdvertisingStateChange$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onAdvertisingStateChange$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2815,18 +2806,16 @@ abstract class UniversalBlePeripheralCallback {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onServiceAdded$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onServiceAdded$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2841,18 +2830,16 @@ abstract class UniversalBlePeripheralCallback {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onMtuChange$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onMtuChange$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2867,18 +2854,16 @@ abstract class UniversalBlePeripheralCallback {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final pigeonVar_channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onConnectionStateChange$messageChannelSuffix',
-        pigeonChannelCodec,
-        binaryMessenger: binaryMessenger,
-      );
+          'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralCallback.onConnectionStateChange$messageChannelSuffix',
+          pigeonChannelCodec,
+          binaryMessenger: binaryMessenger);
       if (api == null) {
         pigeonVar_channel.setMessageHandler(null);
       } else {
@@ -2893,8 +2878,7 @@ abstract class UniversalBlePeripheralCallback {
             return wrapResponse(error: e);
           } catch (e) {
             return wrapResponse(
-              error: PlatformException(code: 'error', message: e.toString()),
-            );
+                error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }

--- a/lib/src/universal_ble_linux/universal_ble_linux.dart
+++ b/lib/src/universal_ble_linux/universal_ble_linux.dart
@@ -173,25 +173,23 @@ class UniversalBleLinux extends UniversalBlePlatform {
   ) async {
     final device = _findDeviceById(deviceId);
     if (device.gattServices.isEmpty && !device.servicesResolved) {
-      await device.propertiesChanged
-          .firstWhere((element) {
-            if (element.contains(BluezProperty.connected)) {
-              if (!device.connected) {
-                UniversalLogger.logInfo(
-                  "DiscoverServicesFailed: Device disconnected",
-                );
-                return true;
-              }
-            }
-            return element.contains(BluezProperty.servicesResolved);
-          })
-          .timeout(
-            const Duration(seconds: 10),
-            onTimeout: () {
-              UniversalLogger.logInfo("DiscoverServicesFailed: Timeout");
-              return [];
-            },
-          );
+      await device.propertiesChanged.firstWhere((element) {
+        if (element.contains(BluezProperty.connected)) {
+          if (!device.connected) {
+            UniversalLogger.logInfo(
+              "DiscoverServicesFailed: Device disconnected",
+            );
+            return true;
+          }
+        }
+        return element.contains(BluezProperty.servicesResolved);
+      }).timeout(
+        const Duration(seconds: 10),
+        onTimeout: () {
+          UniversalLogger.logInfo("DiscoverServicesFailed: Timeout");
+          return [];
+        },
+      );
     }
 
     // Few ble devices requires delay to perform operations after discovering services
@@ -222,8 +220,8 @@ class UniversalBleLinux extends UniversalBlePlatform {
           properties: properties,
           descriptors: withDescriptors
               ? e.descriptors
-                    .map((e) => BleDescriptor(e.uuid.toString()))
-                    .toList()
+                  .map((e) => BleDescriptor(e.uuid.toString()))
+                  .toList()
               : [],
         );
       }).toList();
@@ -239,13 +237,13 @@ class UniversalBleLinux extends UniversalBlePlatform {
   ) {
     final device = _findDeviceById(deviceId);
     final s = device.gattServices.cast<BlueZGattService?>().firstWhere(
-      (s) => s?.uuid.toString() == service,
-      orElse: () => null,
-    );
+          (s) => s?.uuid.toString() == service,
+          orElse: () => null,
+        );
     final c = s?.characteristics.cast<BlueZGattCharacteristic?>().firstWhere(
-      (c) => c?.uuid.toString() == characteristic,
-      orElse: () => null,
-    );
+          (c) => c?.uuid.toString() == characteristic,
+          orElse: () => null,
+        );
 
     if (c == null) {
       throw UniversalBleException(
@@ -264,9 +262,10 @@ class UniversalBleLinux extends UniversalBlePlatform {
   ) {
     final c = _getCharacteristic(deviceId, service, characteristic);
     final d = c.descriptors.cast<BlueZGattDescriptor?>().firstWhere(
-      (d) => BleUuidParser.compareStrings(d?.uuid.toString() ?? '', descriptor),
-      orElse: () => null,
-    );
+          (d) => BleUuidParser.compareStrings(
+              d?.uuid.toString() ?? '', descriptor),
+          orElse: () => null,
+        );
 
     if (d == null) {
       throw UniversalBleException(
@@ -304,30 +303,29 @@ class UniversalBleLinux extends UniversalBlePlatform {
         _characteristicPropertiesSubscriptions[characteristicKey]?.cancel();
       }
 
-      _characteristicPropertiesSubscriptions[characteristicKey] = char
-          .propertiesChanged
-          .listen((List<String> properties) {
-            for (String property in properties) {
-              switch (property) {
-                case BluezProperty.value:
-                  UniversalLogger.logVerbose(
-                    "NOTIFY <- $deviceId $service $characteristic len=${char.value.length} data=${char.value}",
-                    withTimestamp: true,
-                  );
-                  updateCharacteristicValue(
-                    deviceId,
-                    characteristic,
-                    Uint8List.fromList(char.value),
-                    DateTime.now().millisecondsSinceEpoch,
-                  );
-                  break;
-                default:
-                  UniversalLogger.logInfo(
-                    "UnhandledCharValuePropertyChange: $property",
-                  );
-              }
-            }
-          });
+      _characteristicPropertiesSubscriptions[characteristicKey] =
+          char.propertiesChanged.listen((List<String> properties) {
+        for (String property in properties) {
+          switch (property) {
+            case BluezProperty.value:
+              UniversalLogger.logVerbose(
+                "NOTIFY <- $deviceId $service $characteristic len=${char.value.length} data=${char.value}",
+                withTimestamp: true,
+              );
+              updateCharacteristicValue(
+                deviceId,
+                characteristic,
+                Uint8List.fromList(char.value),
+                DateTime.now().millisecondsSinceEpoch,
+              );
+              break;
+            default:
+              UniversalLogger.logInfo(
+                "UnhandledCharValuePropertyChange: $property",
+              );
+          }
+        }
+      });
     } else {
       if (char.notifying) await char.stopNotify();
       _characteristicPropertiesSubscriptions
@@ -522,9 +520,8 @@ class UniversalBleLinux extends UniversalBlePlatform {
   @override
   Future<List<BleDevice>> getSystemDevices(List<String>? withServices) async {
     await _ensureInitialized();
-    List<BlueZDevice> devices = _client.devices
-        .where((device) => device.connected)
-        .toList();
+    List<BlueZDevice> devices =
+        _client.devices.where((device) => device.connected).toList();
     if (withServices != null && withServices.isNotEmpty) {
       devices = devices.where((device) {
         if (device.servicesResolved) {
@@ -567,9 +564,9 @@ class UniversalBleLinux extends UniversalBlePlatform {
   BlueZDevice? _getDeviceById(String deviceId) {
     return _devices[deviceId] ??
         _client.devices.cast<BlueZDevice?>().firstWhere(
-          (device) => device?.address == deviceId,
-          orElse: () => null,
-        );
+              (device) => device?.address == deviceId,
+              orElse: () => null,
+            );
   }
 
   Future<void> _ensureInitialized() async {
@@ -653,23 +650,21 @@ class UniversalBleLinux extends UniversalBlePlatform {
     _devices[device.address] = device;
 
     // Setup advertisements Listener
-    _deviceAdvertisementSubscriptions[device.address] ??= device
-        .propertiesChanged
-        .where((e) {
-          return e.contains(BluezProperty.rssi) ||
-              e.contains(BluezProperty.manufacturerData) ||
-              e.contains(BluezProperty.uuids) ||
-              e.contains(BluezProperty.serviceData);
-        })
-        .listen((_) {
-          if (_bleFilter.shouldAcceptDevice(bleDevice)) {
-            updateScanResult(device.toBleDevice());
-          }
-        });
+    _deviceAdvertisementSubscriptions[device.address] ??=
+        device.propertiesChanged.where((e) {
+      return e.contains(BluezProperty.rssi) ||
+          e.contains(BluezProperty.manufacturerData) ||
+          e.contains(BluezProperty.uuids) ||
+          e.contains(BluezProperty.serviceData);
+    }).listen((_) {
+      if (_bleFilter.shouldAcceptDevice(bleDevice)) {
+        updateScanResult(device.toBleDevice());
+      }
+    });
 
     // Setup update listener
-    _deviceUpdateStreamSubscriptions[device
-        .address] ??= device.propertiesChanged.listen((properties) {
+    _deviceUpdateStreamSubscriptions[device.address] ??=
+        device.propertiesChanged.listen((properties) {
       for (final property in properties) {
         switch (property) {
           // Connection/Pair updates
@@ -824,6 +819,7 @@ extension BlueZDeviceExtension on BlueZDevice {
       manufacturerDataList: manufacturerDataList,
       serviceData: serviceDataMap,
       timestamp: DateTime.now().millisecondsSinceEpoch,
+      timestampMicroseconds: DateTime.now().microsecondsSinceEpoch,
     );
   }
 }

--- a/lib/src/universal_ble_linux/universal_ble_linux.dart
+++ b/lib/src/universal_ble_linux/universal_ble_linux.dart
@@ -809,6 +809,7 @@ extension BlueZDeviceExtension on BlueZDevice {
   }
 
   BleDevice toBleDevice({bool? isSystemDevice}) {
+    final timestampMicroseconds = DateTime.now().microsecondsSinceEpoch;
     return BleDevice(
       name: name,
       deviceId: address,
@@ -818,8 +819,8 @@ extension BlueZDeviceExtension on BlueZDevice {
       services: uuids.map((e) => e.toString()).toList(),
       manufacturerDataList: manufacturerDataList,
       serviceData: serviceDataMap,
-      timestamp: DateTime.now().millisecondsSinceEpoch,
-      timestampMicroseconds: DateTime.now().microsecondsSinceEpoch,
+      timestamp: timestampMicroseconds ~/ Duration.microsecondsPerMillisecond,
+      timestampMicroseconds: timestampMicroseconds,
     );
   }
 }

--- a/lib/src/universal_ble_pigeon/universal_ble_pigeon_channel.dart
+++ b/lib/src/universal_ble_pigeon/universal_ble_pigeon_channel.dart
@@ -69,13 +69,14 @@ class UniversalBlePigeonChannel extends UniversalBlePlatform
     Duration? connectionTimeout,
     bool autoConnect = false,
     ConnectionPlatformConfig? platformConfig,
-  }) => _executeWithErrorHandling(
-    () => _channel.connect(
-      deviceId,
-      autoConnect: autoConnect,
-      platformConfig: platformConfig,
-    ),
-  );
+  }) =>
+      _executeWithErrorHandling(
+        () => _channel.connect(
+          deviceId,
+          autoConnect: autoConnect,
+          platformConfig: platformConfig,
+        ),
+      );
 
   @override
   Future<void> disconnect(String deviceId) =>
@@ -88,8 +89,8 @@ class UniversalBlePigeonChannel extends UniversalBlePlatform
   ) async {
     List<UniversalBleService?> universalBleServices =
         await _executeWithErrorHandling(
-          () => _channel.discoverServices(deviceId, withDescriptors),
-        );
+      () => _channel.discoverServices(deviceId, withDescriptors),
+    );
     return List<BleService>.from(
       universalBleServices
           .where((e) => e != null)
@@ -197,9 +198,10 @@ class UniversalBlePigeonChannel extends UniversalBlePlatform
   Future<void> requestConnectionPriority(
     String deviceId,
     BleConnectionPriority priority,
-  ) => _executeWithErrorHandling(
-    () => _channel.requestConnectionPriority(deviceId, priority),
-  );
+  ) =>
+      _executeWithErrorHandling(
+        () => _channel.requestConnectionPriority(deviceId, priority),
+      );
 
   @override
   Future<bool> isPaired(String deviceId) =>
@@ -287,7 +289,8 @@ class UniversalBlePigeonChannel extends UniversalBlePlatform
     String characteristicId,
     Uint8List value,
     int? timestamp,
-  ) => updateCharacteristicValue(deviceId, characteristicId, value, timestamp);
+  ) =>
+      updateCharacteristicValue(deviceId, characteristicId, value, timestamp);
 
   @override
   void onPairStateChange(String deviceId, bool isPaired, String? error) =>
@@ -329,8 +332,8 @@ extension _UniversalBleScanResultExtension on UniversalBleScanResult {
       isSystemDevice: isSystemDevice,
       services: services?.map(BleUuidParser.string).toList() ?? [],
       timestamp: timestamp,
-      manufacturerDataList:
-          manufacturerDataList
+      timestampMicroseconds: timestampMicroseconds,
+      manufacturerDataList: manufacturerDataList
               ?.map((e) => ManufacturerData(e.companyIdentifier, e.data))
               .toList() ??
           [],

--- a/lib/src/universal_ble_web/universal_ble_web.dart
+++ b/lib/src/universal_ble_web/universal_ble_web.dart
@@ -624,6 +624,7 @@ extension _BluetoothDeviceExtension on BluetoothDevice {
     List<String> services = const [],
     Map<String, Uint8List>? serviceDataMap,
   }) {
+    final timestampMicroseconds = DateTime.now().microsecondsSinceEpoch;
     return BleDevice(
       name: name,
       deviceId: id,
@@ -631,8 +632,8 @@ extension _BluetoothDeviceExtension on BluetoothDevice {
       rssi: rssi,
       services: services,
       serviceData: serviceDataMap ?? {},
-      timestamp: DateTime.now().millisecondsSinceEpoch,
-      timestampMicroseconds: DateTime.now().microsecondsSinceEpoch,
+      timestamp: timestampMicroseconds ~/ Duration.microsecondsPerMillisecond,
+      timestampMicroseconds: timestampMicroseconds,
     );
   }
 }

--- a/lib/src/universal_ble_web/universal_ble_web.dart
+++ b/lib/src/universal_ble_web/universal_ble_web.dart
@@ -197,24 +197,24 @@ class UniversalBleWeb extends UniversalBlePlatform {
         _characteristicStreamList[characteristicKey]?.cancel();
       }
       await bleCharacteristic.startNotifications();
-      _characteristicStreamList[characteristicKey] = bleCharacteristic.value
-          .listen((ByteData event) {
-            final preview = event.buffer
-                .asUint8List()
-                .take(8)
-                .map((e) => e.toRadixString(16).padLeft(2, '0'))
-                .join();
-            UniversalLogger.logVerbose(
-              "NOTIFY <- $deviceId $characteristic len=${event.lengthInBytes} data=$preview",
-              withTimestamp: true,
-            );
-            updateCharacteristicValue(
-              deviceId,
-              characteristic,
-              event.buffer.asUint8List(),
-              DateTime.now().millisecondsSinceEpoch,
-            );
-          });
+      _characteristicStreamList[characteristicKey] =
+          bleCharacteristic.value.listen((ByteData event) {
+        final preview = event.buffer
+            .asUint8List()
+            .take(8)
+            .map((e) => e.toRadixString(16).padLeft(2, '0'))
+            .join();
+        UniversalLogger.logVerbose(
+          "NOTIFY <- $deviceId $characteristic len=${event.lengthInBytes} data=$preview",
+          withTimestamp: true,
+        );
+        updateCharacteristicValue(
+          deviceId,
+          characteristic,
+          event.buffer.asUint8List(),
+          DateTime.now().millisecondsSinceEpoch,
+        );
+      });
     } else {
       await bleCharacteristic.stopNotifications();
       _characteristicStreamList.remove(characteristicKey)?.cancel();
@@ -632,6 +632,7 @@ extension _BluetoothDeviceExtension on BluetoothDevice {
       services: services,
       serviceData: serviceDataMap ?? {},
       timestamp: DateTime.now().millisecondsSinceEpoch,
+      timestampMicroseconds: DateTime.now().microsecondsSinceEpoch,
     );
   }
 }
@@ -685,9 +686,8 @@ class _UniversalWebBluetoothService {
       if (withDescriptors) {
         try {
           var bluetoothDescriptors = await characteristic.getDescriptors();
-          descriptors = bluetoothDescriptors
-              .map((e) => BleDescriptor(e.uuid))
-              .toList();
+          descriptors =
+              bluetoothDescriptors.map((e) => BleDescriptor(e.uuid)).toList();
         } catch (_) {}
       }
       bleCharacteristics.add(

--- a/pigeon/universal_ble.dart
+++ b/pigeon/universal_ble.dart
@@ -17,6 +17,7 @@ import 'package:pigeon/pigeon.dart';
     debugGenerators: true,
   ),
 )
+
 /// Shared models & enums
 /// ------------------------------------------------------------
 class UniversalBleScanResult {
@@ -28,6 +29,7 @@ class UniversalBleScanResult {
   final Map<String, Uint8List>? serviceData;
   final List<String>? services;
   final int? timestamp;
+  final int? timestampMicroseconds;
 
   UniversalBleScanResult({
     required this.name,
@@ -38,6 +40,7 @@ class UniversalBleScanResult {
     required this.serviceData,
     required this.services,
     required this.timestamp,
+    required this.timestampMicroseconds,
   });
 }
 

--- a/test/ble_device_timestamp_test.dart
+++ b/test/ble_device_timestamp_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+void main() {
+  test('exposes a microsecond scan timestamp without rounding', () {
+    const timestampMicroseconds = 1787597612345678;
+    final device = BleDevice(
+      deviceId: 'device',
+      name: null,
+      timestamp: timestampMicroseconds ~/ 1000,
+      timestampMicroseconds: timestampMicroseconds,
+    );
+
+    expect(
+      device.timestampMicrosecondsDateTime?.microsecondsSinceEpoch,
+      timestampMicroseconds,
+    );
+    expect(
+      device.timestampDateTime?.microsecondsSinceEpoch,
+      1787597612345000,
+    );
+  });
+}

--- a/windows/src/generated/universal_ble.g.cpp
+++ b/windows/src/generated/universal_ble.g.cpp
@@ -238,7 +238,8 @@ UniversalBleScanResult::UniversalBleScanResult(
   const EncodableList* manufacturer_data_list,
   const EncodableMap* service_data,
   const EncodableList* services,
-  const int64_t* timestamp)
+  const int64_t* timestamp,
+  const int64_t* timestamp_microseconds)
  : device_id_(device_id),
     name_(name ? std::optional<std::string>(*name) : std::nullopt),
     is_paired_(is_paired ? std::optional<bool>(*is_paired) : std::nullopt),
@@ -246,7 +247,8 @@ UniversalBleScanResult::UniversalBleScanResult(
     manufacturer_data_list_(manufacturer_data_list ? std::optional<EncodableList>(*manufacturer_data_list) : std::nullopt),
     service_data_(service_data ? std::optional<EncodableMap>(*service_data) : std::nullopt),
     services_(services ? std::optional<EncodableList>(*services) : std::nullopt),
-    timestamp_(timestamp ? std::optional<int64_t>(*timestamp) : std::nullopt) {}
+    timestamp_(timestamp ? std::optional<int64_t>(*timestamp) : std::nullopt),
+    timestamp_microseconds_(timestamp_microseconds ? std::optional<int64_t>(*timestamp_microseconds) : std::nullopt) {}
 
 const std::string& UniversalBleScanResult::device_id() const {
   return device_id_;
@@ -348,9 +350,22 @@ void UniversalBleScanResult::set_timestamp(int64_t value_arg) {
 }
 
 
+const int64_t* UniversalBleScanResult::timestamp_microseconds() const {
+  return timestamp_microseconds_ ? &(*timestamp_microseconds_) : nullptr;
+}
+
+void UniversalBleScanResult::set_timestamp_microseconds(const int64_t* value_arg) {
+  timestamp_microseconds_ = value_arg ? std::optional<int64_t>(*value_arg) : std::nullopt;
+}
+
+void UniversalBleScanResult::set_timestamp_microseconds(int64_t value_arg) {
+  timestamp_microseconds_ = value_arg;
+}
+
+
 EncodableList UniversalBleScanResult::ToEncodableList() const {
   EncodableList list;
-  list.reserve(8);
+  list.reserve(9);
   list.push_back(EncodableValue(device_id_));
   list.push_back(name_ ? EncodableValue(*name_) : EncodableValue());
   list.push_back(is_paired_ ? EncodableValue(*is_paired_) : EncodableValue());
@@ -359,6 +374,7 @@ EncodableList UniversalBleScanResult::ToEncodableList() const {
   list.push_back(service_data_ ? EncodableValue(*service_data_) : EncodableValue());
   list.push_back(services_ ? EncodableValue(*services_) : EncodableValue());
   list.push_back(timestamp_ ? EncodableValue(*timestamp_) : EncodableValue());
+  list.push_back(timestamp_microseconds_ ? EncodableValue(*timestamp_microseconds_) : EncodableValue());
   return list;
 }
 
@@ -393,11 +409,15 @@ UniversalBleScanResult UniversalBleScanResult::FromEncodableList(const Encodable
   if (!encodable_timestamp.IsNull()) {
     decoded.set_timestamp(std::get<int64_t>(encodable_timestamp));
   }
+  auto& encodable_timestamp_microseconds = list[8];
+  if (!encodable_timestamp_microseconds.IsNull()) {
+    decoded.set_timestamp_microseconds(std::get<int64_t>(encodable_timestamp_microseconds));
+  }
   return decoded;
 }
 
 bool UniversalBleScanResult::operator==(const UniversalBleScanResult& other) const {
-  return PigeonInternalDeepEquals(device_id_, other.device_id_) && PigeonInternalDeepEquals(name_, other.name_) && PigeonInternalDeepEquals(is_paired_, other.is_paired_) && PigeonInternalDeepEquals(rssi_, other.rssi_) && PigeonInternalDeepEquals(manufacturer_data_list_, other.manufacturer_data_list_) && PigeonInternalDeepEquals(service_data_, other.service_data_) && PigeonInternalDeepEquals(services_, other.services_) && PigeonInternalDeepEquals(timestamp_, other.timestamp_);
+  return PigeonInternalDeepEquals(device_id_, other.device_id_) && PigeonInternalDeepEquals(name_, other.name_) && PigeonInternalDeepEquals(is_paired_, other.is_paired_) && PigeonInternalDeepEquals(rssi_, other.rssi_) && PigeonInternalDeepEquals(manufacturer_data_list_, other.manufacturer_data_list_) && PigeonInternalDeepEquals(service_data_, other.service_data_) && PigeonInternalDeepEquals(services_, other.services_) && PigeonInternalDeepEquals(timestamp_, other.timestamp_) && PigeonInternalDeepEquals(timestamp_microseconds_, other.timestamp_microseconds_);
 }
 
 bool UniversalBleScanResult::operator!=(const UniversalBleScanResult& other) const {
@@ -414,6 +434,7 @@ size_t UniversalBleScanResult::Hash() const {
   result = result * 31 + PigeonInternalDeepHash(service_data_);
   result = result * 31 + PigeonInternalDeepHash(services_);
   result = result * 31 + PigeonInternalDeepHash(timestamp_);
+  result = result * 31 + PigeonInternalDeepHash(timestamp_microseconds_);
   return result;
 }
 

--- a/windows/src/generated/universal_ble.g.h
+++ b/windows/src/generated/universal_ble.g.h
@@ -265,7 +265,8 @@ class UniversalBleScanResult {
     const ::flutter::EncodableList* manufacturer_data_list,
     const ::flutter::EncodableMap* service_data,
     const ::flutter::EncodableList* services,
-    const int64_t* timestamp);
+    const int64_t* timestamp,
+    const int64_t* timestamp_microseconds);
 
   const std::string& device_id() const;
   void set_device_id(std::string_view value_arg);
@@ -298,6 +299,10 @@ class UniversalBleScanResult {
   void set_timestamp(const int64_t* value_arg);
   void set_timestamp(int64_t value_arg);
 
+  const int64_t* timestamp_microseconds() const;
+  void set_timestamp_microseconds(const int64_t* value_arg);
+  void set_timestamp_microseconds(int64_t value_arg);
+
   bool operator==(const UniversalBleScanResult& other) const;
   bool operator!=(const UniversalBleScanResult& other) const;
   /// Returns a hash code value for the object. This method is supported for the benefit of hash tables.
@@ -319,6 +324,7 @@ class UniversalBleScanResult {
   std::optional<::flutter::EncodableMap> service_data_;
   std::optional<::flutter::EncodableList> services_;
   std::optional<int64_t> timestamp_;
+  std::optional<int64_t> timestamp_microseconds_;
 };
 
 

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -1118,7 +1118,9 @@ void UniversalBlePlugin::PushUniversalScanResult(
 
   // Filter final result before sending to Flutter
   if (is_connectable && filterDevice(scan_result)) {
-    scan_result.set_timestamp(GetCurrentTimestampMillis());
+    const auto timestamp_microseconds = GetCurrentTimestampMicros();
+    scan_result.set_timestamp(timestamp_microseconds / 1000);
+    scan_result.set_timestamp_microseconds(timestamp_microseconds);
     ui_thread_handler_.Post([scan_result] {
       callback_channel->OnScanResult(scan_result, SuccessCallback,
                                      ErrorCallback);

--- a/windows/src/universal_ble_plugin.h
+++ b/windows/src/universal_ble_plugin.h
@@ -208,6 +208,11 @@ private:
                std::chrono::system_clock::now().time_since_epoch())
         .count();
   }
+  static int64_t GetCurrentTimestampMicros() {
+    return std::chrono::duration_cast<std::chrono::microseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+  }
 
   flutter::PluginRegistrarWindows *registrar_;
   bool initialized_ = false;


### PR DESCRIPTION
## Why

High-accuracy synchronization needs the BLE advertisement's receive instant. Universal BLE exposed only a millisecond timestamp, and Android derived it after the packet reached the plugin callback. That discarded sub-millisecond phase and allowed Flutter/main-thread dispatch delay to move the timecode anchor.

## What changed

- Add optional `timestampMicroseconds` to `BleDevice` and the Pigeon scan-result model while retaining the existing millisecond field for compatibility.
- On Android, convert `ScanResult.timestampNanos` from the Bluetooth event's monotonic clock to epoch microseconds before dispatching to Flutter.
- Capture microsecond timestamps before Flutter dispatch on Apple and Windows.
- Populate the same field on Linux and web.
- Regenerate all platform bindings and add a timestamp precision test.
