### PR TITLE
Do not queue readRssi commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Android: add `closeGattOnDetach` connection option to release GATT clients when the app is killed
 * Android: close the GATT client once the disconnect completes instead of right after `disconnect()`, and report the real disconnect status
 * Android: Fix peripheral `getReadinessState()` to check permissions and adapter power before advertising support, and throttle `startAdvertising` Bluetooth enable prompts to at most one dialog.
+* Decouple `readRssi` from the default command queue to prevent telemetry polling from blocking queued GATT commands
 
 
 ## 2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Android: add `closeGattOnDetach` connection option to release GATT clients when the app is killed
 * Android: close the GATT client once the disconnect completes instead of right after `disconnect()`, and report the real disconnect status
 * Android: Fix peripheral `getReadinessState()` to check permissions and adapter power before advertising support, and throttle `startAdvertising` Bluetooth enable prompts to at most one dialog.
-* Decouple `readRssi` from the default command queue to prevent telemetry polling from blocking queued GATT commands
+* readRssi commands are not queued anymore
 
 
 ## 2.2.0

--- a/README.md
+++ b/README.md
@@ -621,6 +621,8 @@ UniversalBle.queueType = QueueType.none;
 
 Keep in mind that some platforms (e.g. Android) may not handle well devices that fail to process consecutive commands without a minimum interval. Therefore, it is not advised to set `queueType` to `none`.
 
+Link-layer telemetry (`readRssi`) bypasses the command queue by default so periodic polling does not block or stall queued GATT commands. If desired, it can still be queued by passing an explicit `queueId`.
+
 You can get queue updates by setting:
 
 ```dart

--- a/README.md
+++ b/README.md
@@ -621,8 +621,6 @@ UniversalBle.queueType = QueueType.none;
 
 Keep in mind that some platforms (e.g. Android) may not handle well devices that fail to process consecutive commands without a minimum interval. Therefore, it is not advised to set `queueType` to `none`.
 
-Link-layer telemetry (`readRssi`) bypasses the command queue by default so periodic polling does not block or stall queued GATT commands. If desired, it can still be queued by passing an explicit `queueId`.
-
 You can get queue updates by setting:
 
 ```dart

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -470,6 +470,10 @@ class UniversalBle {
   ///
   /// **Note**: The device must be connected before reading RSSI.
   ///
+  /// By default, RSSI reads bypass the GATT command serialization queue so that periodic
+  /// telemetry polling does not block or get blocked by queued GATT operations.
+  /// If serialization is desired, an explicit [queueId] can be provided.
+  ///
   /// Throws [UniversalBleException] if:
   /// - The device is not connected
   /// - Reading RSSI fails
@@ -478,12 +482,17 @@ class UniversalBle {
     Duration? timeout,
     String? queueId,
   }) async {
-    return await _bleCommandQueue.queueCommand(
-      () => _platform.readRssi(deviceId),
-      timeout: timeout,
-      deviceId: deviceId,
-      queueId: queueId,
-    );
+    if (queueId != null) {
+      return await _bleCommandQueue.queueCommand(
+        () => _platform.readRssi(deviceId),
+        timeout: timeout,
+        deviceId: deviceId,
+        queueId: queueId,
+      );
+    }
+    final future = _platform.readRssi(deviceId);
+    final timeoutDuration = timeout ?? _bleCommandQueue.timeout;
+    return timeoutDuration != null ? await future.timeout(timeoutDuration) : await future;
   }
 
   /// Check if a device is paired.

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -476,11 +476,11 @@ class UniversalBle {
   static Future<int> readRssi(
     String deviceId, {
     Duration? timeout,
-  }) {
-    final future = _platform.readRssi(deviceId);
-    final timeoutDuration = timeout ?? _bleCommandQueue.timeout;
-    return timeoutDuration != null ? future.timeout(timeoutDuration) : future;
-  }
+  }) =>
+      _runWithTimeout(
+        () => _platform.readRssi(deviceId),
+        timeout: timeout,
+      );
 
   /// Check if a device is paired.
   ///
@@ -964,5 +964,14 @@ class UniversalBle {
       return universalBleLinuxInstance;
     }
     return UniversalBlePigeonChannel.instance;
+  }
+
+  static Future<T> _runWithTimeout<T>(
+    Future<T> Function() action, {
+    Duration? timeout,
+  }) {
+    final future = action();
+    final timeoutDuration = timeout ?? _bleCommandQueue.timeout;
+    return timeoutDuration != null ? future.timeout(timeoutDuration) : future;
   }
 }

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -476,7 +476,6 @@ class UniversalBle {
   static Future<int> readRssi(
     String deviceId, {
     Duration? timeout,
-    String? queueId,
   }) {
     final future = _platform.readRssi(deviceId);
     final timeoutDuration = timeout ?? _bleCommandQueue.timeout;

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -470,10 +470,6 @@ class UniversalBle {
   ///
   /// **Note**: The device must be connected before reading RSSI.
   ///
-  /// By default, RSSI reads bypass the GATT command serialization queue so that periodic
-  /// telemetry polling does not block or get blocked by queued GATT operations.
-  /// If serialization is desired, an explicit [queueId] can be provided.
-  ///
   /// Throws [UniversalBleException] if:
   /// - The device is not connected
   /// - Reading RSSI fails

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -477,10 +477,10 @@ class UniversalBle {
     String deviceId, {
     Duration? timeout,
     String? queueId,
-  }) async {
+  }) {
     final future = _platform.readRssi(deviceId);
     final timeoutDuration = timeout ?? _bleCommandQueue.timeout;
-    return timeoutDuration != null ? await future.timeout(timeoutDuration) : await future;
+    return timeoutDuration != null ? future.timeout(timeoutDuration) : future;
   }
 
   /// Check if a device is paired.

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -58,7 +58,8 @@ class UniversalBle {
   static Stream<Uint8List> characteristicValueStream(
     String deviceId,
     String characteristicId,
-  ) => _platform.characteristicValueStream(deviceId, characteristicId);
+  ) =>
+      _platform.characteristicValueStream(deviceId, characteristicId);
 
   /// Pairing state stream
   static Stream<bool> pairingStateStream(String deviceId) =>
@@ -168,15 +169,15 @@ class UniversalBle {
 
     _platform
         .connect(
-          deviceId,
-          connectionTimeout: timeout,
-          autoConnect: autoConnect,
-          platformConfig: platformConfig,
-        )
+      deviceId,
+      connectionTimeout: timeout,
+      autoConnect: autoConnect,
+      platformConfig: platformConfig,
+    )
         .catchError((error) {
-          if (completer.isCompleted) return;
-          completer.completeError(ConnectionException(error));
-        });
+      if (completer.isCompleted) return;
+      completer.completeError(ConnectionException(error));
+    });
 
     if (!await completer.future.timeout(timeout)) {
       throw ConnectionException("Failed to connect");
@@ -206,15 +207,15 @@ class UniversalBle {
 
       await _bleCommandQueue
           .queueCommand(
-            () => _platform.disconnect(deviceId),
-            timeout: timeout,
-            deviceId: deviceId,
-            queueId: queueId,
-          )
+        () => _platform.disconnect(deviceId),
+        timeout: timeout,
+        deviceId: deviceId,
+        queueId: queueId,
+      )
           .catchError((error) {
-            if (completer.isCompleted) return;
-            completer.completeError(ConnectionException(error));
-          });
+        if (completer.isCompleted) return;
+        completer.completeError(ConnectionException(error));
+      });
 
       if (connectionState == BleConnectionState.disconnected ||
           connectionState == BleConnectionState.disconnecting) {
@@ -659,11 +660,9 @@ class UniversalBle {
   static set onAvailabilityChange(OnAvailabilityChange? onAvailabilityChange) {
     _platform.onAvailabilityChange = onAvailabilityChange;
     if (onAvailabilityChange != null) {
-      getBluetoothAvailabilityState()
-          .then((value) {
-            onAvailabilityChange(value);
-          })
-          .onError((error, stackTrace) => null);
+      getBluetoothAvailabilityState().then((value) {
+        onAvailabilityChange(value);
+      }).onError((error, stackTrace) => null);
     }
   }
 
@@ -734,32 +733,29 @@ class UniversalBle {
     }
 
     connectionSubscription = _platform
-        .bleConnectionUpdateStreamController
-        .stream
-        .where((e) => e.deviceId == deviceId || e.deviceId.toLowerCase() == target)
+        .bleConnectionUpdateStreamController.stream
+        .where(
+            (e) => e.deviceId == deviceId || e.deviceId.toLowerCase() == target)
         .listen(
-          (e) {
-            cancelSubscription();
-            if (e.error != null) {
-              handleError(e.error);
-            } else {
-              if (!completer.isCompleted) {
-                completer.complete(e.isConnected);
-              }
-            }
-          },
-          onError: handleError,
-          cancelOnError: true,
-        );
+      (e) {
+        cancelSubscription();
+        if (e.error != null) {
+          handleError(e.error);
+        } else {
+          if (!completer.isCompleted) {
+            completer.complete(e.isConnected);
+          }
+        }
+      },
+      onError: handleError,
+      cancelOnError: true,
+    );
 
-    completer.future
-        .timeout(timeout)
-        .then((_) {
-          cancelSubscription();
-        })
-        .catchError((_) {
-          cancelSubscription();
-        });
+    completer.future.timeout(timeout).then((_) {
+      cancelSubscription();
+    }).catchError((_) {
+      cancelSubscription();
+    });
 
     return completer;
   }
@@ -956,7 +952,8 @@ class UniversalBle {
   /// Connection parameter updates (Android API 26+).
   static set onConnectionParametersChange(
     OnConnectionParametersChange? onConnectionParametersChange,
-  ) => _platform.onConnectionParametersChange = onConnectionParametersChange;
+  ) =>
+      _platform.onConnectionParametersChange = onConnectionParametersChange;
 
   static UniversalBlePlatform _defaultPlatform() {
     if (kIsWeb) return UniversalBleWeb.instance;
@@ -970,8 +967,9 @@ class UniversalBle {
     Future<T> Function() action, {
     Duration? timeout,
   }) {
-    final future = action();
     final timeoutDuration = timeout ?? _bleCommandQueue.timeout;
-    return timeoutDuration != null ? future.timeout(timeoutDuration) : future;
+    return timeoutDuration != null
+        ? action().timeout(timeoutDuration)
+        : action();
   }
 }

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -478,14 +478,6 @@ class UniversalBle {
     Duration? timeout,
     String? queueId,
   }) async {
-    if (queueId != null) {
-      return await _bleCommandQueue.queueCommand(
-        () => _platform.readRssi(deviceId),
-        timeout: timeout,
-        deviceId: deviceId,
-        queueId: queueId,
-      );
-    }
     final future = _platform.readRssi(deviceId);
     final timeoutDuration = timeout ?? _bleCommandQueue.timeout;
     return timeoutDuration != null ? await future.timeout(timeoutDuration) : await future;

--- a/test/universal_ble_rssi_queue_test.dart
+++ b/test/universal_ble_rssi_queue_test.dart
@@ -43,7 +43,7 @@ void main() {
     expect(platform.reads, 1);
 
     // readRssi should execute immediately without waiting for readFuture
-    final rssiFuture = UniversalBle.readRssi('device', queueId: 'custom');
+    final rssiFuture = UniversalBle.readRssi('device');
     await pumpEventQueue();
     expect(platform.rssiReads, 1);
 

--- a/test/universal_ble_rssi_queue_test.dart
+++ b/test/universal_ble_rssi_queue_test.dart
@@ -35,25 +35,23 @@ void main() {
     expect(await rssiFuture, -65);
   });
 
-  test('readRssi respects explicit queueId', () async {
+  test('readRssi is not queued even when queue is blocked', () async {
     final platform = _PendingPlatform();
     UniversalBle.setInstance(platform);
 
-    final readFuture = UniversalBle.read('device', '180a', '202a', queueId: 'custom');
+    final readFuture = UniversalBle.read('device', '180a', '202a');
     expect(platform.reads, 1);
 
+    // readRssi should execute immediately without waiting for readFuture
     final rssiFuture = UniversalBle.readRssi('device', queueId: 'custom');
-    await pumpEventQueue();
-    // Because 'custom' queue is blocked by readFuture, readRssi should not have started
-    expect(platform.rssiReads, 0);
-
-    platform.readPending.complete(Uint8List(0));
-    await readFuture;
     await pumpEventQueue();
     expect(platform.rssiReads, 1);
 
     platform.rssiPending.complete(-70);
     expect(await rssiFuture, -70);
+
+    platform.readPending.complete(Uint8List(0));
+    await readFuture;
   });
 }
 

--- a/test/universal_ble_rssi_queue_test.dart
+++ b/test/universal_ble_rssi_queue_test.dart
@@ -1,0 +1,101 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:universal_ble/universal_ble.dart';
+
+import 'universal_ble_test_mock.dart';
+
+void main() {
+  setUp(() {
+    UniversalBle.clearQueue();
+    UniversalBle.queueType = QueueType.global;
+  });
+
+  tearDown(() {
+    UniversalBle.clearQueue();
+  });
+
+  test('readRssi bypasses queue by default and does not block queued writes', () async {
+    final platform = _PendingPlatform();
+    UniversalBle.setInstance(platform);
+
+    final rssiFuture = UniversalBle.readRssi('device');
+    expect(platform.rssiReads, 1);
+
+    // A write should start immediately even though readRssi is pending
+    final writeFuture = _write(1);
+    await pumpEventQueue();
+    expect(platform.started, [1]);
+
+    platform.pending.single.complete();
+    await writeFuture;
+
+    platform.rssiPending.complete(-65);
+    expect(await rssiFuture, -65);
+  });
+
+  test('readRssi respects explicit queueId', () async {
+    final platform = _PendingPlatform();
+    UniversalBle.setInstance(platform);
+
+    final readFuture = UniversalBle.read('device', '180a', '202a', queueId: 'custom');
+    expect(platform.reads, 1);
+
+    final rssiFuture = UniversalBle.readRssi('device', queueId: 'custom');
+    await pumpEventQueue();
+    // Because 'custom' queue is blocked by readFuture, readRssi should not have started
+    expect(platform.rssiReads, 0);
+
+    platform.readPending.complete(Uint8List(0));
+    await readFuture;
+    await pumpEventQueue();
+    expect(platform.rssiReads, 1);
+
+    platform.rssiPending.complete(-70);
+    expect(await rssiFuture, -70);
+  });
+}
+
+Future<void> _write(int value) =>
+    UniversalBle.write('device', '180a', '202a', Uint8List.fromList([value]));
+
+class _PendingPlatform extends UniversalBlePlatformMock {
+  final started = <int>[];
+  final pending = <Completer<void>>[];
+  final readPending = Completer<Uint8List>();
+  final rssiPending = Completer<int>();
+  var reads = 0;
+  var rssiReads = 0;
+
+  @override
+  Future<Uint8List> readValue(
+    String deviceId,
+    String service,
+    String characteristic, {
+    Duration? timeout,
+  }) {
+    reads++;
+    return readPending.future;
+  }
+
+  @override
+  Future<int> readRssi(String deviceId) {
+    rssiReads++;
+    return rssiPending.future;
+  }
+
+  @override
+  Future<void> writeValue(
+    String deviceId,
+    String service,
+    String characteristic,
+    Uint8List value,
+    BleOutputProperty bleOutputProperty,
+  ) {
+    started.add(value.single);
+    final completion = Completer<void>();
+    pending.add(completion);
+    return completion.future;
+  }
+}

--- a/test/universal_ble_test_mock.dart
+++ b/test/universal_ble_test_mock.dart
@@ -76,6 +76,11 @@ abstract class UniversalBlePlatformMock extends UniversalBlePlatform {
   }
 
   @override
+  Future<int> readRssi(String deviceId) {
+    throw UnimplementedError();
+  }
+
+  @override
   Future<void> requestConnectionPriority(
     String deviceId,
     BleConnectionPriority priority,


### PR DESCRIPTION
### Description

Bypasses `_bleCommandQueue` completely for `UniversalBle.readRssi()` so that periodic link-layer telemetry polling does not block or get blocked by queued GATT operations.

- `readRssi` is never queued into `_bleCommandQueue`.
- Removed `queueId` parameter from `readRssi` signature since commands are never queued.
- Preserves timeout behavior using the queue's configured default timeout or the optional explicit `timeout`.
- Adds unit tests verifying that `readRssi` executes immediately even while the command queue is blocked.
- Updates `CHANGELOG.md`.