### PR TITLE
Windows: support connectionless manufacturer-data advertising

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,6 +5,21 @@ on:
     branches: [main]
 
 jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+        working-directory: example
+      - run: flutter build windows
+        working-directory: example
+      - run: cmake -S windows/test -B build/windows-tests
+      - run: cmake --build build/windows-tests --config Debug
+      - run: ctest --test-dir build/windows-tests -C Debug --output-on-failure
+
   test:
     runs-on: ubuntu-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.3.0
 * Windows: support connectionless manufacturer-data advertising without a GATT service, including state/error reporting and cleanup on stop/disposal.
+* Apple/Peripheral: Accurately report supportsManufacturerDataInAdvertisement as false (CoreBluetooth does not support advertising manufacturer data).
 * Android: add `closeGattOnDetach` connection option to release GATT clients when the app is killed
 * Android: close the GATT client once the disconnect completes instead of right after `disconnect()`, and report the real disconnect status
 * Report manufacturer-data advertising capabilities accurately on iOS/macOS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 2.3.0
 * Windows: support connectionless manufacturer-data advertising without a GATT service, including state/error reporting and cleanup on stop/disposal.
-* Apple/Peripheral: Accurately report supportsManufacturerDataInAdvertisement as false (CoreBluetooth does not support advertising manufacturer data).
+* Apple: Accurately report manufacturer-data advertising capabilities.
 * Android: add `closeGattOnDetach` connection option to release GATT clients when the app is killed
 * Android: close the GATT client once the disconnect completes instead of right after `disconnect()`, and report the real disconnect status
-* Report manufacturer-data advertising capabilities accurately on iOS/macOS.
+
 
 ## 2.2.0
 * Expose microsecond scan timestamps captured before Flutter event dispatch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 2.2.1
+## 2.3.0
+* Windows: support connectionless manufacturer-data advertising without a GATT service, including state/error reporting and cleanup on stop/disposal.
 * Android: add `closeGattOnDetach` connection option to release GATT clients when the app is killed
 * Android: close the GATT client once the disconnect completes instead of right after `disconnect()`, and report the real disconnect status
+* Report manufacturer-data advertising capabilities accurately on iOS/macOS.
 
 ## 2.2.0
 * Expose microsecond scan timestamps captured before Flutter event dispatch

--- a/README.md
+++ b/README.md
@@ -811,7 +811,9 @@ await UniversalBlePeripheral.clearServices();
 
 On **Android**, passing `localName` may temporarily change the system Bluetooth device name (so it can appear in the advertisement). The plugin restores the previous name when advertising stops, if starting advertising fails, or when the plugin is disposed.
 
-On **Windows**, `GattServiceProvider`-based advertising does not support `localName`, manufacturer data, or a scan-response flag; pass `null` for those parameters or the call returns a not-supported error. Use `getCapabilities()` to check feature support before calling.
+On **Windows**, pass `services: []` and `manufacturerData` for connectionless advertising via `BluetoothLEAdvertisementPublisher`. No GATT service registration is needed. The company ID must fit 16 bits and the payload must be at most 27 bytes (legacy advertising). Stop advertising before changing the payload. Registered-service advertising still uses `GattServiceProvider`; combining service UUIDs with manufacturer data is not supported. Windows does not allow a custom `localName` in either mode. Unsupported combinations return `not-supported`. Advertising is best effort; listen to `advertisingStateStream` for asynchronous failures. See [Microsoft's publisher restrictions](https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.advertisement.bluetoothleadvertisementpublisher).
+
+On **iOS/macOS**, CoreBluetooth supports local names and service UUIDs, not manufacturer data. `getCapabilities()` reflects this restriction. Use a local-name carrier when your protocol must also broadcast on Apple platforms.
 
 ```dart
 import 'dart:typed_data';

--- a/lib/src/universal_ble_pigeon/universal_ble_peripheral_pigeon.dart
+++ b/lib/src/universal_ble_pigeon/universal_ble_peripheral_pigeon.dart
@@ -19,8 +19,8 @@ class UniversalBlePeripheralPigeon extends UniversalBlePeripheralPlatform
 
   UniversalBleAndroidChannel? get _androidChannel =>
       (kIsWeb || defaultTargetPlatform != TargetPlatform.android)
-      ? null
-      : _androidChannelRef ??= UniversalBleAndroidChannel();
+          ? null
+          : _androidChannelRef ??= UniversalBleAndroidChannel();
 
   OnPeripheralReadRequest? _readRequestHandler;
   OnPeripheralWriteRequest? _writeRequestHandler;
@@ -45,7 +45,9 @@ class UniversalBlePeripheralPigeon extends UniversalBlePeripheralPlatform
         defaultTargetPlatform == TargetPlatform.android;
     return BlePeripheralCapabilities(
       supportsPeripheralMode: supported,
-      supportsManufacturerDataInAdvertisement: supported,
+      supportsManufacturerDataInAdvertisement: supported &&
+          (defaultTargetPlatform == TargetPlatform.android ||
+              defaultTargetPlatform == TargetPlatform.windows),
       supportsManufacturerDataInScanResponse:
           supported && supportsManufacturerDataInScanResponse,
       supportsServiceDataInAdvertisement: false,
@@ -71,15 +73,15 @@ class UniversalBlePeripheralPigeon extends UniversalBlePeripheralPlatform
               BlePeripheralServiceAdded(serviceId, 'Service add timed out'),
         )
         .then((e) {
-          if (completer.isCompleted) return;
-          if (e.error != null) {
-            completer.completeError(
-              PlatformException(code: 'service-add-failed', message: e.error),
-            );
-          } else {
-            completer.complete();
-          }
-        });
+      if (completer.isCompleted) return;
+      if (e.error != null) {
+        completer.completeError(
+          PlatformException(code: 'service-add-failed', message: e.error),
+        );
+      } else {
+        completer.complete();
+      }
+    });
 
     await _channel.addService(service);
     await completer.future;
@@ -148,12 +150,14 @@ class UniversalBlePeripheralPigeon extends UniversalBlePeripheralPlatform
   @override
   void setDescriptorReadRequestHandler(
     OnPeripheralDescriptorReadRequest? handler,
-  ) => _descriptorReadRequestHandler = handler;
+  ) =>
+      _descriptorReadRequestHandler = handler;
 
   @override
   void setDescriptorWriteRequestHandler(
     OnPeripheralDescriptorWriteRequest? handler,
-  ) => _descriptorWriteRequestHandler = handler;
+  ) =>
+      _descriptorWriteRequestHandler = handler;
 
   @override
   void onAdvertisingStateChange(

--- a/test/peripheral_capabilities_test.dart
+++ b/test/peripheral_capabilities_test.dart
@@ -1,3 +1,7 @@
+// These tests exercise the native Pigeon backend; web uses a separate backend.
+@TestOn('vm')
+library;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/peripheral_capabilities_test.dart
+++ b/test/peripheral_capabilities_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:universal_ble/src/universal_ble.g.dart';
+import 'package:universal_ble/src/universal_ble_pigeon/universal_ble_peripheral_pigeon.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = BasicMessageChannel<Object?>(
+    'dev.flutter.pigeon.universal_ble.UniversalBlePeripheralChannel.getReadinessState',
+    UniversalBlePeripheralChannel.pigeonChannelCodec,
+  );
+  var readiness = PeripheralReadinessState.ready;
+  setUp(() {
+    readiness = PeripheralReadinessState.ready;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockDecodedMessageHandler<Object?>(
+            channel, (_) async => [readiness]);
+  });
+  tearDown(() {
+    debugDefaultTargetPlatformOverride = null;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockDecodedMessageHandler<Object?>(channel, null);
+  });
+  for (final platform in [
+    TargetPlatform.android,
+    TargetPlatform.iOS,
+    TargetPlatform.macOS,
+    TargetPlatform.windows,
+  ]) {
+    test('manufacturer capability on $platform', () async {
+      debugDefaultTargetPlatformOverride = platform;
+      final capabilities =
+          await UniversalBlePeripheralPigeon.instance.getCapabilities();
+      expect(
+          capabilities.supportsManufacturerDataInAdvertisement,
+          platform == TargetPlatform.android ||
+              platform == TargetPlatform.windows);
+      readiness = PeripheralReadinessState.unsupported;
+      expect(
+          (await UniversalBlePeripheralPigeon.instance.getCapabilities())
+              .supportsManufacturerDataInAdvertisement,
+          isFalse);
+    });
+  }
+}

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -117,6 +117,10 @@ UniversalBlePlugin::~UniversalBlePlugin() {
   // lease finish while every member is still alive, then release owned state.
   callback_operations_.Close();
   WaitForCallbacksWithMessagePump(callback_operations_);
+  {
+    std::lock_guard<std::mutex> lock(peripheral_mutex_);
+    DisposeAdvertisementPublisher();
+  }
   ResetState();
   ClearServices();
   ui_thread_handler_.Shutdown();
@@ -2952,6 +2956,16 @@ void UniversalBlePlugin::GattCharacteristicValueChanged(
 
 ErrorOr<PeripheralAdvertisingState> UniversalBlePlugin::GetAdvertisingState() {
   std::lock_guard<std::mutex> lock(peripheral_mutex_);
+  if (advertisement_publisher_) {
+    switch (advertisement_publisher_.Status()) {
+    case BluetoothLEAdvertisementPublisherStatus::Started:
+      return PeripheralAdvertisingState::kAdvertising;
+    case BluetoothLEAdvertisementPublisherStatus::Aborted:
+      return PeripheralAdvertisingState::kError;
+    default:
+      return PeripheralAdvertisingState::kIdle;
+    }
+  }
   if (peripheral_service_provider_map_.empty()) {
     return PeripheralAdvertisingState::kIdle;
   }
@@ -2969,6 +2983,7 @@ ErrorOr<PeripheralReadinessState> UniversalBlePlugin::GetReadinessState() {
 
 std::optional<FlutterError> UniversalBlePlugin::StopAdvertising() {
   std::lock_guard<std::mutex> lock(peripheral_mutex_);
+  DisposeAdvertisementPublisher();
   peripheral_advertising_targets_lc_.clear();
   for (auto const &[key, provider] : peripheral_service_provider_map_) {
     try {
@@ -3082,22 +3097,67 @@ std::optional<FlutterError> UniversalBlePlugin::StartAdvertising(
     const int64_t *timeout, const UniversalManufacturerData *manufacturer_data,
     const PeripheralPlatformConfig *platform_config) {
   std::lock_guard<std::mutex> lock(peripheral_mutex_);
-  if (peripheral_service_provider_map_.empty()) {
-    return FlutterError("failed", "No services added to advertise");
-  }
   if (local_name != nullptr) {
-    UniversalBleLogger::LogDebug("Windows GattServiceProvider advertising does "
-                                 "not support overriding local name");
+    return FlutterError("not-supported", "Windows cannot advertise a local name");
   }
-  if (manufacturer_data != nullptr) {
-    UniversalBleLogger::LogDebug("Windows GattServiceProvider advertising does "
-                                 "not support manufacturer data");
+  if (manufacturer_data != nullptr && !services.empty()) {
+    return FlutterError("not-supported",
+                        "Windows manufacturer advertising requires services: []");
+  }
+  if (manufacturer_data != nullptr &&
+      (manufacturer_data->company_identifier() < 0 ||
+       manufacturer_data->company_identifier() > 0xffff ||
+       manufacturer_data->data().size() > 27)) {
+    return FlutterError("invalid-arguments",
+                        "Manufacturer advertising requires a 16-bit company ID "
+                        "and at most 27 payload bytes");
   }
   if (timeout != nullptr && *timeout > 0) {
     UniversalBleLogger::LogDebug(
         "Windows GattServiceProvider advertising timeout is not supported");
   }
   try {
+    if (manufacturer_data != nullptr) {
+      // Connectionless advertising does not need a registered GATT service.
+      // Windows reserves local names and service UUID AD types for the system.
+      DisposeAdvertisementPublisher();
+      for (const auto &[_, provider] : peripheral_service_provider_map_) {
+        provider->obj.StopAdvertising();
+      }
+      peripheral_advertising_targets_lc_.clear();
+      BluetoothLEAdvertisement advertisement;
+      advertisement.ManufacturerData().Append(BluetoothLEManufacturerData(
+          static_cast<uint16_t>(manufacturer_data->company_identifier()),
+          from_bytevc(manufacturer_data->data())));
+      advertisement_publisher_ = BluetoothLEAdvertisementPublisher(advertisement);
+      const auto callback_operations = callback_operations_;
+      advertisement_publisher_status_token_ = advertisement_publisher_.StatusChanged(
+          [this, callback_operations](const auto &publisher, const auto &args) {
+            const auto callback = callback_operations.TryAcquire();
+            if (!callback.has_value()) return;
+            const auto status = args.Status();
+            const auto error = args.Error();
+            ui_thread_handler_.Post([this, publisher, status, error] {
+              std::lock_guard<std::mutex> lock(peripheral_mutex_);
+              // A queued callback from a replaced/stopped publisher is stale.
+              if (publisher != advertisement_publisher_) return;
+              const auto state = status == BluetoothLEAdvertisementPublisherStatus::Started
+                  ? PeripheralAdvertisingState::kAdvertising
+                  : status == BluetoothLEAdvertisementPublisherStatus::Aborted
+                      ? PeripheralAdvertisingState::kError
+                      : PeripheralAdvertisingState::kIdle;
+              const auto message = ParsePeripheralBluetoothError(error);
+              peripheral_callback_channel_->OnAdvertisingStateChange(
+                  state, state == PeripheralAdvertisingState::kError ? &message : nullptr,
+                  SuccessCallback, ErrorCallback);
+            });
+          });
+      advertisement_publisher_.Start();
+      return std::nullopt;
+    }
+    if (peripheral_service_provider_map_.empty()) {
+      return FlutterError("failed", "No services added to advertise");
+    }
     std::vector<std::string> selected_services_lc;
     selected_services_lc.reserve(services.size());
     for (const auto &service_encoded : services) {
@@ -3115,8 +3175,7 @@ std::optional<FlutterError> UniversalBlePlugin::StartAdvertising(
     auto params = GattServiceProviderAdvertisingParameters();
     params.IsDiscoverable(true);
     params.IsConnectable(true);
-    // TODO: migrate to BluetoothLEAdvertisementPublisher to support richer
-    // payload customization (local name, manufacturer data, scan response).
+    DisposeAdvertisementPublisher();
     for (auto const &[key, provider] : peripheral_service_provider_map_) {
       const bool should_start =
           selected_services_lc.empty() ||
@@ -3136,12 +3195,28 @@ std::optional<FlutterError> UniversalBlePlugin::StartAdvertising(
     peripheral_advertising_targets_lc_ = std::move(selected_services_lc);
     return std::nullopt;
   } catch (const hresult_error &err) {
+    DisposeAdvertisementPublisher();
     return FlutterError(
         "failed",
         "Failed to start advertising (hr=" + std::to_string(err.code()) +
             "): " + to_string(err.message()));
   } catch (...) {
+    DisposeAdvertisementPublisher();
     return FlutterError("failed", "Failed to start advertising");
+  }
+}
+
+void UniversalBlePlugin::DisposeAdvertisementPublisher() {
+  if (!advertisement_publisher_) return;
+  auto publisher = advertisement_publisher_;
+  advertisement_publisher_ = nullptr;
+  try {
+    publisher.StatusChanged(advertisement_publisher_status_token_);
+  } catch (...) {
+  }
+  try {
+    publisher.Stop();
+  } catch (...) {
   }
 }
 

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -3121,9 +3121,12 @@ std::optional<FlutterError> UniversalBlePlugin::StartAdvertising(
       // Connectionless advertising does not need a registered GATT service.
       // Windows reserves local names and service UUID AD types for the system.
       DisposeAdvertisementPublisher();
-      for (const auto &[_, provider] : peripheral_service_provider_map_) {
-        provider->obj.StopAdvertising();
-      }
+for (const auto &[_, provider] : peripheral_service_provider_map_) {
+  try {
+    if (provider != nullptr) provider->obj.StopAdvertising();
+  } catch (...) {
+  }
+}
       peripheral_advertising_targets_lc_.clear();
       BluetoothLEAdvertisement advertisement;
       advertisement.ManufacturerData().Append(BluetoothLEManufacturerData(

--- a/windows/src/universal_ble_plugin.cpp
+++ b/windows/src/universal_ble_plugin.cpp
@@ -3121,12 +3121,12 @@ std::optional<FlutterError> UniversalBlePlugin::StartAdvertising(
       // Connectionless advertising does not need a registered GATT service.
       // Windows reserves local names and service UUID AD types for the system.
       DisposeAdvertisementPublisher();
-for (const auto &[_, provider] : peripheral_service_provider_map_) {
-  try {
-    if (provider != nullptr) provider->obj.StopAdvertising();
-  } catch (...) {
-  }
-}
+      for (const auto &[_, provider] : peripheral_service_provider_map_) {
+        try {
+          if (provider != nullptr) provider->obj.StopAdvertising();
+        } catch (...) {
+        }
+      }
       peripheral_advertising_targets_lc_.clear();
       BluetoothLEAdvertisement advertisement;
       advertisement.ManufacturerData().Append(BluetoothLEManufacturerData(

--- a/windows/src/universal_ble_plugin.h
+++ b/windows/src/universal_ble_plugin.h
@@ -504,10 +504,13 @@ private:
   /// Lowercased service UUIDs from the last successful `StartAdvertising` call.
   /// Empty means all registered services were selected.
   std::vector<std::string> peripheral_advertising_targets_lc_{};
+  BluetoothLEAdvertisementPublisher advertisement_publisher_{nullptr};
+  event_token advertisement_publisher_status_token_{};
   event_revoker<IRadio> peripheral_radio_state_changed_revoker_;
   std::mutex peripheral_mutex_;
 
   // Peripheral helpers
+  void DisposeAdvertisementPublisher();  // Requires peripheral_mutex_.
   fire_and_forget PeripheralAddServiceAsync(const PeripheralService &service);
   fire_and_forget PeripheralReadRequestedAsync(
       GattLocalCharacteristic const &local_char,


### PR DESCRIPTION
## Summary

- Add a BluetoothLEAdvertisementPublisher path for manufacturer-only advertising with services: []; no GATT registration required.
- Preserve GattServiceProvider for service advertising and explicitly reject unsupported local-name/mixed payloads.
- Report publisher state/errors and revoke callbacks on stop/replacement/disposal.
- Correct Apple manufacturer-data capability reporting and document platform restrictions.
- Add Windows example-build/native-test CI coverage.

## Validation

- flutter test: 103 tests passed on macOS.
- New cross-platform capability tests cover Android, iOS, macOS, and Windows.
- Windows compilation runs in the added CI job; Windows radio validation remains required (start/update/stop, adapter unavailable, and manufacturer reception on other platforms).

## API rationale

Microsoft reserves service UUID/local-name AD types in BluetoothLEAdvertisementPublisher. Manufacturer-only connectionless advertising is supported: https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.advertisement.bluetoothleadvertisementpublisher