### PR TITLE
Android: add `closeGattOnDetach` connection option to release GATT clients on engine teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.1
+* Android: add `closeGattOnDetach` connection option to release GATT clients when the app is killed
+
 ## 2.2.0
 * Expose microsecond scan timestamps captured before Flutter event dispatch
 * Lower minimum Dart SDK to 3.3 (Flutter 3.19+) to restore compatibility with older stable Flutter releases

--- a/README.md
+++ b/README.md
@@ -287,6 +287,26 @@ await bleDevice.connect(
 );
 ```
 
+#### Close GATT on app teardown (Android)
+
+When the Android app is killed by the user (typically swiped away from recents), the OS tears down the FlutterEngine without ever delivering a "disconnect" — the peripheral keeps the link open until its connection supervision timeout (often 10–20 s), leaving the device occupied and draining battery meanwhile.
+
+Pass `AndroidConnectionOptions(closeGattOnDetach: true)` to have the plugin close every open GATT client as soon as the engine detaches, releasing the peripheral immediately — even when `autoConnect` is enabled (which otherwise keeps the GATT open for auto-reconnect):
+
+```dart
+await bleDevice.connect(
+  autoConnect: true,
+  platformConfig: ConnectionPlatformConfig(
+    android: AndroidConnectionOptions(closeGattOnDetach: true),
+  ),
+);
+```
+
+Notes:
+- Once any connection opts in, the behavior is global for the running process — every current and future GATT client is released on engine teardown, with no runtime opt-out (a fresh app launch resets it).
+- Android-only. Explicit `disconnect()` calls and rotation are unaffected.
+- Hard force-stop from Settings skips the teardown callbacks entirely; the firmware should also request a short supervision timeout (Connection Parameter Update) to cover that case.
+
 ### Discovering Services
 
 After establishing a connection, services need to be discovered. This method will discover all services and their characteristics.

--- a/README.md
+++ b/README.md
@@ -289,9 +289,9 @@ await bleDevice.connect(
 
 #### Close GATT on app teardown (Android)
 
-When the Android app is killed by the user (typically swiped away from recents), the OS tears down the FlutterEngine without ever delivering a "disconnect" — the peripheral keeps the link open until its connection supervision timeout (often 10–20 s), leaving the device occupied and draining battery meanwhile.
+When the Android app is killed by the user (typically swiped away from recents), the OS tears down the FlutterEngine without ever delivering a "disconnect" — the peripheral keeps the link open until its connection supervision timeout (often 10–20 s), leaving the device occupied.
 
-Pass `AndroidConnectionOptions(closeGattOnDetach: true)` to have the plugin close every open GATT client as soon as the engine detaches, releasing the peripheral immediately — even when `autoConnect` is enabled (which otherwise keeps the GATT open for auto-reconnect):
+Pass `AndroidConnectionOptions(closeGattOnDetach: true)` to have the plugin close every known GATT client as soon as the engine detaches, releasing the peripheral immediately. This applies regardless of `autoConnect` value, in both cases the link persists until the peripheral's supervision timeout.
 
 ```dart
 await bleDevice.connect(
@@ -303,9 +303,8 @@ await bleDevice.connect(
 ```
 
 Notes:
-- Once any connection opts in, the behavior is global for the running process — every current and future GATT client is released on engine teardown, with no runtime opt-out (a fresh app launch resets it).
+- Once any connection opts in, the behavior is global for the running process — every current and future GATT client is released on engine teardown. It can be disabled at runtime by connecting with `closeGattOnDetach: false`; connecting without the option leaves the current value unchanged (a fresh app launch resets it).
 - Android-only. Explicit `disconnect()` calls and rotation are unaffected.
-- Hard force-stop from Settings skips the teardown callbacks entirely; the firmware should also request a short supervision timeout (Connection Parameter Update) to cover that case.
 
 ### Discovering Services
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ await bleDevice.connect(
 
 When the Android app is killed by the user (typically swiped away from recents), the OS tears down the FlutterEngine without ever delivering a "disconnect" — the peripheral keeps the link open until its connection supervision timeout (often 10–20 s), leaving the device occupied.
 
-Pass `AndroidConnectionOptions(closeGattOnDetach: true)` to have the plugin close every known GATT client as soon as the engine detaches, releasing the peripheral immediately. This applies regardless of `autoConnect` value, in both cases the link persists until the peripheral's supervision timeout.
+Pass `AndroidConnectionOptions(closeGattOnDetach: true)` to have the plugin close every known GATT client as soon as the engine detaches, releasing the peripheral immediately. Without the option, whatever the `autoConnect` value, the link persists until the peripheral's supervision timeout.
 
 ```dart
 await bleDevice.connect(

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBle.g.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBle.g.kt
@@ -1043,19 +1043,60 @@ data class AppleConnectionOptions (
 }
 
 /** Generated class from Pigeon that represents data sent in messages. */
+data class AndroidConnectionOptions (
+  /**
+   * Close the GATT client when the FlutterEngine is
+   * detached (for example, when the app is "killed").
+   */
+  val closeGattOnDetach: Boolean? = null
+)
+ {
+  companion object {
+    fun fromList(pigeonVar_list: List<Any?>): AndroidConnectionOptions {
+      val closeGattOnDetach = pigeonVar_list[0] as Boolean?
+      return AndroidConnectionOptions(closeGattOnDetach)
+    }
+  }
+  fun toList(): List<Any?> {
+    return listOf(
+      closeGattOnDetach,
+    )
+  }
+  override fun equals(other: Any?): Boolean {
+    if (other == null || other.javaClass != javaClass) {
+      return false
+    }
+    if (this === other) {
+      return true
+    }
+    val other = other as AndroidConnectionOptions
+    return UniversalBlePigeonUtils.deepEquals(this.closeGattOnDetach, other.closeGattOnDetach)
+  }
+
+  override fun hashCode(): Int {
+    var result = javaClass.hashCode()
+    result = 31 * result + UniversalBlePigeonUtils.deepHash(this.closeGattOnDetach)
+    return result
+  }
+}
+
+/** Generated class from Pigeon that represents data sent in messages. */
 data class ConnectionPlatformConfig (
-  val apple: AppleConnectionOptions? = null
+  val apple: AppleConnectionOptions? = null,
+  val android: AndroidConnectionOptions? = null
 )
  {
   companion object {
     fun fromList(pigeonVar_list: List<Any?>): ConnectionPlatformConfig {
       val apple = pigeonVar_list[0] as AppleConnectionOptions?
-      return ConnectionPlatformConfig(apple)
+      val android = pigeonVar_list[1] as AndroidConnectionOptions?
+      return ConnectionPlatformConfig(apple, android)
     }
   }
   fun toList(): List<Any?> {
     return listOf(
       apple,
+      android,
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -1066,12 +1107,13 @@ data class ConnectionPlatformConfig (
       return true
     }
     val other = other as ConnectionPlatformConfig
-    return UniversalBlePigeonUtils.deepEquals(this.apple, other.apple)
+    return UniversalBlePigeonUtils.deepEquals(this.apple, other.apple) && UniversalBlePigeonUtils.deepEquals(this.android, other.android)
   }
 
   override fun hashCode(): Int {
     var result = javaClass.hashCode()
     result = 31 * result + UniversalBlePigeonUtils.deepHash(this.apple)
+    result = 31 * result + UniversalBlePigeonUtils.deepHash(this.android)
     return result
   }
 }
@@ -1512,40 +1554,45 @@ private open class UniversalBlePigeonCodec : StandardMessageCodec() {
       }
       155.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          ConnectionPlatformConfig.fromList(it)
+          AndroidConnectionOptions.fromList(it)
         }
       }
       156.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PeripheralAndroidOptions.fromList(it)
+          ConnectionPlatformConfig.fromList(it)
         }
       }
       157.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PeripheralPlatformConfig.fromList(it)
+          PeripheralAndroidOptions.fromList(it)
         }
       }
       158.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PeripheralService.fromList(it)
+          PeripheralPlatformConfig.fromList(it)
         }
       }
       159.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PeripheralCharacteristic.fromList(it)
+          PeripheralService.fromList(it)
         }
       }
       160.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PeripheralDescriptor.fromList(it)
+          PeripheralCharacteristic.fromList(it)
         }
       }
       161.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
-          PeripheralReadRequestResult.fromList(it)
+          PeripheralDescriptor.fromList(it)
         }
       }
       162.toByte() -> {
+        return (readValue(buffer) as? List<Any?>)?.let {
+          PeripheralReadRequestResult.fromList(it)
+        }
+      }
+      163.toByte() -> {
         return (readValue(buffer) as? List<Any?>)?.let {
           PeripheralWriteRequestResult.fromList(it)
         }
@@ -1659,36 +1706,40 @@ private open class UniversalBlePigeonCodec : StandardMessageCodec() {
         stream.write(154)
         writeValue(stream, value.toList())
       }
-      is ConnectionPlatformConfig -> {
+      is AndroidConnectionOptions -> {
         stream.write(155)
         writeValue(stream, value.toList())
       }
-      is PeripheralAndroidOptions -> {
+      is ConnectionPlatformConfig -> {
         stream.write(156)
         writeValue(stream, value.toList())
       }
-      is PeripheralPlatformConfig -> {
+      is PeripheralAndroidOptions -> {
         stream.write(157)
         writeValue(stream, value.toList())
       }
-      is PeripheralService -> {
+      is PeripheralPlatformConfig -> {
         stream.write(158)
         writeValue(stream, value.toList())
       }
-      is PeripheralCharacteristic -> {
+      is PeripheralService -> {
         stream.write(159)
         writeValue(stream, value.toList())
       }
-      is PeripheralDescriptor -> {
+      is PeripheralCharacteristic -> {
         stream.write(160)
         writeValue(stream, value.toList())
       }
-      is PeripheralReadRequestResult -> {
+      is PeripheralDescriptor -> {
         stream.write(161)
         writeValue(stream, value.toList())
       }
-      is PeripheralWriteRequestResult -> {
+      is PeripheralReadRequestResult -> {
         stream.write(162)
+        writeValue(stream, value.toList())
+      }
+      is PeripheralWriteRequestResult -> {
+        stream.write(163)
         writeValue(stream, value.toList())
       }
       else -> super.writeValue(stream, value)

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBle.g.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBle.g.kt
@@ -1045,8 +1045,12 @@ data class AppleConnectionOptions (
 /** Generated class from Pigeon that represents data sent in messages. */
 data class AndroidConnectionOptions (
   /**
-   * Close the GATT client when the FlutterEngine is
-   * detached (for example, when the app is "killed").
+   * Close the GATT client when the FlutterEngine is detached (for
+   * example, when the app is "killed"). The plugin otherwise leaves the
+   * GATT open, keeping the peripheral occupied until its supervision
+   * timeout; with `autoConnect` it also stays open for reconnection.
+   *
+   * When `null`, the current process-wide value is kept.
    */
   val closeGattOnDetach: Boolean? = null
 )

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt
@@ -71,6 +71,13 @@ fun String.findGatt(): BluetoothGatt? {
     return knownGatts[this]
 }
 
+/**
+ * Snapshot of every known (connected) GATT client.
+ */
+fun connectedGatts(): List<BluetoothGatt> {
+    return knownGatts.values.toList()
+}
+
 fun BluetoothManager.isBluetoothEnabled(): Boolean {
     return adapter?.isEnabled == true
 }

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt
@@ -72,7 +72,8 @@ fun String.findGatt(): BluetoothGatt? {
 }
 
 /**
- * Snapshot of every known (connected) GATT client.
+ * Snapshot of every known GATT client. The snapshot avoids mutating the
+ * map while clients are released.
  */
 fun connectedGatts(): List<BluetoothGatt> {
     return knownGatts.values.toList()

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -73,8 +73,9 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
     private val autoConnectDevices = mutableSetOf<String>()
 
     /**
-     * Controls whether all known GATT clients are closed on engine detach
-     * so the peripheral is released immediately.
+     * When enabled, close every known GATT client on engine detach. The
+     * plugin otherwise leaves GATT open, so a killed app keeps the
+     * peripheral occupied until its supervision timeout.
      */
     private var closeGattOnDetach = false
 
@@ -271,9 +272,7 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
         autoConnect: Boolean?,
         platformConfig: ConnectionPlatformConfig?,
     ) {
-        if (platformConfig?.android?.closeGattOnDetach == true) {
-            closeGattOnDetach = true
-        }
+        platformConfig?.android?.closeGattOnDetach?.let { closeGattOnDetach = it }
 
         // Note: platformConfig carries platform-specific connection options
         // If already connected, send connected message,

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -72,6 +72,12 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
     private val rssiResultFutureList = mutableListOf<RssiResultFuture>()
     private val autoConnectDevices = mutableSetOf<String>()
 
+    /**
+     * Controls whether all known GATT clients are closed on engine detach
+     * so the peripheral is released immediately.
+     */
+    private var closeGattOnDetach = false
+
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         context = flutterPluginBinding.applicationContext
         mainThreadHandler = Handler(Looper.getMainLooper())
@@ -101,6 +107,7 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        if (closeGattOnDetach) connectedGatts().forEach(::cleanConnection)
         bluetoothManager.adapter.bluetoothLeScanner?.stopScan(scanCallback)
         context.unregisterReceiver(broadcastReceiver)
         peripheralPlugin.dispose()
@@ -264,7 +271,11 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
         autoConnect: Boolean?,
         platformConfig: ConnectionPlatformConfig?,
     ) {
-        // Note: platformConfig only carries Apple-specific options
+        if (platformConfig?.android?.closeGattOnDetach == true) {
+            closeGattOnDetach = true
+        }
+
+        // Note: platformConfig carries platform-specific connection options
         // If already connected, send connected message,
         // if connecting, do nothing
         deviceId.findGatt()?.let {

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBle.g.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBle.g.swift
@@ -909,33 +909,71 @@ struct AppleConnectionOptions: Hashable {
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
+struct AndroidConnectionOptions: Hashable {
+  /// Close the GATT client when the FlutterEngine is
+  /// detached (for example, when the app is "killed").
+  var closeGattOnDetach: Bool? = nil
+
+
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ pigeonVar_list: [Any?]) -> AndroidConnectionOptions? {
+    let closeGattOnDetach: Bool? = nilOrValue(pigeonVar_list[0])
+
+    return AndroidConnectionOptions(
+      closeGattOnDetach: closeGattOnDetach
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      closeGattOnDetach
+    ]
+  }
+  static func == (lhs: AndroidConnectionOptions, rhs: AndroidConnectionOptions) -> Bool {
+    if Swift.type(of: lhs) != Swift.type(of: rhs) {
+      return false
+    }
+    return deepEqualsUniversalBle(lhs.closeGattOnDetach, rhs.closeGattOnDetach)
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine("AndroidConnectionOptions")
+    deepHashUniversalBle(value: closeGattOnDetach, hasher: &hasher)
+  }
+}
+
+/// Generated class from Pigeon that represents data sent in messages.
 struct ConnectionPlatformConfig: Hashable {
   var apple: AppleConnectionOptions? = nil
+  var android: AndroidConnectionOptions? = nil
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
   static func fromList(_ pigeonVar_list: [Any?]) -> ConnectionPlatformConfig? {
     let apple: AppleConnectionOptions? = nilOrValue(pigeonVar_list[0])
+    let android: AndroidConnectionOptions? = nilOrValue(pigeonVar_list[1])
 
     return ConnectionPlatformConfig(
-      apple: apple
+      apple: apple,
+      android: android
     )
   }
   func toList() -> [Any?] {
     return [
-      apple
+      apple,
+      android,
     ]
   }
   static func == (lhs: ConnectionPlatformConfig, rhs: ConnectionPlatformConfig) -> Bool {
     if Swift.type(of: lhs) != Swift.type(of: rhs) {
       return false
     }
-    return deepEqualsUniversalBle(lhs.apple, rhs.apple)
+    return deepEqualsUniversalBle(lhs.apple, rhs.apple) && deepEqualsUniversalBle(lhs.android, rhs.android)
   }
 
   func hash(into hasher: inout Hasher) {
     hasher.combine("ConnectionPlatformConfig")
     deepHashUniversalBle(value: apple, hasher: &hasher)
+    deepHashUniversalBle(value: android, hasher: &hasher)
   }
 }
 
@@ -1345,20 +1383,22 @@ private class UniversalBlePigeonCodecReader: FlutterStandardReader {
     case 154:
       return AppleConnectionOptions.fromList(self.readValue() as! [Any?])
     case 155:
-      return ConnectionPlatformConfig.fromList(self.readValue() as! [Any?])
+      return AndroidConnectionOptions.fromList(self.readValue() as! [Any?])
     case 156:
-      return PeripheralAndroidOptions.fromList(self.readValue() as! [Any?])
+      return ConnectionPlatformConfig.fromList(self.readValue() as! [Any?])
     case 157:
-      return PeripheralPlatformConfig.fromList(self.readValue() as! [Any?])
+      return PeripheralAndroidOptions.fromList(self.readValue() as! [Any?])
     case 158:
-      return PeripheralService.fromList(self.readValue() as! [Any?])
+      return PeripheralPlatformConfig.fromList(self.readValue() as! [Any?])
     case 159:
-      return PeripheralCharacteristic.fromList(self.readValue() as! [Any?])
+      return PeripheralService.fromList(self.readValue() as! [Any?])
     case 160:
-      return PeripheralDescriptor.fromList(self.readValue() as! [Any?])
+      return PeripheralCharacteristic.fromList(self.readValue() as! [Any?])
     case 161:
-      return PeripheralReadRequestResult.fromList(self.readValue() as! [Any?])
+      return PeripheralDescriptor.fromList(self.readValue() as! [Any?])
     case 162:
+      return PeripheralReadRequestResult.fromList(self.readValue() as! [Any?])
+    case 163:
       return PeripheralWriteRequestResult.fromList(self.readValue() as! [Any?])
     default:
       return super.readValue(ofType: type)
@@ -1446,29 +1486,32 @@ private class UniversalBlePigeonCodecWriter: FlutterStandardWriter {
     } else if let value = value as? AppleConnectionOptions {
       super.writeByte(154)
       super.writeValue(value.toList())
-    } else if let value = value as? ConnectionPlatformConfig {
+    } else if let value = value as? AndroidConnectionOptions {
       super.writeByte(155)
       super.writeValue(value.toList())
-    } else if let value = value as? PeripheralAndroidOptions {
+    } else if let value = value as? ConnectionPlatformConfig {
       super.writeByte(156)
       super.writeValue(value.toList())
-    } else if let value = value as? PeripheralPlatformConfig {
+    } else if let value = value as? PeripheralAndroidOptions {
       super.writeByte(157)
       super.writeValue(value.toList())
-    } else if let value = value as? PeripheralService {
+    } else if let value = value as? PeripheralPlatformConfig {
       super.writeByte(158)
       super.writeValue(value.toList())
-    } else if let value = value as? PeripheralCharacteristic {
+    } else if let value = value as? PeripheralService {
       super.writeByte(159)
       super.writeValue(value.toList())
-    } else if let value = value as? PeripheralDescriptor {
+    } else if let value = value as? PeripheralCharacteristic {
       super.writeByte(160)
       super.writeValue(value.toList())
-    } else if let value = value as? PeripheralReadRequestResult {
+    } else if let value = value as? PeripheralDescriptor {
       super.writeByte(161)
       super.writeValue(value.toList())
-    } else if let value = value as? PeripheralWriteRequestResult {
+    } else if let value = value as? PeripheralReadRequestResult {
       super.writeByte(162)
+      super.writeValue(value.toList())
+    } else if let value = value as? PeripheralWriteRequestResult {
+      super.writeByte(163)
       super.writeValue(value.toList())
     } else {
       super.writeValue(value)

--- a/darwin/universal_ble/Sources/universal_ble/UniversalBle.g.swift
+++ b/darwin/universal_ble/Sources/universal_ble/UniversalBle.g.swift
@@ -910,8 +910,12 @@ struct AppleConnectionOptions: Hashable {
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct AndroidConnectionOptions: Hashable {
-  /// Close the GATT client when the FlutterEngine is
-  /// detached (for example, when the app is "killed").
+  /// Close the GATT client when the FlutterEngine is detached (for
+  /// example, when the app is "killed"). The plugin otherwise leaves the
+  /// GATT open, keeping the peripheral occupied until its supervision
+  /// timeout; with `autoConnect` it also stays open for reconnection.
+  ///
+  /// When `null`, the current process-wide value is kept.
   var closeGattOnDetach: Bool? = nil
 
 

--- a/lib/src/universal_ble.g.dart
+++ b/lib/src/universal_ble.g.dart
@@ -981,16 +981,64 @@ class AppleConnectionOptions {
   int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
 }
 
+class AndroidConnectionOptions {
+  AndroidConnectionOptions({
+    this.closeGattOnDetach,
+  });
+
+  /// Close the GATT client when the FlutterEngine is
+  /// detached (for example, when the app is "killed").
+  bool? closeGattOnDetach;
+
+  List<Object?> _toList() {
+    return <Object?>[
+      closeGattOnDetach,
+    ];
+  }
+
+  Object encode() {
+    return _toList();
+  }
+
+  static AndroidConnectionOptions decode(Object result) {
+    result as List<Object?>;
+    return AndroidConnectionOptions(
+      closeGattOnDetach: result[0] as bool?,
+    );
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  bool operator ==(Object other) {
+    if (other is! AndroidConnectionOptions ||
+        other.runtimeType != runtimeType) {
+      return false;
+    }
+    if (identical(this, other)) {
+      return true;
+    }
+    return _deepEquals(closeGattOnDetach, other.closeGattOnDetach);
+  }
+
+  @override
+  // ignore: avoid_equals_and_hash_code_on_mutable_classes
+  int get hashCode => _deepHash(<Object?>[runtimeType, ..._toList()]);
+}
+
 class ConnectionPlatformConfig {
   ConnectionPlatformConfig({
     this.apple,
+    this.android,
   });
 
   AppleConnectionOptions? apple;
 
+  AndroidConnectionOptions? android;
+
   List<Object?> _toList() {
     return <Object?>[
       apple,
+      android,
     ];
   }
 
@@ -1002,6 +1050,7 @@ class ConnectionPlatformConfig {
     result as List<Object?>;
     return ConnectionPlatformConfig(
       apple: result[0] as AppleConnectionOptions?,
+      android: result[1] as AndroidConnectionOptions?,
     );
   }
 
@@ -1015,7 +1064,8 @@ class ConnectionPlatformConfig {
     if (identical(this, other)) {
       return true;
     }
-    return _deepEquals(apple, other.apple);
+    return _deepEquals(apple, other.apple) &&
+        _deepEquals(android, other.android);
   }
 
   @override
@@ -1489,29 +1539,32 @@ class _PigeonCodec extends StandardMessageCodec {
     } else if (value is AppleConnectionOptions) {
       buffer.putUint8(154);
       writeValue(buffer, value.encode());
-    } else if (value is ConnectionPlatformConfig) {
+    } else if (value is AndroidConnectionOptions) {
       buffer.putUint8(155);
       writeValue(buffer, value.encode());
-    } else if (value is PeripheralAndroidOptions) {
+    } else if (value is ConnectionPlatformConfig) {
       buffer.putUint8(156);
       writeValue(buffer, value.encode());
-    } else if (value is PeripheralPlatformConfig) {
+    } else if (value is PeripheralAndroidOptions) {
       buffer.putUint8(157);
       writeValue(buffer, value.encode());
-    } else if (value is PeripheralService) {
+    } else if (value is PeripheralPlatformConfig) {
       buffer.putUint8(158);
       writeValue(buffer, value.encode());
-    } else if (value is PeripheralCharacteristic) {
+    } else if (value is PeripheralService) {
       buffer.putUint8(159);
       writeValue(buffer, value.encode());
-    } else if (value is PeripheralDescriptor) {
+    } else if (value is PeripheralCharacteristic) {
       buffer.putUint8(160);
       writeValue(buffer, value.encode());
-    } else if (value is PeripheralReadRequestResult) {
+    } else if (value is PeripheralDescriptor) {
       buffer.putUint8(161);
       writeValue(buffer, value.encode());
-    } else if (value is PeripheralWriteRequestResult) {
+    } else if (value is PeripheralReadRequestResult) {
       buffer.putUint8(162);
+      writeValue(buffer, value.encode());
+    } else if (value is PeripheralWriteRequestResult) {
+      buffer.putUint8(163);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -1591,20 +1644,22 @@ class _PigeonCodec extends StandardMessageCodec {
       case 154:
         return AppleConnectionOptions.decode(readValue(buffer)!);
       case 155:
-        return ConnectionPlatformConfig.decode(readValue(buffer)!);
+        return AndroidConnectionOptions.decode(readValue(buffer)!);
       case 156:
-        return PeripheralAndroidOptions.decode(readValue(buffer)!);
+        return ConnectionPlatformConfig.decode(readValue(buffer)!);
       case 157:
-        return PeripheralPlatformConfig.decode(readValue(buffer)!);
+        return PeripheralAndroidOptions.decode(readValue(buffer)!);
       case 158:
-        return PeripheralService.decode(readValue(buffer)!);
+        return PeripheralPlatformConfig.decode(readValue(buffer)!);
       case 159:
-        return PeripheralCharacteristic.decode(readValue(buffer)!);
+        return PeripheralService.decode(readValue(buffer)!);
       case 160:
-        return PeripheralDescriptor.decode(readValue(buffer)!);
+        return PeripheralCharacteristic.decode(readValue(buffer)!);
       case 161:
-        return PeripheralReadRequestResult.decode(readValue(buffer)!);
+        return PeripheralDescriptor.decode(readValue(buffer)!);
       case 162:
+        return PeripheralReadRequestResult.decode(readValue(buffer)!);
+      case 163:
         return PeripheralWriteRequestResult.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);

--- a/lib/src/universal_ble.g.dart
+++ b/lib/src/universal_ble.g.dart
@@ -986,8 +986,12 @@ class AndroidConnectionOptions {
     this.closeGattOnDetach,
   });
 
-  /// Close the GATT client when the FlutterEngine is
-  /// detached (for example, when the app is "killed").
+  /// Close the GATT client when the FlutterEngine is detached (for
+  /// example, when the app is "killed"). The plugin otherwise leaves the
+  /// GATT open, keeping the peripheral occupied until its supervision
+  /// timeout; with `autoConnect` it also stays open for reconnection.
+  ///
+  /// When `null`, the current process-wide value is kept.
   bool? closeGattOnDetach;
 
   List<Object?> _toList() {

--- a/lib/universal_ble.dart
+++ b/lib/universal_ble.dart
@@ -11,6 +11,7 @@ export 'package:universal_ble/src/interfaces/universal_ble_peripheral_platform_i
 export 'package:universal_ble/src/universal_ble.g.dart'
     show
         AndroidOptions,
+        AndroidConnectionOptions,
         AppleConnectionOptions,
         ConnectionPlatformConfig,
         AndroidScanMode,

--- a/pigeon/universal_ble.dart
+++ b/pigeon/universal_ble.dart
@@ -295,9 +295,18 @@ class AppleConnectionOptions {
   });
 }
 
+class AndroidConnectionOptions {
+  /// Close the GATT client when the FlutterEngine is
+  /// detached (for example, when the app is "killed").
+  bool? closeGattOnDetach;
+
+  AndroidConnectionOptions({this.closeGattOnDetach});
+}
+
 class ConnectionPlatformConfig {
   AppleConnectionOptions? apple;
-  ConnectionPlatformConfig({this.apple});
+  AndroidConnectionOptions? android;
+  ConnectionPlatformConfig({this.apple, this.android});
 }
 
 class PeripheralAndroidOptions {

--- a/pigeon/universal_ble.dart
+++ b/pigeon/universal_ble.dart
@@ -296,8 +296,12 @@ class AppleConnectionOptions {
 }
 
 class AndroidConnectionOptions {
-  /// Close the GATT client when the FlutterEngine is
-  /// detached (for example, when the app is "killed").
+  /// Close the GATT client when the FlutterEngine is detached (for
+  /// example, when the app is "killed"). The plugin otherwise leaves the
+  /// GATT open, keeping the peripheral occupied until its supervision
+  /// timeout; with `autoConnect` it also stays open for reconnection.
+  ///
+  /// When `null`, the current process-wide value is kept.
   bool? closeGattOnDetach;
 
   AndroidConnectionOptions({this.closeGattOnDetach});

--- a/windows/src/generated/universal_ble.g.cpp
+++ b/windows/src/generated/universal_ble.g.cpp
@@ -1298,18 +1298,77 @@ size_t PigeonInternalDeepHash(const AppleConnectionOptions& v) {
   return v.Hash();
 }
 
+// AndroidConnectionOptions
+
+AndroidConnectionOptions::AndroidConnectionOptions() {}
+
+AndroidConnectionOptions::AndroidConnectionOptions(const bool* close_gatt_on_detach)
+ : close_gatt_on_detach_(close_gatt_on_detach ? std::optional<bool>(*close_gatt_on_detach) : std::nullopt) {}
+
+const bool* AndroidConnectionOptions::close_gatt_on_detach() const {
+  return close_gatt_on_detach_ ? &(*close_gatt_on_detach_) : nullptr;
+}
+
+void AndroidConnectionOptions::set_close_gatt_on_detach(const bool* value_arg) {
+  close_gatt_on_detach_ = value_arg ? std::optional<bool>(*value_arg) : std::nullopt;
+}
+
+void AndroidConnectionOptions::set_close_gatt_on_detach(bool value_arg) {
+  close_gatt_on_detach_ = value_arg;
+}
+
+
+EncodableList AndroidConnectionOptions::ToEncodableList() const {
+  EncodableList list;
+  list.reserve(1);
+  list.push_back(close_gatt_on_detach_ ? EncodableValue(*close_gatt_on_detach_) : EncodableValue());
+  return list;
+}
+
+AndroidConnectionOptions AndroidConnectionOptions::FromEncodableList(const EncodableList& list) {
+  AndroidConnectionOptions decoded;
+  auto& encodable_close_gatt_on_detach = list[0];
+  if (!encodable_close_gatt_on_detach.IsNull()) {
+    decoded.set_close_gatt_on_detach(std::get<bool>(encodable_close_gatt_on_detach));
+  }
+  return decoded;
+}
+
+bool AndroidConnectionOptions::operator==(const AndroidConnectionOptions& other) const {
+  return PigeonInternalDeepEquals(close_gatt_on_detach_, other.close_gatt_on_detach_);
+}
+
+bool AndroidConnectionOptions::operator!=(const AndroidConnectionOptions& other) const {
+  return !(*this == other);
+}
+
+size_t AndroidConnectionOptions::Hash() const {
+  size_t result = 1;
+  result = result * 31 + PigeonInternalDeepHash(close_gatt_on_detach_);
+  return result;
+}
+
+size_t PigeonInternalDeepHash(const AndroidConnectionOptions& v) {
+  return v.Hash();
+}
+
 // ConnectionPlatformConfig
 
 ConnectionPlatformConfig::ConnectionPlatformConfig() {}
 
-ConnectionPlatformConfig::ConnectionPlatformConfig(const AppleConnectionOptions* apple)
- : apple_(apple ? std::make_unique<AppleConnectionOptions>(*apple) : nullptr) {}
+ConnectionPlatformConfig::ConnectionPlatformConfig(
+  const AppleConnectionOptions* apple,
+  const AndroidConnectionOptions* android)
+ : apple_(apple ? std::make_unique<AppleConnectionOptions>(*apple) : nullptr),
+    android_(android ? std::make_unique<AndroidConnectionOptions>(*android) : nullptr) {}
 
 ConnectionPlatformConfig::ConnectionPlatformConfig(const ConnectionPlatformConfig& other)
- : apple_(other.apple_ ? std::make_unique<AppleConnectionOptions>(*other.apple_) : nullptr) {}
+ : apple_(other.apple_ ? std::make_unique<AppleConnectionOptions>(*other.apple_) : nullptr),
+    android_(other.android_ ? std::make_unique<AndroidConnectionOptions>(*other.android_) : nullptr) {}
 
 ConnectionPlatformConfig& ConnectionPlatformConfig::operator=(const ConnectionPlatformConfig& other) {
   apple_ = other.apple_ ? std::make_unique<AppleConnectionOptions>(*other.apple_) : nullptr;
+  android_ = other.android_ ? std::make_unique<AndroidConnectionOptions>(*other.android_) : nullptr;
   return *this;
 }
 
@@ -1326,10 +1385,24 @@ void ConnectionPlatformConfig::set_apple(const AppleConnectionOptions& value_arg
 }
 
 
+const AndroidConnectionOptions* ConnectionPlatformConfig::android() const {
+  return android_.get();
+}
+
+void ConnectionPlatformConfig::set_android(const AndroidConnectionOptions* value_arg) {
+  android_ = value_arg ? std::make_unique<AndroidConnectionOptions>(*value_arg) : nullptr;
+}
+
+void ConnectionPlatformConfig::set_android(const AndroidConnectionOptions& value_arg) {
+  android_ = std::make_unique<AndroidConnectionOptions>(value_arg);
+}
+
+
 EncodableList ConnectionPlatformConfig::ToEncodableList() const {
   EncodableList list;
-  list.reserve(1);
+  list.reserve(2);
   list.push_back(apple_ ? CustomEncodableValue(*apple_) : EncodableValue());
+  list.push_back(android_ ? CustomEncodableValue(*android_) : EncodableValue());
   return list;
 }
 
@@ -1339,11 +1412,15 @@ ConnectionPlatformConfig ConnectionPlatformConfig::FromEncodableList(const Encod
   if (!encodable_apple.IsNull()) {
     decoded.set_apple(std::any_cast<const AppleConnectionOptions&>(std::get<CustomEncodableValue>(encodable_apple)));
   }
+  auto& encodable_android = list[1];
+  if (!encodable_android.IsNull()) {
+    decoded.set_android(std::any_cast<const AndroidConnectionOptions&>(std::get<CustomEncodableValue>(encodable_android)));
+  }
   return decoded;
 }
 
 bool ConnectionPlatformConfig::operator==(const ConnectionPlatformConfig& other) const {
-  return PigeonInternalDeepEquals(apple_, other.apple_);
+  return PigeonInternalDeepEquals(apple_, other.apple_) && PigeonInternalDeepEquals(android_, other.android_);
 }
 
 bool ConnectionPlatformConfig::operator!=(const ConnectionPlatformConfig& other) const {
@@ -1353,6 +1430,7 @@ bool ConnectionPlatformConfig::operator!=(const ConnectionPlatformConfig& other)
 size_t ConnectionPlatformConfig::Hash() const {
   size_t result = 1;
   result = result * 31 + PigeonInternalDeepHash(apple_);
+  result = result * 31 + PigeonInternalDeepHash(android_);
   return result;
 }
 
@@ -2091,27 +2169,30 @@ EncodableValue PigeonInternalCodecSerializer::ReadValueOfType(
         return CustomEncodableValue(AppleConnectionOptions::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 155: {
-        return CustomEncodableValue(ConnectionPlatformConfig::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(AndroidConnectionOptions::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 156: {
-        return CustomEncodableValue(PeripheralAndroidOptions::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(ConnectionPlatformConfig::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 157: {
-        return CustomEncodableValue(PeripheralPlatformConfig::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(PeripheralAndroidOptions::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 158: {
-        return CustomEncodableValue(PeripheralService::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(PeripheralPlatformConfig::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 159: {
-        return CustomEncodableValue(PeripheralCharacteristic::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(PeripheralService::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 160: {
-        return CustomEncodableValue(PeripheralDescriptor::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(PeripheralCharacteristic::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 161: {
-        return CustomEncodableValue(PeripheralReadRequestResult::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+        return CustomEncodableValue(PeripheralDescriptor::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     case 162: {
+        return CustomEncodableValue(PeripheralReadRequestResult::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
+      }
+    case 163: {
         return CustomEncodableValue(PeripheralWriteRequestResult::FromEncodableList(std::get<EncodableList>(ReadValue(stream))));
       }
     default:
@@ -2253,43 +2334,48 @@ void PigeonInternalCodecSerializer::WriteValue(
       WriteValue(EncodableValue(std::any_cast<AppleConnectionOptions>(*custom_value).ToEncodableList()), stream);
       return;
     }
-    if (custom_value->type() == typeid(ConnectionPlatformConfig)) {
+    if (custom_value->type() == typeid(AndroidConnectionOptions)) {
       stream->WriteByte(155);
+      WriteValue(EncodableValue(std::any_cast<AndroidConnectionOptions>(*custom_value).ToEncodableList()), stream);
+      return;
+    }
+    if (custom_value->type() == typeid(ConnectionPlatformConfig)) {
+      stream->WriteByte(156);
       WriteValue(EncodableValue(std::any_cast<ConnectionPlatformConfig>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralAndroidOptions)) {
-      stream->WriteByte(156);
+      stream->WriteByte(157);
       WriteValue(EncodableValue(std::any_cast<PeripheralAndroidOptions>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralPlatformConfig)) {
-      stream->WriteByte(157);
+      stream->WriteByte(158);
       WriteValue(EncodableValue(std::any_cast<PeripheralPlatformConfig>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralService)) {
-      stream->WriteByte(158);
+      stream->WriteByte(159);
       WriteValue(EncodableValue(std::any_cast<PeripheralService>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralCharacteristic)) {
-      stream->WriteByte(159);
+      stream->WriteByte(160);
       WriteValue(EncodableValue(std::any_cast<PeripheralCharacteristic>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralDescriptor)) {
-      stream->WriteByte(160);
+      stream->WriteByte(161);
       WriteValue(EncodableValue(std::any_cast<PeripheralDescriptor>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralReadRequestResult)) {
-      stream->WriteByte(161);
+      stream->WriteByte(162);
       WriteValue(EncodableValue(std::any_cast<PeripheralReadRequestResult>(*custom_value).ToEncodableList()), stream);
       return;
     }
     if (custom_value->type() == typeid(PeripheralWriteRequestResult)) {
-      stream->WriteByte(162);
+      stream->WriteByte(163);
       WriteValue(EncodableValue(std::any_cast<PeripheralWriteRequestResult>(*custom_value).ToEncodableList()), stream);
       return;
     }

--- a/windows/src/generated/universal_ble.g.h
+++ b/windows/src/generated/universal_ble.g.h
@@ -793,13 +793,48 @@ class AppleConnectionOptions {
 
 
 // Generated class from Pigeon that represents data sent in messages.
+class AndroidConnectionOptions {
+ public:
+  // Constructs an object setting all non-nullable fields.
+  AndroidConnectionOptions();
+
+  // Constructs an object setting all fields.
+  explicit AndroidConnectionOptions(const bool* close_gatt_on_detach);
+
+  // Close the GATT client when the FlutterEngine is
+  // detached (for example, when the app is "killed").
+  const bool* close_gatt_on_detach() const;
+  void set_close_gatt_on_detach(const bool* value_arg);
+  void set_close_gatt_on_detach(bool value_arg);
+
+  bool operator==(const AndroidConnectionOptions& other) const;
+  bool operator!=(const AndroidConnectionOptions& other) const;
+  /// Returns a hash code value for the object. This method is supported for the benefit of hash tables.
+  size_t Hash() const;
+ private:
+  static AndroidConnectionOptions FromEncodableList(const ::flutter::EncodableList& list);
+  ::flutter::EncodableList ToEncodableList() const;
+  friend class ConnectionPlatformConfig;
+  friend class UniversalBlePlatformChannel;
+  friend class UniversalBleCallbackChannel;
+  friend class UniversalBlePeripheralChannel;
+  friend class UniversalBleAndroidChannel;
+  friend class UniversalBlePeripheralCallback;
+  friend class PigeonInternalCodecSerializer;
+  std::optional<bool> close_gatt_on_detach_;
+};
+
+
+// Generated class from Pigeon that represents data sent in messages.
 class ConnectionPlatformConfig {
  public:
   // Constructs an object setting all non-nullable fields.
   ConnectionPlatformConfig();
 
   // Constructs an object setting all fields.
-  explicit ConnectionPlatformConfig(const AppleConnectionOptions* apple);
+  explicit ConnectionPlatformConfig(
+    const AppleConnectionOptions* apple,
+    const AndroidConnectionOptions* android);
 
   ~ConnectionPlatformConfig() = default;
   ConnectionPlatformConfig(const ConnectionPlatformConfig& other);
@@ -809,6 +844,10 @@ class ConnectionPlatformConfig {
   const AppleConnectionOptions* apple() const;
   void set_apple(const AppleConnectionOptions* value_arg);
   void set_apple(const AppleConnectionOptions& value_arg);
+
+  const AndroidConnectionOptions* android() const;
+  void set_android(const AndroidConnectionOptions* value_arg);
+  void set_android(const AndroidConnectionOptions& value_arg);
 
   bool operator==(const ConnectionPlatformConfig& other) const;
   bool operator!=(const ConnectionPlatformConfig& other) const;
@@ -824,6 +863,7 @@ class ConnectionPlatformConfig {
   friend class UniversalBlePeripheralCallback;
   friend class PigeonInternalCodecSerializer;
   std::unique_ptr<AppleConnectionOptions> apple_;
+  std::unique_ptr<AndroidConnectionOptions> android_;
 };
 
 

--- a/windows/src/generated/universal_ble.g.h
+++ b/windows/src/generated/universal_ble.g.h
@@ -801,8 +801,12 @@ class AndroidConnectionOptions {
   // Constructs an object setting all fields.
   explicit AndroidConnectionOptions(const bool* close_gatt_on_detach);
 
-  // Close the GATT client when the FlutterEngine is
-  // detached (for example, when the app is "killed").
+  // Close the GATT client when the FlutterEngine is detached (for
+  // example, when the app is "killed"). The plugin otherwise leaves the
+  // GATT open, keeping the peripheral occupied until its supervision
+  // timeout; with `autoConnect` it also stays open for reconnection.
+  //
+  // When `null`, the current process-wide value is kept.
   const bool* close_gatt_on_detach() const;
   void set_close_gatt_on_detach(const bool* value_arg);
   void set_close_gatt_on_detach(bool value_arg);


### PR DESCRIPTION
This PR fixes #291 

### Motivation
When the app is killed (swiped away), the OS tears down the FlutterEngine without a `disconnect` callback. The plugin never closed GATT clients on engine teardown, so the peripheral stayed occupied until its connection supervision timeout (10-60 seconds), whether `autoConnect` was enabled or not.

### Changes
- New `AndroidConnectionOptions` (`closeGattOnDetach`) in Pigeon, forwarded via `ConnectionPlatformConfig.android`; generated bindings regenerated for all platforms.
- `UniversalBlePlugin` tracks the option; when enabled, it closes every known GATT client in `onDetachedFromEngine` (reusing the existing `cleanConnection` path, so rotation is unaffected and explicit `disconnect()` still works).
- The value is process-wide and can be toggled at runtime: any connect with `closeGattOnDetach: true`/`false` sets it; omitting the option leaves the current value unchanged.
- README + CHANGELOG updated.

### Tests
- `flutter test`: 99/99 pass.
- `./gradlew :universal_ble:testDebugUnitTest` (JDK 17): 10/10 pass.
- Verified on physical Android device: peripheral released within ~2 seconds of swiping the app away (previously 10-60 s).