### PR TITLE
Add QueueType.auto as default queueing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
+## 3.0.0
+* **Breaking:** Add `QueueType.defaultPlatform` which auto-selects the best queueing strategy per platform: Android uses a per-device queue, all other platforms run commands in parallel. It is now the default for both `UniversalBle` and `UniversalBlePeripheral`, replacing the previous `QueueType.global` default.
+
 ## 2.3.0
-* Add `QueueType.defaultPlatform` which auto-selects the best queueing strategy per platform: Android uses a per-device queue, all other platforms run commands in parallel. It is now the default for both `UniversalBle` and `UniversalBlePeripheral`.
 * Windows: support connectionless manufacturer-data advertising without a GATT service, including state/error reporting and cleanup on stop/disposal.
 * Apple: Accurately report manufacturer-data advertising capabilities.
 * Android: add `closeGattOnDetach` connection option to release GATT clients when the app is killed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 2.3.0
+* Add `QueueType.defaultPlatform` which auto-selects the best queueing strategy per platform: Android uses a per-device queue, all other platforms run commands in parallel. It is now the default for both `UniversalBle` and `UniversalBlePeripheral`.
 * Windows: support connectionless manufacturer-data advertising without a GATT service, including state/error reporting and cleanup on stop/disposal.
 * Apple: Accurately report manufacturer-data advertising capabilities.
 * Android: add `closeGattOnDetach` connection option to release GATT clients when the app is killed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 3.0.0
-* **Breaking:** Add `QueueType.defaultPlatform` which auto-selects the best queueing strategy per platform: Android uses a per-device queue, all other platforms run commands in parallel. It is now the default for both `UniversalBle` and `UniversalBlePeripheral`, replacing the previous `QueueType.global` default.
+* **Breaking:** Add `QueueType.auto` which auto-selects the best queueing strategy per platform: Android uses a per-device queue, all other platforms run commands in parallel. It is now the default for both `UniversalBle` and `UniversalBlePeripheral`, replacing the previous `QueueType.global` default.
 
 ## 2.3.0
 * Windows: support connectionless manufacturer-data advertising without a GATT service, including state/error reporting and cleanup on stop/disposal.

--- a/README.md
+++ b/README.md
@@ -613,13 +613,19 @@ int rssi = await bleDevice.readRssi();
 
 ## Command Queue
 
-By default, all commands are executed in a global queue (`QueueType.global`), with each command waiting for the previous one to finish. While this method is slower it is the safest to avoid command exceptions and therefore is the default.
+By default, commands use `QueueType.defaultPlatform`, which automatically picks the best strategy for the current platform with zero configuration. Android uses a per-device queue (its native BLE stack rejects overlapping operations), while all other platforms run commands in parallel (they pipeline natively).
 
-If you want to parallelize commands between multiple devices, you can set:
+If you want explicit control over how commands are serialized, you can set `queueType`:
 
 ```dart
+// Run all commands in a single global queue (safest, but slower).
+UniversalBle.queueType = QueueType.global;
+
 // Create a separate queue for each device.
 UniversalBle.queueType = QueueType.perDevice;
+
+// Auto-decide per platform (default): Android queues per device, all others run in parallel.
+UniversalBle.queueType = QueueType.defaultPlatform;
 ```
 
 You can have separate queues by passing an optional `queueId`. Commands with the same `queueId` are serialized together, but run in parallel with both `QueueType.perDevice` and `QueueType.global`:
@@ -668,7 +674,7 @@ UniversalBle.clearQueue();
 `UniversalBlePeripheral` supports the same queueing configuration (`queueType`, `timeout`, `clearQueue`, and `onQueueUpdate`) for peripheral commands (e.g. `addService`, `startAdvertising`, `updateCharacteristicValue`):
 
 ```dart
-// Configure peripheral command queue (defaults to QueueType.global)
+// Configure peripheral command queue (defaults to QueueType.defaultPlatform)
 UniversalBlePeripheral.queueType = QueueType.perDevice;
 
 // Clear peripheral queue

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ int rssi = await bleDevice.readRssi();
 
 ## Command Queue
 
-By default, commands use `QueueType.defaultPlatform`, which automatically picks the best strategy for the current platform with zero configuration. Android uses a per-device queue (its native BLE stack rejects overlapping operations), while all other platforms run commands in parallel (they pipeline natively).
+By default, commands use `QueueType.auto`, which automatically picks the best strategy for the current platform with zero configuration. Android uses a per-device queue (its native BLE stack rejects overlapping operations), while all other platforms run commands in parallel (they pipeline natively).
 
 If you want explicit control over how commands are serialized, you can set `queueType`:
 
@@ -625,7 +625,7 @@ UniversalBle.queueType = QueueType.global;
 UniversalBle.queueType = QueueType.perDevice;
 
 // Auto-decide per platform (default): Android queues per device, all others run in parallel.
-UniversalBle.queueType = QueueType.defaultPlatform;
+UniversalBle.queueType = QueueType.auto;
 ```
 
 You can have separate queues by passing an optional `queueId`. Commands with the same `queueId` are serialized together, but run in parallel with both `QueueType.perDevice` and `QueueType.global`:
@@ -674,7 +674,7 @@ UniversalBle.clearQueue();
 `UniversalBlePeripheral` supports the same queueing configuration (`queueType`, `timeout`, `clearQueue`, and `onQueueUpdate`) for peripheral commands (e.g. `addService`, `startAdvertising`, `updateCharacteristicValue`):
 
 ```dart
-// Configure peripheral command queue (defaults to QueueType.defaultPlatform)
+// Configure peripheral command queue (defaults to QueueType.auto)
 UniversalBlePeripheral.queueType = QueueType.perDevice;
 
 // Clear peripheral queue

--- a/example/lib/home/home.dart
+++ b/example/lib/home/home.dart
@@ -24,7 +24,7 @@ class _CentralHomeState extends State<CentralHome> {
   final _bleDevices = <BleDevice>[];
   final _hiddenDevices = <BleDevice>[];
   bool _isScanning = false;
-  QueueType _queueType = QueueType.defaultPlatform;
+  QueueType _queueType = QueueType.auto;
   TextEditingController servicesFilterController = TextEditingController();
   TextEditingController namePrefixController = TextEditingController();
   TextEditingController manufacturerDataController = TextEditingController();
@@ -294,8 +294,8 @@ class _CentralHomeState extends State<CentralHome> {
                       _queueType = switch (_queueType) {
                         QueueType.global => QueueType.perDevice,
                         QueueType.perDevice => QueueType.none,
-                        QueueType.none => QueueType.defaultPlatform,
-                        QueueType.defaultPlatform => QueueType.global,
+                        QueueType.none => QueueType.auto,
+                        QueueType.auto => QueueType.global,
                       };
                       UniversalBle.queueType = _queueType;
                     });

--- a/example/lib/home/home.dart
+++ b/example/lib/home/home.dart
@@ -24,7 +24,7 @@ class _CentralHomeState extends State<CentralHome> {
   final _bleDevices = <BleDevice>[];
   final _hiddenDevices = <BleDevice>[];
   bool _isScanning = false;
-  QueueType _queueType = QueueType.global;
+  QueueType _queueType = QueueType.defaultPlatform;
   TextEditingController servicesFilterController = TextEditingController();
   TextEditingController namePrefixController = TextEditingController();
   TextEditingController manufacturerDataController = TextEditingController();
@@ -294,7 +294,8 @@ class _CentralHomeState extends State<CentralHome> {
                       _queueType = switch (_queueType) {
                         QueueType.global => QueueType.perDevice,
                         QueueType.perDevice => QueueType.none,
-                        QueueType.none => QueueType.global,
+                        QueueType.none => QueueType.defaultPlatform,
+                        QueueType.defaultPlatform => QueueType.global,
                       };
                       UniversalBle.queueType = _queueType;
                     });

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -333,7 +333,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.3.0"
+    version: "3.0.0"
   vector_math:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -333,7 +333,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.2.0"
+    version: "2.3.0"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/models/queue_type.dart
+++ b/lib/src/models/queue_type.dart
@@ -1,1 +1,1 @@
-enum QueueType { none, perDevice, global }
+enum QueueType { none, perDevice, global, defaultPlatform }

--- a/lib/src/models/queue_type.dart
+++ b/lib/src/models/queue_type.dart
@@ -1,1 +1,1 @@
-enum QueueType { none, perDevice, global, defaultPlatform }
+enum QueueType { none, perDevice, global, auto }

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -33,8 +33,10 @@ class UniversalBle {
     await _platform.setLogLevel(logLevel);
   }
 
-  /// Set how commands will be executed. By default, all commands are executed in a global queue (`QueueType.global`),
-  /// with each command waiting for the previous one to finish.
+  /// Set how commands will be executed. By default, [QueueType.defaultPlatform] is used,
+  /// which automatically picks the best strategy for the current platform: Android uses a
+  /// per-device queue (its native stack rejects overlapping operations), while all other
+  /// platforms run commands in parallel (they pipeline natively).
   ///
   /// [QueueType.global] will execute commands of all devices in a single queue.
   /// [QueueType.perDevice] will execute command of each device in separate queues.

--- a/lib/src/universal_ble.dart
+++ b/lib/src/universal_ble.dart
@@ -33,7 +33,7 @@ class UniversalBle {
     await _platform.setLogLevel(logLevel);
   }
 
-  /// Set how commands will be executed. By default, [QueueType.defaultPlatform] is used,
+  /// Set how commands will be executed. By default, [QueueType.auto] is used,
   /// which automatically picks the best strategy for the current platform: Android uses a
   /// per-device queue (its native stack rejects overlapping operations), while all other
   /// platforms run commands in parallel (they pipeline natively).

--- a/lib/src/universal_ble_peripheral.dart
+++ b/lib/src/universal_ble_peripheral.dart
@@ -22,8 +22,10 @@ class UniversalBlePeripheral {
     _bleCommandQueue.timeout = duration;
   }
 
-  /// Set how peripheral commands will be executed. By default, all commands are executed in a global queue (`QueueType.global`),
-  /// with each command waiting for the previous one to finish.
+  /// Set how peripheral commands will be executed. By default, [QueueType.defaultPlatform] is used,
+  /// which automatically picks the best strategy for the current platform: Android uses a
+  /// per-device queue (its native stack rejects overlapping operations), while all other
+  /// platforms run commands in parallel (they pipeline natively).
   ///
   /// [QueueType.global] will execute commands in a single queue.
   /// [QueueType.perDevice] will execute commands of each device in separate queues.

--- a/lib/src/universal_ble_peripheral.dart
+++ b/lib/src/universal_ble_peripheral.dart
@@ -22,7 +22,7 @@ class UniversalBlePeripheral {
     _bleCommandQueue.timeout = duration;
   }
 
-  /// Set how peripheral commands will be executed. By default, [QueueType.defaultPlatform] is used,
+  /// Set how peripheral commands will be executed. By default, [QueueType.auto] is used,
   /// which automatically picks the best strategy for the current platform: Android uses a
   /// per-device queue (its native stack rejects overlapping operations), while all other
   /// platforms run commands in parallel (they pipeline natively).
@@ -48,16 +48,16 @@ class UniversalBlePeripheral {
 
   /// Advertising state update stream.
   static Stream<BlePeripheralAdvertisingStateChanged>
-  get advertisingStateStream => _platform.advertisingStateStream;
+      get advertisingStateStream => _platform.advertisingStateStream;
 
   /// Characteristic subscription update stream.
   static Stream<BlePeripheralCharacteristicSubscriptionChanged>
-  get characteristicSubscriptionStream =>
-      _platform.characteristicSubscriptionStream;
+      get characteristicSubscriptionStream =>
+          _platform.characteristicSubscriptionStream;
 
   /// Connection state update stream.
   static Stream<BlePeripheralConnectionStateChanged>
-  get connectionStateStream => _platform.connectionStateStream;
+      get connectionStateStream => _platform.connectionStateStream;
 
   /// Service addition update stream.
   static Stream<BlePeripheralServiceAdded> get serviceAddedStream =>
@@ -75,11 +75,13 @@ class UniversalBlePeripheral {
 
   static void setDescriptorReadRequestHandlers(
     OnPeripheralDescriptorReadRequest? handlers,
-  ) => _platform.setDescriptorReadRequestHandler(handlers);
+  ) =>
+      _platform.setDescriptorReadRequestHandler(handlers);
 
   static void setDescriptorWriteRequestHandlers(
     OnPeripheralDescriptorWriteRequest? handlers,
-  ) => _platform.setDescriptorWriteRequestHandler(handlers);
+  ) =>
+      _platform.setDescriptorWriteRequestHandler(handlers);
 
   static Future<PeripheralReadinessState> getAvailabilityState() =>
       _platform.getAvailabilityState();
@@ -93,10 +95,12 @@ class UniversalBlePeripheral {
   static Future<void> addService(
     BlePeripheralService service, {
     Duration? timeout,
-  }) => _bleCommandQueue.queueCommand(
-    () => _platform.addService(service.toPeripheralService(), timeout: timeout),
-    timeout: timeout,
-  );
+  }) =>
+      _bleCommandQueue.queueCommand(
+        () => _platform.addService(service.toPeripheralService(),
+            timeout: timeout),
+        timeout: timeout,
+      );
 
   static Future<void> removeService(String serviceId) =>
       _bleCommandQueue.queueCommand(
@@ -104,12 +108,12 @@ class UniversalBlePeripheral {
       );
 
   static Future<void> clearServices() => _bleCommandQueue.queueCommand(
-    () => _platform.clearServices(),
-  );
+        () => _platform.clearServices(),
+      );
 
   static Future<List<String>> getServices() => _bleCommandQueue.queueCommand(
-    () => _platform.getServices(),
-  );
+        () => _platform.getServices(),
+      );
 
   static Future<void> startAdvertising({
     required List<String> services,
@@ -117,35 +121,37 @@ class UniversalBlePeripheral {
     Duration? timeout,
     ManufacturerData? manufacturerData,
     PeripheralPlatformConfig? platformConfig,
-  }) => _bleCommandQueue.queueCommand(
-    () => _platform.startAdvertising(
-      services: services.map(BleUuidParser.string).toList(),
-      localName: localName,
-      timeout: timeout,
-      manufacturerData: manufacturerData,
-      platformConfig: platformConfig,
-    ),
-    timeout: timeout,
-  );
+  }) =>
+      _bleCommandQueue.queueCommand(
+        () => _platform.startAdvertising(
+          services: services.map(BleUuidParser.string).toList(),
+          localName: localName,
+          timeout: timeout,
+          manufacturerData: manufacturerData,
+          platformConfig: platformConfig,
+        ),
+        timeout: timeout,
+      );
 
   static Future<void> stopAdvertising() => _bleCommandQueue.queueCommand(
-    () => _platform.stopAdvertising(),
-  );
+        () => _platform.stopAdvertising(),
+      );
 
   static Future<void> updateCharacteristicValue({
     required String characteristicId,
     required Uint8List value,
     String? deviceId,
     String? queueId,
-  }) => _bleCommandQueue.queueCommand(
-    () => _platform.updateCharacteristicValue(
-      characteristicId: BleUuidParser.string(characteristicId),
-      value: value,
-      deviceId: deviceId,
-    ),
-    deviceId: deviceId,
-    queueId: queueId,
-  );
+  }) =>
+      _bleCommandQueue.queueCommand(
+        () => _platform.updateCharacteristicValue(
+          characteristicId: BleUuidParser.string(characteristicId),
+          value: value,
+          deviceId: deviceId,
+        ),
+        deviceId: deviceId,
+        queueId: queueId,
+      );
 
   /// Returns client device ids currently subscribed to [characteristicId]
   /// (e.g. HID report characteristic). Used to restore in-app state after restart.

--- a/lib/src/utils/ble_command_queue.dart
+++ b/lib/src/utils/ble_command_queue.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:universal_ble/src/queue.dart';
 import 'package:universal_ble/universal_ble.dart';
 
@@ -9,7 +10,19 @@ class BleCommandQueue {
   final Map<String, Queue> _queueMap = {};
   static const String globalQueueId = 'global';
 
-  BleCommandQueue({this.queueType = QueueType.global});
+  BleCommandQueue({this.queueType = QueueType.defaultPlatform});
+
+  /// Resolve [QueueType.defaultPlatform] to a concrete queue type based on the
+  /// current platform. Android is the only platform whose native BLE stack
+  /// requires serialization (its `mDeviceBusy` GATT state machine rejects
+  /// overlapping operations), so it gets a per-device queue. All other
+  /// platforms pipeline natively and run commands in parallel.
+  QueueType get _resolvedQueueType =>
+      queueType == QueueType.defaultPlatform
+          ? (!kIsWeb && defaultTargetPlatform == TargetPlatform.android
+                ? QueueType.perDevice
+                : QueueType.none)
+          : queueType;
 
   Future<T> queueCommand<T>(
     Future<T> Function() command, {
@@ -25,12 +38,13 @@ class BleCommandQueue {
         queueId: queueId,
       );
     }
-    return switch (queueType) {
+    return switch (_resolvedQueueType) {
       QueueType.global => _queue(queueId).add(command, timeoutDuration),
       QueueType.perDevice => _queue(
         queueId ?? deviceId,
       ).add(command, timeoutDuration),
-      QueueType.none => command().timeout(timeoutDuration),
+      QueueType.none || QueueType.defaultPlatform =>
+        command().timeout(timeoutDuration),
     };
   }
 
@@ -39,10 +53,10 @@ class BleCommandQueue {
     String? deviceId,
     String? queueId,
   }) {
-    return switch (queueType) {
+    return switch (_resolvedQueueType) {
       QueueType.global => _queue(queueId).add(command),
       QueueType.perDevice => _queue(queueId ?? deviceId).add(command),
-      QueueType.none => command(),
+      QueueType.none || QueueType.defaultPlatform => command(),
     };
   }
 

--- a/lib/src/utils/ble_command_queue.dart
+++ b/lib/src/utils/ble_command_queue.dart
@@ -10,19 +10,18 @@ class BleCommandQueue {
   final Map<String, Queue> _queueMap = {};
   static const String globalQueueId = 'global';
 
-  BleCommandQueue({this.queueType = QueueType.defaultPlatform});
+  BleCommandQueue({this.queueType = QueueType.auto});
 
-  /// Resolve [QueueType.defaultPlatform] to a concrete queue type based on the
+  /// Resolve [QueueType.auto] to a concrete queue type based on the
   /// current platform. Android is the only platform whose native BLE stack
   /// requires serialization (its `mDeviceBusy` GATT state machine rejects
   /// overlapping operations), so it gets a per-device queue. All other
   /// platforms pipeline natively and run commands in parallel.
-  QueueType get _resolvedQueueType =>
-      queueType == QueueType.defaultPlatform
-          ? (!kIsWeb && defaultTargetPlatform == TargetPlatform.android
-                ? QueueType.perDevice
-                : QueueType.none)
-          : queueType;
+  QueueType get _resolvedQueueType => queueType == QueueType.auto
+      ? (!kIsWeb && defaultTargetPlatform == TargetPlatform.android
+          ? QueueType.perDevice
+          : QueueType.none)
+      : queueType;
 
   Future<T> queueCommand<T>(
     Future<T> Function() command, {
@@ -41,10 +40,9 @@ class BleCommandQueue {
     return switch (_resolvedQueueType) {
       QueueType.global => _queue(queueId).add(command, timeoutDuration),
       QueueType.perDevice => _queue(
-        queueId ?? deviceId,
-      ).add(command, timeoutDuration),
-      QueueType.none || QueueType.defaultPlatform =>
-        command().timeout(timeoutDuration),
+          queueId ?? deviceId,
+        ).add(command, timeoutDuration),
+      QueueType.none || QueueType.auto => command().timeout(timeoutDuration),
     };
   }
 
@@ -56,7 +54,7 @@ class BleCommandQueue {
     return switch (_resolvedQueueType) {
       QueueType.global => _queue(queueId).add(command),
       QueueType.perDevice => _queue(queueId ?? deviceId).add(command),
-      QueueType.none || QueueType.defaultPlatform => command(),
+      QueueType.none || QueueType.auto => command(),
     };
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: universal_ble
 description: A cross-platform (Android/iOS/macOS/Windows/Linux/Web) Bluetooth Low Energy (BLE) plugin for Flutter
-version: 2.3.0
+version: 3.0.0
 homepage: https://navideck.com
 repository: https://github.com/Navideck/universal_ble
 issue_tracker: https://github.com/Navideck/universal_ble/issues

--- a/test/ble_command_queue_test.dart
+++ b/test/ble_command_queue_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:universal_ble/src/utils/ble_command_queue.dart';
 import 'package:universal_ble/universal_ble.dart';
@@ -7,7 +8,7 @@ import 'package:universal_ble/universal_ble.dart';
 void main() {
   group('BleCommandQueue', () {
     test('global queue executes commands sequentially', () async {
-      final commandQueue = BleCommandQueue();
+      final commandQueue = BleCommandQueue(queueType: QueueType.global);
       final order = <int>[];
 
       final firstStarted = Completer<void>();
@@ -36,7 +37,7 @@ void main() {
     });
 
     test('null queueId uses the global queue', () async {
-      final commandQueue = BleCommandQueue();
+      final commandQueue = BleCommandQueue(queueType: QueueType.global);
       final order = <int>[];
 
       final firstStarted = Completer<void>();
@@ -71,7 +72,7 @@ void main() {
     });
 
     test('custom queueId creates an independent queue in global mode', () async {
-      final commandQueue = BleCommandQueue();
+      final commandQueue = BleCommandQueue(queueType: QueueType.global);
       final order = <String>[];
 
       final releaseDefault = Completer<void>();
@@ -206,7 +207,7 @@ void main() {
     });
 
     test('queueCommandWithoutTimeout bypasses global timeout', () async {
-      final commandQueue = BleCommandQueue()
+      final commandQueue = BleCommandQueue(queueType: QueueType.global)
         ..timeout = const Duration(milliseconds: 10);
 
       await expectLater(
@@ -225,7 +226,7 @@ void main() {
     });
 
     test('onQueueUpdate reports remaining items per queue id', () async {
-      final commandQueue = BleCommandQueue();
+      final commandQueue = BleCommandQueue(queueType: QueueType.global);
       final updates = <String, List<int>>{};
 
       commandQueue.onQueueUpdate = (id, remaining) {
@@ -256,7 +257,7 @@ void main() {
     });
 
     test('clearQueue cancels pending commands for a specific queue id', () async {
-      final commandQueue = BleCommandQueue();
+      final commandQueue = BleCommandQueue(queueType: QueueType.global);
       final order = <String>[];
 
       final release = Completer<void>();
@@ -299,7 +300,7 @@ void main() {
     });
 
     test('clearQueue without id clears all queues', () async {
-      final commandQueue = BleCommandQueue();
+      final commandQueue = BleCommandQueue(queueType: QueueType.global);
       final releaseDefault = Completer<void>();
       final releaseCustom = Completer<void>();
       final defaultStarted = Completer<void>();
@@ -342,11 +343,90 @@ void main() {
     });
 
     test('new commands recreate a cleared queue id', () async {
-      final commandQueue = BleCommandQueue();
+      final commandQueue = BleCommandQueue(queueType: QueueType.global);
 
       commandQueue.clearQueue(BleCommandQueue.globalQueueId);
 
       expect(await commandQueue.queueCommand(() async => 7), 7);
+    });
+
+    test(
+      'defaultPlatform queues per device on Android',
+      () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+        final commandQueue = BleCommandQueue(queueType: QueueType.defaultPlatform);
+        final order = <String>[];
+
+        final releaseA = Completer<void>();
+        final releaseB = Completer<void>();
+        final deviceBStarted = Completer<void>();
+
+        commandQueue.queueCommand(
+          () async {
+            await releaseA.future;
+            order.add('device-a');
+          },
+          deviceId: 'device-a',
+        );
+        commandQueue.queueCommand(
+          () async {
+            deviceBStarted.complete();
+            await releaseB.future;
+            order.add('device-b');
+          },
+          deviceId: 'device-b',
+        );
+
+        await deviceBStarted.future;
+        expect(order, isEmpty);
+
+        releaseB.complete();
+        await pumpEventQueue();
+        expect(order, ['device-b']);
+
+        releaseA.complete();
+        await pumpEventQueue();
+        expect(order, ['device-b', 'device-a']);
+      },
+    );
+
+    test('defaultPlatform runs commands in parallel on non-Android', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+
+      final commandQueue = BleCommandQueue(queueType: QueueType.defaultPlatform);
+      final order = <String>[];
+
+      final releaseA = Completer<void>();
+      final releaseB = Completer<void>();
+
+      commandQueue.queueCommand(
+        () async {
+          await releaseA.future;
+          order.add('device-a');
+        },
+        deviceId: 'device-a',
+      );
+      commandQueue.queueCommand(
+        () async {
+          await releaseB.future;
+          order.add('device-b');
+        },
+        deviceId: 'device-b',
+      );
+
+      await pumpEventQueue();
+      expect(order, isEmpty);
+
+      releaseB.complete();
+      await pumpEventQueue();
+      expect(order, ['device-b']);
+
+      releaseA.complete();
+      await pumpEventQueue();
+      expect(order, ['device-b', 'device-a']);
     });
   });
 }

--- a/test/ble_command_queue_test.dart
+++ b/test/ble_command_queue_test.dart
@@ -71,7 +71,8 @@ void main() {
       expect(order, [1, 2]);
     });
 
-    test('custom queueId creates an independent queue in global mode', () async {
+    test('custom queueId creates an independent queue in global mode',
+        () async {
       final commandQueue = BleCommandQueue(queueType: QueueType.global);
       final order = <String>[];
 
@@ -256,7 +257,8 @@ void main() {
       expect(updates['tilta']!.last, 0);
     });
 
-    test('clearQueue cancels pending commands for a specific queue id', () async {
+    test('clearQueue cancels pending commands for a specific queue id',
+        () async {
       final commandQueue = BleCommandQueue(queueType: QueueType.global);
       final order = <String>[];
 
@@ -351,12 +353,12 @@ void main() {
     });
 
     test(
-      'defaultPlatform queues per device on Android',
+      'auto queues per device on Android',
       () async {
         debugDefaultTargetPlatformOverride = TargetPlatform.android;
         addTearDown(() => debugDefaultTargetPlatformOverride = null);
 
-        final commandQueue = BleCommandQueue(queueType: QueueType.defaultPlatform);
+        final commandQueue = BleCommandQueue(queueType: QueueType.auto);
         final order = <String>[];
 
         final releaseA = Completer<void>();
@@ -392,11 +394,11 @@ void main() {
       },
     );
 
-    test('defaultPlatform runs commands in parallel on non-Android', () async {
+    test('auto runs commands in parallel on non-Android', () async {
       debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
       addTearDown(() => debugDefaultTargetPlatformOverride = null);
 
-      final commandQueue = BleCommandQueue(queueType: QueueType.defaultPlatform);
+      final commandQueue = BleCommandQueue(queueType: QueueType.auto);
       final order = <String>[];
 
       final releaseA = Completer<void>();


### PR DESCRIPTION
Fixes #297

## Description

Adds a new `QueueType.auto` value that automatically selects the best queueing strategy per platform, without changing any native layer.

- **Android** → resolves to a per-device queue (its native BLE stack enforces a single-operation state machine via `mDeviceBusy`, so serialization is required).
- **All other platforms** (Apple, Linux, Windows, Web) → resolves to no queueing (`none`), since they pipeline natively. This eliminates the Dart-level head-of-line blocking that caused the write throughput degradation on Apple (see #271).

`auto` is now the default for both `UniversalBle.queueType` and `UniversalBlePeripheral.queueType`, achieving the issue's "zero-configuration concurrency" goal.

## Changes

- `lib/src/models/queue_type.dart`: added `auto` enum value
- `lib/src/utils/ble_command_queue.dart`: `_resolvedQueueType` getter maps `auto` → `perDevice` on Android, `none` elsewhere; new default
- `lib/src/universal_ble.dart` / `lib/src/universal_ble_peripheral.dart`: updated doc comments
- `example/lib/home/home.dart`: default to `auto`; toggle cycles all four values
- `README.md` / `CHANGELOG.md`: documented the new default and behavior
- `test/ble_command_queue_test.dart`: existing default-global tests made explicit; added tests verifying Android queues per-device vs non-Android parallel (via `debugDefaultTargetPlatformOverride`)

## Verification

- `flutter analyze` — clean (package and example)
- `flutter test` — all 108 tests pass