### PR TITLE
Android: close the GATT client once the disconnect completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.2.1
 * Android: add `closeGattOnDetach` connection option to release GATT clients when the app is killed
+* Android: close the GATT client once the disconnect completes instead of right after `disconnect()`, and report the real disconnect status
 
 ## 2.2.0
 * Expose microsecond scan timestamps captured before Flutter event dispatch

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt
@@ -120,7 +120,8 @@ fun BluetoothGatt.saveCacheIfNeeded() {
 }
 
 fun BluetoothGatt.removeCache() {
-    knownGatts.remove(this.device.address)
+    // Only while still the registered client; a newer connect() may have replaced it.
+    knownGatts.remove(this.device.address, this)
 }
 
 

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -27,7 +27,9 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.PluginRegistry
+import java.util.Collections
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import androidx.core.content.edit
@@ -78,6 +80,11 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
      * peripheral occupied until its supervision timeout.
      */
     private var closeGattOnDetach = false
+
+    // Clients that disconnect() is tearing down; closed on STATE_DISCONNECTED or by the fallback timer.
+    private val closingGatts: MutableSet<BluetoothGatt> =
+        Collections.newSetFromMap(ConcurrentHashMap<BluetoothGatt, Boolean>())
+    private val gattCloseTimeoutMs = 1500L
 
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         context = flutterPluginBinding.applicationContext
@@ -1437,21 +1444,21 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
     private fun cleanConnection(gatt: BluetoothGatt) {
         val deviceId = gatt.device.address
         gatt.removeCache()
-        gatt.disconnect()
-        // Release the GATT client interface. disconnect() tears down the link but never frees the
-        // client that connectGatt() registered - only close() does. When the connection was never
-        // established (still CONNECTING when the caller gives up, e.g. on a client-side connect
-        // timeout) Android delivers no STATE_DISCONNECTED callback at all, so the close() in
-        // onConnectionStateChange never runs and the client leaks for the lifetime of the process.
-        // Once the per-app pool is exhausted, registerClient fails and every subsequent
-        // connectGatt returns status 257 (GATT_FAILURE) for every device until the app restarts.
-        gatt.close()
         cleanUpConnection(deviceId)
-        // close() suppresses the STATE_DISCONNECTED callback that would otherwise report this,
-        // so surface the disconnect here - mirrors the gatt == null branch of disconnect().
-        mainThreadHandler?.post {
-            callbackChannel?.onConnectionChanged(deviceId, false, null) {}
-        }
+        closingGatts.add(gatt)
+        gatt.disconnect()
+        // close() runs from onConnectionStateChange once the link is down. A client that never
+        // reached CONNECTED gets no callback at all, so release it anyway after a while (#277).
+        mainThreadHandler?.postDelayed({
+            if (closingGatts.remove(gatt)) {
+                UniversalBleLogger.logDebug("No STATE_DISCONNECTED for $deviceId, closing gatt")
+                gatt.close()
+                // A newer connect() owns this address now; its state is not ours to report.
+                if (!deviceId.isKnownGatt()) {
+                    callbackChannel?.onConnectionChanged(deviceId, false, null) {}
+                }
+            }
+        }, gattCloseTimeoutMs)
     }
 
     private fun onBondStateUpdate(deviceId: String, bonded: Boolean, error: String? = null) {
@@ -1577,22 +1584,28 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
         } else if (newState == BluetoothGatt.STATE_DISCONNECTED) {
             val deviceId = gatt.device.address
             val shouldAutoConnect = autoConnectDevices.contains(deviceId)
+            val closingByRequest = closingGatts.remove(gatt)
+            // disconnect() already dropped this client from the cache, so a known gatt is a newer
+            // connect() whose pending operations and connection state must be left alone.
+            val superseded = closingByRequest && deviceId.isKnownGatt()
 
-            // Always clean up internal state (futures, etc.)
-            cleanUpConnection(deviceId)
+            if (!superseded) {
+                // Always clean up internal state (futures, etc.)
+                cleanUpConnection(deviceId)
 
-            // Send connection changed callback
-            mainThreadHandler?.post {
-                callbackChannel?.onConnectionChanged(
-                    deviceId, false, status.parseHciErrorCode()
-                ) {}
+                // Send connection changed callback
+                mainThreadHandler?.post {
+                    callbackChannel?.onConnectionChanged(
+                        deviceId, false, status.parseHciErrorCode()
+                    ) {}
+                }
             }
 
-            if (!shouldAutoConnect) {
-                // Only close GATT resources when autoConnect is disabled
+            if (closingByRequest || !shouldAutoConnect) {
+                // Only keep the client open when autoConnect should let Android reconnect it
                 gatt.removeCache()
                 gatt.disconnect()
-                UniversalBleLogger.logDebug("Closing gatt for ${gatt.device.name}")
+                UniversalBleLogger.logDebug("Closing gatt for $deviceId")
                 gatt.close()
             }
             // When autoConnect is enabled, keep GATT open for Android to reconnect

--- a/android/src/test/kotlin/com/navideck/universal_ble/DisconnectCloseTest.kt
+++ b/android/src/test/kotlin/com/navideck/universal_ble/DisconnectCloseTest.kt
@@ -1,0 +1,104 @@
+package com.navideck.universal_ble
+
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.os.Handler
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+
+/*
+ * disconnect() keeps the GATT client registered until STATE_DISCONNECTED
+ * arrives (or the fallback timer fires). A connect() issued in the meantime
+ * registers a new client for the same address; the old one must then close
+ * without failing the new client's operations, evicting it from the cache or
+ * reporting a disconnect the new client would take for its own.
+ */
+internal class DisconnectCloseTest {
+    private val deviceAddress = "AA:BB:CC:DD:EE:FF"
+
+    // (deviceId, connected, error) of every onConnectionChanged delivered to Dart.
+    private val connectionChanges = mutableListOf<List<Any?>>()
+    private val callbackChannel: UniversalBleCallbackChannel =
+        Mockito.mock(UniversalBleCallbackChannel::class.java) { invocation ->
+            if (invocation.method.name == "onConnectionChanged") {
+                connectionChanges.add(invocation.arguments.take(3))
+            }
+            null
+        }
+
+    @AfterTest
+    fun clearCache() {
+        deviceAddress.findGatt()?.removeCache()
+    }
+
+    private fun plugin(): UniversalBlePlugin {
+        val plugin = UniversalBlePlugin()
+        // Callbacks are posted to the main looper; run them inline.
+        val handler = Mockito.mock(Handler::class.java)
+        Mockito.doAnswer { invocation ->
+            invocation.getArgument<Runnable>(0).run()
+            true
+        }.`when`(handler).post(any())
+        setField(plugin, "mainThreadHandler", handler)
+        setField(plugin, "callbackChannel", callbackChannel)
+        return plugin
+    }
+
+    private fun setField(plugin: UniversalBlePlugin, name: String, value: Any) {
+        val field = UniversalBlePlugin::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        field.set(plugin, value)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun closingGatts(plugin: UniversalBlePlugin): MutableSet<BluetoothGatt> {
+        val field = UniversalBlePlugin::class.java.getDeclaredField("closingGatts")
+        field.isAccessible = true
+        return field.get(plugin) as MutableSet<BluetoothGatt>
+    }
+
+    private fun mockGatt(): BluetoothGatt {
+        val device = Mockito.mock(BluetoothDevice::class.java)
+        Mockito.`when`(device.address).thenReturn(deviceAddress)
+        val gatt = Mockito.mock(BluetoothGatt::class.java)
+        Mockito.`when`(gatt.device).thenReturn(device)
+        return gatt
+    }
+
+    @Test
+    fun closingClientIsClosedAndReportedOnDisconnect() {
+        val plugin = plugin()
+        val gatt = mockGatt()
+        closingGatts(plugin).add(gatt)
+
+        plugin.onConnectionStateChange(
+            gatt, BluetoothGatt.GATT_SUCCESS, BluetoothGatt.STATE_DISCONNECTED
+        )
+
+        Mockito.verify(gatt).close()
+        assertEquals(listOf(listOf<Any?>(deviceAddress, false, null)), connectionChanges)
+        assertTrue(closingGatts(plugin).isEmpty())
+    }
+
+    @Test
+    fun supersededClientClosesWithoutTouchingTheNewOne() {
+        val plugin = plugin()
+        val oldGatt = mockGatt()
+        val newGatt = mockGatt()
+        closingGatts(plugin).add(oldGatt)
+        newGatt.saveCacheIfNeeded()
+
+        plugin.onConnectionStateChange(
+            oldGatt, BluetoothGatt.GATT_SUCCESS, BluetoothGatt.STATE_DISCONNECTED
+        )
+
+        Mockito.verify(oldGatt).close()
+        assertTrue(connectionChanges.isEmpty())
+        assertSame(newGatt, deviceAddress.findGatt())
+    }
+}


### PR DESCRIPTION
Since #277, `cleanConnection()` calls `close()` right after `disconnect()`, so the client is released while the disconnect is still in flight. On the setups we tested the ACL then stays up for about a second, the peripheral never sees a disconnect in that window, and a `connect()` to the same device issued within it silently re-attaches to the stale link (`GATT_StartIf: interface already has connected device` in logcat) instead of creating a new connection. `connectionStream` also reports `false` synthetically at `close()` time, so the Dart side has nothing to wait on.

This keeps the client registered until `STATE_DISCONNECTED`, closes it there and reports the real status. A 1.5 s fallback closes a client that never gets that callback (it never reached CONNECTED), which keeps the leak fix from #277. A `connect()` to the same address during that window registers a new client; the old one no longer evicts it from `knownGatts`, fails its pending operations or reports a disconnect on its behalf (`removeCache()` is now identity-conditional). No API change.

Verified with `flutter analyze`, `flutter test` (99 passed), `gradle :universal_ble:testDebugUnitTest` (12 passed; two new tests cover the close paths) and a debug build of the example app. The same approach was validated on an API 34 emulator against a virtual peripheral: `disconnect()` followed by `connect()` now produces a new connection on the peripheral, and `connectionStream` reports the drop when the link is actually gone. I had no hardware to test on. #291 / #292 are about engine teardown and are not addressed here.
