### PR TITLE
Bump to 3.0.0 and make QueueType.none the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.0
+* **Breaking:** `queueType` now defaults to `QueueType.none` (commands run in parallel). Serialization is handled natively by each platform: Android serializes GATT operations per device (`PerDeviceGattQueue`), and Apple pipelines writes through CoreBluetooth. Set `UniversalBle.queueType = QueueType.global` (or `perDevice`) to restore the previous serialized behavior.
+
 ## 2.3.0
 * Windows: support connectionless manufacturer-data advertising without a GATT service, including state/error reporting and cleanup on stop/disposal.
 * Apple: Accurately report manufacturer-data advertising capabilities.

--- a/README.md
+++ b/README.md
@@ -613,9 +613,16 @@ int rssi = await bleDevice.readRssi();
 
 ## Command Queue
 
-By default, all commands are executed in a global queue (`QueueType.global`), with each command waiting for the previous one to finish. While this method is slower it is the safest to avoid command exceptions and therefore is the default.
+By default, all commands are executed in parallel (`QueueType.none`). Serialization is handled natively by each platform: Android serializes GATT operations per device (`PerDeviceGattQueue`), while Apple pipelines writes through CoreBluetooth. This gives maximum throughput with no configuration.
 
-If you want to parallelize commands between multiple devices, you can set:
+If you want to serialize commands between all devices, you can set:
+
+```dart
+// Execute all commands in a single queue, one after the other.
+UniversalBle.queueType = QueueType.global;
+```
+
+If you want to parallelize commands between multiple devices but serialize commands per device, you can set:
 
 ```dart
 // Create a separate queue for each device.
@@ -632,11 +639,11 @@ UniversalBle.write(deviceId, service, char, value2, queueId: '2');
 You can also completely disable the queue and batch all commands, even for the same device, by using:
 
 ```dart
-// Disable queue
+// Disable queue (this is the default)
 UniversalBle.queueType = QueueType.none;
 ```
 
-Keep in mind that some platforms (e.g. Android) may not handle well devices that fail to process consecutive commands without a minimum interval. Therefore, it is not advised to set `queueType` to `none`.
+Keep in mind that the Dart queue is an additional safety layer on top of native serialization. Most applications do not need it — each platform's native stack (Android `mDeviceBusy` handling, CoreBluetooth write pipelining) already prevents command collisions.
 
 You can get queue updates by setting:
 
@@ -668,7 +675,7 @@ UniversalBle.clearQueue();
 `UniversalBlePeripheral` supports the same queueing configuration (`queueType`, `timeout`, `clearQueue`, and `onQueueUpdate`) for peripheral commands (e.g. `addService`, `startAdvertising`, `updateCharacteristicValue`):
 
 ```dart
-// Configure peripheral command queue (defaults to QueueType.global)
+// Configure peripheral command queue (defaults to QueueType.none)
 UniversalBlePeripheral.queueType = QueueType.perDevice;
 
 // Clear peripheral queue

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -33,12 +33,14 @@ class UniversalBle {
     await _platform.setLogLevel(logLevel);
   }
 
-  /// Set how commands will be executed. By default, all commands are executed in a global queue (`QueueType.global`),
-  /// with each command waiting for the previous one to finish.
+  /// Set how commands will be executed. By default, all commands are executed
+  /// in parallel (`QueueType.none`) and rely on each platform's native
+  /// serialization (Android serializes GATT operations per device natively,
+  /// Apple pipelines writes through CoreBluetooth).
   ///
-  /// [QueueType.global] will execute commands of all devices in a single queue.
-  /// [QueueType.perDevice] will execute command of each device in separate queues.
   /// [QueueType.none] will execute all commands in parallel.
+  /// [QueueType.perDevice] will execute command of each device in separate queues.
+  /// [QueueType.global] will execute commands of all devices in a single queue.
   static set queueType(QueueType queueType) {
     _bleCommandQueue.queueType = queueType;
     UniversalLogger.logInfo('Queue ${queueType.name}');

--- a/lib/src/universal_ble_peripheral.dart
+++ b/lib/src/universal_ble_peripheral.dart
@@ -22,12 +22,13 @@ class UniversalBlePeripheral {
     _bleCommandQueue.timeout = duration;
   }
 
-  /// Set how peripheral commands will be executed. By default, all commands are executed in a global queue (`QueueType.global`),
-  /// with each command waiting for the previous one to finish.
+  /// Set how peripheral commands will be executed. By default, all commands are
+  /// executed in parallel (`QueueType.none`) and rely on each platform's
+  /// native serialization.
   ///
-  /// [QueueType.global] will execute commands in a single queue.
-  /// [QueueType.perDevice] will execute commands of each device in separate queues.
   /// [QueueType.none] will execute all commands in parallel.
+  /// [QueueType.perDevice] will execute commands of each device in separate queues.
+  /// [QueueType.global] will execute commands in a single queue.
   static set queueType(QueueType queueType) {
     _bleCommandQueue.queueType = queueType;
     UniversalLogger.logInfo('Peripheral Queue ${queueType.name}');

--- a/lib/src/utils/ble_command_queue.dart
+++ b/lib/src/utils/ble_command_queue.dart
@@ -9,7 +9,7 @@ class BleCommandQueue {
   final Map<String, Queue> _queueMap = {};
   static const String globalQueueId = 'global';
 
-  BleCommandQueue({this.queueType = QueueType.global});
+  BleCommandQueue({this.queueType = QueueType.none});
 
   Future<T> queueCommand<T>(
     Future<T> Function() command, {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: universal_ble
 description: A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE) plugin for Flutter
-version: 2.3.0
+version: 3.0.0
 homepage: https://navideck.com
 repository: https://github.com/Navideck/universal_ble
 issue_tracker: https://github.com/Navideck/universal_ble/issues

--- a/test/ble_command_queue_test.dart
+++ b/test/ble_command_queue_test.dart
@@ -6,8 +6,12 @@ import 'package:universal_ble/universal_ble.dart';
 
 void main() {
   group('BleCommandQueue', () {
+    test('default queue type is none', () {
+      expect(BleCommandQueue().queueType, QueueType.none);
+    });
+
     test('global queue executes commands sequentially', () async {
-      final commandQueue = BleCommandQueue();
+      final commandQueue = BleCommandQueue(queueType: QueueType.global);
       final order = <int>[];
 
       final firstStarted = Completer<void>();
@@ -36,7 +40,7 @@ void main() {
     });
 
     test('null queueId uses the global queue', () async {
-      final commandQueue = BleCommandQueue();
+      final commandQueue = BleCommandQueue(queueType: QueueType.global);
       final order = <int>[];
 
       final firstStarted = Completer<void>();
@@ -71,7 +75,7 @@ void main() {
     });
 
     test('custom queueId creates an independent queue in global mode', () async {
-      final commandQueue = BleCommandQueue();
+      final commandQueue = BleCommandQueue(queueType: QueueType.global);
       final order = <String>[];
 
       final releaseDefault = Completer<void>();
@@ -206,7 +210,7 @@ void main() {
     });
 
     test('queueCommandWithoutTimeout bypasses global timeout', () async {
-      final commandQueue = BleCommandQueue()
+      final commandQueue = BleCommandQueue(queueType: QueueType.global)
         ..timeout = const Duration(milliseconds: 10);
 
       await expectLater(
@@ -225,7 +229,7 @@ void main() {
     });
 
     test('onQueueUpdate reports remaining items per queue id', () async {
-      final commandQueue = BleCommandQueue();
+      final commandQueue = BleCommandQueue(queueType: QueueType.global);
       final updates = <String, List<int>>{};
 
       commandQueue.onQueueUpdate = (id, remaining) {
@@ -256,7 +260,7 @@ void main() {
     });
 
     test('clearQueue cancels pending commands for a specific queue id', () async {
-      final commandQueue = BleCommandQueue();
+      final commandQueue = BleCommandQueue(queueType: QueueType.global);
       final order = <String>[];
 
       final release = Completer<void>();
@@ -299,7 +303,7 @@ void main() {
     });
 
     test('clearQueue without id clears all queues', () async {
-      final commandQueue = BleCommandQueue();
+      final commandQueue = BleCommandQueue(queueType: QueueType.global);
       final releaseDefault = Completer<void>();
       final releaseCustom = Completer<void>();
       final defaultStarted = Completer<void>();
@@ -342,7 +346,7 @@ void main() {
     });
 
     test('new commands recreate a cleared queue id', () async {
-      final commandQueue = BleCommandQueue();
+      final commandQueue = BleCommandQueue(queueType: QueueType.global);
 
       commandQueue.clearQueue(BleCommandQueue.globalQueueId);
 


### PR DESCRIPTION
Part of #297. Depends on the native per-device Android queue (#302) — that PR makes `QueueType.none` safe on Android, which is what allows flipping the default here.

## Breaking change

`queueType` now defaults to `QueueType.none` (commands run in parallel) instead of `QueueType.global` (serialized).

Serialization is handled natively per platform:
- **Android**: GATT operations are serialized per device by `PerDeviceGattQueue` (#302), so parallel Dart calls can no longer collide on `mDeviceBusy`.
- **Apple**: CoreBluetooth pipelines writes natively, so Dart-level serialization was the cause of the throughput degradation in #271.

The Dart queue remains available as an opt-in safety layer: `UniversalBle.queueType = QueueType.global` (or `perDevice`) restores the previous serialized behavior.

## Changes

- `pubspec.yaml`: version `2.3.0` → `3.0.0`
- `BleCommandQueue` defaults to `QueueType.none`
- Updated docstrings in `universal_ble.dart` / `universal_ble_peripheral.dart`
- `CHANGELOG.md`: new `## 3.0.0` section marking the default change as breaking
- `README.md`: Command Queue + Peripheral Command Queue sections now document `none` as the default
- `test/ble_command_queue_test.dart`: tests that assumed the `global` default now construct it explicitly; added a `default queue type is none` assertion

## Testing

All 107 Dart tests pass (`flutter test`), `flutter analyze` clean.