### PR TITLE
fix(android): correctly report readiness state and throttle bluetooth enable dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Apple: Accurately report manufacturer-data advertising capabilities.
 * Android: add `closeGattOnDetach` connection option to release GATT clients when the app is killed
 * Android: close the GATT client once the disconnect completes instead of right after `disconnect()`, and report the real disconnect status
+* Android: Fix peripheral `getReadinessState()` to check permissions and adapter power before advertising support, and throttle `startAdvertising` Bluetooth enable prompts to at most one dialog.
 
 
 ## 2.2.0

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePeripheralPlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePeripheralPlugin.kt
@@ -1,6 +1,10 @@
 package com.navideck.universal_ble
 
 import android.annotation.SuppressLint
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.content.ContextCompat
 import android.app.Activity
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
@@ -42,6 +46,7 @@ class UniversalBlePeripheralPlugin(
     private var advertisingState: PeripheralAdvertisingState = PeripheralAdvertisingState.IDLE
     private var originalAdapterName: String? = null
     private var adapterNameOverridden = false
+    private var isEnableBluetoothPromptPending = false
 
 
     fun attachActivity(activity: Activity?) {
@@ -59,6 +64,15 @@ class UniversalBlePeripheralPlugin(
         }
         synchronized(mtuByDeviceId) { mtuByDeviceId.clear() }
         clearPeripheralCaches()
+        isEnableBluetoothPromptPending = false
+    }
+
+    fun handleActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+        if (requestCode == 0xB1E) {
+            isEnableBluetoothPromptPending = false
+            return true
+        }
+        return false
     }
 
     /** Opens the LE advertiser and GATT server on first use (not in the constructor). */
@@ -81,10 +95,19 @@ class UniversalBlePeripheralPlugin(
 
     override fun getAdvertisingState(): PeripheralAdvertisingState = advertisingState
 
+    private fun hasBluetoothAdvertisePermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+        return ContextCompat.checkSelfPermission(
+            applicationContext,
+            Manifest.permission.BLUETOOTH_ADVERTISE,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
     override fun getReadinessState(): PeripheralReadinessState {
         val adapter = bluetoothManager.adapter ?: return PeripheralReadinessState.UNSUPPORTED
-        if (!adapter.isMultipleAdvertisementSupported) return PeripheralReadinessState.UNSUPPORTED
+        if (!hasBluetoothAdvertisePermission()) return PeripheralReadinessState.UNAUTHORIZED
         if (!adapter.isEnabled) return PeripheralReadinessState.BLUETOOTH_OFF
+        if (adapter.bluetoothLeAdvertiser == null) return PeripheralReadinessState.UNSUPPORTED
         return PeripheralReadinessState.READY
     }
 
@@ -119,12 +142,16 @@ class UniversalBlePeripheralPlugin(
                 PeripheralAdvertisingState.ERROR,
                 "Bluetooth is not enabled",
             ) {}
-            activity?.startActivityForResult(
-                Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE),
-                0xB1E,
-            )
+            if (!isEnableBluetoothPromptPending) {
+                isEnableBluetoothPromptPending = true
+                activity?.startActivityForResult(
+                    Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE),
+                    0xB1E,
+                )
+            }
             throw Exception("Bluetooth is not enabled")
         }
+        isEnableBluetoothPromptPending = false
         advertisingState = PeripheralAdvertisingState.STARTING
         callback.onAdvertisingStateChange(PeripheralAdvertisingState.STARTING, null) {}
 

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePeripheralPlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePeripheralPlugin.kt
@@ -28,6 +28,7 @@ import android.util.Log
 import io.flutter.plugin.common.BinaryMessenger
 
 private const val TAG = "UniversalBlePeripheral"
+private const val REQUEST_CODE_ENABLE_BLUETOOTH = 0xB1E
 
 @SuppressLint("MissingPermission")
 class UniversalBlePeripheralPlugin(
@@ -68,11 +69,25 @@ class UniversalBlePeripheralPlugin(
     }
 
     fun handleActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
-        if (requestCode == 0xB1E) {
+        if (requestCode == REQUEST_CODE_ENABLE_BLUETOOTH) {
             isEnableBluetoothPromptPending = false
             return true
         }
         return false
+    }
+
+    private fun promptEnableBluetooth(activity: Activity) {
+        if (isEnableBluetoothPromptPending) return
+        isEnableBluetoothPromptPending = true
+        try {
+            activity.startActivityForResult(
+                Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE),
+                REQUEST_CODE_ENABLE_BLUETOOTH,
+            )
+        } catch (e: Exception) {
+            isEnableBluetoothPromptPending = false
+            Log.e(TAG, "Failed to start Bluetooth enable activity", e)
+        }
     }
 
     /** Opens the LE advertiser and GATT server on first use (not in the constructor). */
@@ -141,19 +156,7 @@ class UniversalBlePeripheralPlugin(
                 PeripheralAdvertisingState.ERROR,
                 "Bluetooth is not enabled",
             ) {}
-            val currentActivity = activity
-            if (!isEnableBluetoothPromptPending && currentActivity != null) {
-                isEnableBluetoothPromptPending = true
-                try {
-                    currentActivity.startActivityForResult(
-                        Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE),
-                        0xB1E,
-                    )
-                } catch (e: Exception) {
-                    isEnableBluetoothPromptPending = false
-                    Log.e(TAG, "Failed to start Bluetooth enable activity", e)
-                }
-            }
+            activity?.let { promptEnableBluetooth(it) }
             throw Exception("Bluetooth is not enabled")
         }
         isEnableBluetoothPromptPending = false

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePeripheralPlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePeripheralPlugin.kt
@@ -28,7 +28,7 @@ import android.util.Log
 import io.flutter.plugin.common.BinaryMessenger
 
 private const val TAG = "UniversalBlePeripheral"
-private const val REQUEST_CODE_ENABLE_BLUETOOTH = 0xB1E
+private const val REQUEST_CODE_ENABLE_BLUETOOTH = 2342717
 
 @SuppressLint("MissingPermission")
 class UniversalBlePeripheralPlugin(
@@ -110,20 +110,33 @@ class UniversalBlePeripheralPlugin(
 
     override fun getAdvertisingState(): PeripheralAdvertisingState = advertisingState
 
-    private fun hasBluetoothAdvertisePermission(): Boolean {
+    private fun hasRequiredPermissions(): Boolean {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
-        return ContextCompat.checkSelfPermission(
+        val hasAdvertise = ContextCompat.checkSelfPermission(
             applicationContext,
             Manifest.permission.BLUETOOTH_ADVERTISE,
         ) == PackageManager.PERMISSION_GRANTED
+        val hasConnect = ContextCompat.checkSelfPermission(
+            applicationContext,
+            Manifest.permission.BLUETOOTH_CONNECT,
+        ) == PackageManager.PERMISSION_GRANTED
+        return hasAdvertise && hasConnect
     }
 
     override fun getReadinessState(): PeripheralReadinessState {
         val adapter = bluetoothManager.adapter ?: return PeripheralReadinessState.UNSUPPORTED
-        if (!hasBluetoothAdvertisePermission()) return PeripheralReadinessState.UNAUTHORIZED
-        if (!adapter.isEnabled) return PeripheralReadinessState.BLUETOOTH_OFF
-        if (adapter.bluetoothLeAdvertiser == null) return PeripheralReadinessState.UNSUPPORTED
-        return PeripheralReadinessState.READY
+        if (!hasRequiredPermissions()) return PeripheralReadinessState.UNAUTHORIZED
+        return try {
+            if (!adapter.isEnabled) {
+                PeripheralReadinessState.BLUETOOTH_OFF
+            } else if (adapter.bluetoothLeAdvertiser == null) {
+                PeripheralReadinessState.UNSUPPORTED
+            } else {
+                PeripheralReadinessState.READY
+            }
+        } catch (e: SecurityException) {
+            PeripheralReadinessState.UNAUTHORIZED
+        }
     }
 
     override fun addService(service: PeripheralService) {
@@ -150,7 +163,25 @@ class UniversalBlePeripheralPlugin(
         manufacturerData: UniversalManufacturerData?,
         platformConfig: PeripheralPlatformConfig?,
     ) {
-        if (!bluetoothManager.isBluetoothEnabled()) {
+        if (!hasRequiredPermissions()) {
+            advertisingState = PeripheralAdvertisingState.ERROR
+            callback.onAdvertisingStateChange(
+                PeripheralAdvertisingState.ERROR,
+                "Bluetooth permission not granted",
+            ) {}
+            throw SecurityException("Bluetooth permission not granted")
+        }
+        val isEnabled = try {
+            bluetoothManager.isBluetoothEnabled()
+        } catch (e: SecurityException) {
+            advertisingState = PeripheralAdvertisingState.ERROR
+            callback.onAdvertisingStateChange(
+                PeripheralAdvertisingState.ERROR,
+                "Bluetooth permission not granted",
+            ) {}
+            throw e
+        }
+        if (!isEnabled) {
             advertisingState = PeripheralAdvertisingState.ERROR
             callback.onAdvertisingStateChange(
                 PeripheralAdvertisingState.ERROR,

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePeripheralPlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePeripheralPlugin.kt
@@ -135,23 +135,29 @@ class UniversalBlePeripheralPlugin(
         manufacturerData: UniversalManufacturerData?,
         platformConfig: PeripheralPlatformConfig?,
     ) {
-        ensurePeripheralInitialized()
         if (!bluetoothManager.isBluetoothEnabled()) {
             advertisingState = PeripheralAdvertisingState.ERROR
             callback.onAdvertisingStateChange(
                 PeripheralAdvertisingState.ERROR,
                 "Bluetooth is not enabled",
             ) {}
-            if (!isEnableBluetoothPromptPending) {
+            val currentActivity = activity
+            if (!isEnableBluetoothPromptPending && currentActivity != null) {
                 isEnableBluetoothPromptPending = true
-                activity?.startActivityForResult(
-                    Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE),
-                    0xB1E,
-                )
+                try {
+                    currentActivity.startActivityForResult(
+                        Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE),
+                        0xB1E,
+                    )
+                } catch (e: Exception) {
+                    isEnableBluetoothPromptPending = false
+                    Log.e(TAG, "Failed to start Bluetooth enable activity", e)
+                }
             }
             throw Exception("Bluetooth is not enabled")
         }
         isEnableBluetoothPromptPending = false
+        ensurePeripheralInitialized()
         advertisingState = PeripheralAdvertisingState.STARTING
         callback.onAdvertisingStateChange(PeripheralAdvertisingState.STARTING, null) {}
 

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -1749,6 +1749,9 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+        if (peripheralPlugin.handleActivityResult(requestCode, resultCode, data)) {
+            return true
+        }
         if (requestCode == bluetoothEnableRequestCode) {
             val future = bluetoothEnableRequestFuture ?: return false
             future(Result.success(resultCode == Activity.RESULT_OK))


### PR DESCRIPTION
### Summary
1. **Readiness State Evaluation Order**:
   - `getReadinessState()` was checking `!adapter.isMultipleAdvertisementSupported` before `!adapter.isEnabled` and runtime permissions.
   - When Bluetooth is disabled or in transition, `isMultipleAdvertisementSupported` returns `false`, incorrectly reporting `UNSUPPORTED` instead of `BLUETOOTH_OFF`.
   - Updated to check runtime `BLUETOOTH_ADVERTISE` permissions first (`UNAUTHORIZED`), `!adapter.isEnabled` next (`BLUETOOTH_OFF`), and `adapter.bluetoothLeAdvertiser == null` (`UNSUPPORTED`), otherwise `READY`.

2. **Throttle Bluetooth Enable Dialogs**:
   - When `startAdvertising` is invoked with Bluetooth disabled, it launches `ACTION_REQUEST_ENABLE`. Without tracking in-flight requests or handling activity results, high-frequency advertisement loops (e.g. streaming timecode at 24–30 FPS) spawned dozens of stacked system dialogs.
   - Added an `isEnableBluetoothPromptPending` guard and handled `onActivityResult` for request code `0xB1E` to ensure at most one enable dialog is launched simultaneously.