### PR TITLE
Android: fix lost MTU completions and reconnect isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 3.0.0
+* Android: Register MTU waiters before the native request, serialize completions onto the main looper, and fail rejected requests immediately.
+* Android: Reuse an MTU already negotiated on the current GATT connection; isolate reconnects from late callbacks.
 * **Breaking:** Add `QueueType.auto` which auto-selects the best queueing strategy per platform: Android uses a per-device queue, all other platforms run commands in parallel. It is now the default for both `UniversalBle` and `UniversalBlePeripheral`, replacing the previous `QueueType.global` default.
 * iOS/macOS: Handle write-without-response transmit buffer backpressure
 * iOS/macOS: complete concurrent reads, descriptor operations, notification changes, and RSSI reads one callback at a time.

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBleHelper.kt
@@ -444,6 +444,7 @@ class DiscoverServicesFuture(
 
 class MtuResultFuture(
     val deviceId: String,
+    val gatt: BluetoothGatt,
     val result: (Result<Long>) -> Unit,
 )
 
@@ -488,3 +489,8 @@ class WriteDescriptorResultFuture(
     val serviceId: String,
     val result: (Result<Unit>) -> Unit,
 )
+
+// Android 14+ negotiates once per connection. Older releases can request an
+// increase, but an MTU already meeting the requested size needs no new exchange.
+internal fun canReuseNegotiatedMtu(mtu: Int, requested: Int, sdkInt: Int): Boolean =
+    sdkInt >= 34 || mtu >= requested

--- a/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
+++ b/android/src/main/kotlin/com/navideck/universal_ble/UniversalBlePlugin.kt
@@ -29,6 +29,7 @@ import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.PluginRegistry
 import java.util.Collections
 import java.util.UUID
+import java.util.WeakHashMap
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -65,6 +66,9 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
     private var bluetoothDisableRequestFuture: ((Result<Boolean>) -> Unit)? = null
     private val discoverServicesFutureList = mutableListOf<DiscoverServicesFuture>()
     private val mtuResultFutureList = mutableListOf<MtuResultFuture>()
+    // Protected by mtuResultFutureList's lock. An observed MTU belongs to this
+    // GATT client, never to a later connection using the same device address.
+    private val negotiatedMtus = WeakHashMap<BluetoothGatt, Int>()
     private val readResultFutureList = mutableListOf<ReadResultFuture>()
     private val writeResultFutureList = mutableListOf<WriteResultFuture>()
     private val readDescriptorResultFutureList = mutableListOf<ReadDescriptorResultFuture>()
@@ -1050,13 +1054,64 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
 
     override fun requestMtu(deviceId: String, expectedMtu: Long, callback: (Result<Long>) -> Unit) {
         UniversalBleLogger.logDebug("REQUEST_MTU -> $deviceId expected=$expectedMtu")
-        try {
-            val gatt = deviceId.toBluetoothGatt()
-            gatt.requestMtu(expectedMtu.toInt())
-            mtuResultFutureList.add(MtuResultFuture(deviceId, callback))
+        val gatt = try {
+            deviceId.toBluetoothGatt()
         } catch (e: FlutterError) {
-            callback(Result.failure(e))
+            postMtuResult(callback, Result.failure(e))
+            return
         }
+        synchronized(mtuResultFutureList) {
+            negotiatedMtus[gatt]?.let { mtu ->
+                // Android 14+ ignores subsequent negotiations. Earlier versions
+                // can still request an increase when the observed MTU is smaller.
+                if (canReuseNegotiatedMtu(mtu, expectedMtu.toInt(), Build.VERSION.SDK_INT)) {
+                    postMtuResult(callback, Result.success(mtu.toLong()))
+                    return
+                }
+            }
+            val alreadyPending = mtuResultFutureList.any { it.gatt === gatt }
+            // Register before requestMtu: its callback can arrive immediately.
+            mtuResultFutureList.add(MtuResultFuture(deviceId, gatt, callback))
+            if (alreadyPending) return
+        }
+        try {
+            if (!gatt.requestMtu(expectedMtu.toInt())) {
+                completeMtu(gatt, Result.failure(createFlutterError(
+                    UniversalBleErrorCode.FAILED,
+                    "MTU request was not accepted",
+                )))
+            }
+        } catch (e: Exception) {
+            completeMtu(gatt, Result.failure(
+                if (e is FlutterError) e else createFlutterError(
+                    UniversalBleErrorCode.FAILED,
+                    "Failed to request MTU",
+                    e.toString(),
+                )
+            ))
+        }
+    }
+
+    private fun postMtuResult(callback: (Result<Long>) -> Unit, result: Result<Long>) {
+        postToMainLooper {
+            try {
+                callback(result)
+            } catch (e: Exception) {
+                UniversalBleLogger.logError("MTU completion delivery failed: $e")
+            }
+        }
+    }
+
+    private fun completeMtu(gatt: BluetoothGatt, result: Result<Long>) {
+        val pending: List<MtuResultFuture>
+        synchronized(mtuResultFutureList) {
+            result.getOrNull()?.let { negotiatedMtus[gatt] = it.toInt() }
+            pending = mtuResultFutureList.filter { it.gatt === gatt }
+            mtuResultFutureList.removeAll(pending)
+        }
+        // GATT callbacks run on Binder threads. Match the main-looper delivery
+        // used by other BLE completions, after removing requests under the lock.
+        for (future in pending) postMtuResult(future.result, result)
     }
 
     override fun requestConnectionPriority(
@@ -1130,25 +1185,19 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
 
     override fun onMtuChanged(gatt: BluetoothGatt?, mtu: Int, status: Int) {
         val deviceId = gatt?.device?.address ?: return
-        mtuResultFutureList.removeAll {
-            if (it.deviceId == deviceId) {
-                if (status == BluetoothGatt.GATT_SUCCESS) {
-                    it.result(Result.success(mtu.toLong()))
-                } else {
-                    it.result(
-                        Result.failure(
-                            createFlutterError(
-                                UniversalBleErrorCode.FAILED,
-                                "Failed to change MTU"
-                            )
-                        )
-                    )
-                }
-                true
-            } else {
-                false
-            }
-        }
+        if (closingGatts.contains(gatt)) return
+        val current = deviceId.findGatt()
+        if (current != null && current !== gatt) return
+        UniversalBleLogger.logDebug("MTU_CHANGED <- $deviceId mtu=$mtu status=$status")
+        completeMtu(gatt, if (status == BluetoothGatt.GATT_SUCCESS) {
+            Result.success(mtu.toLong())
+        } else {
+            Result.failure(createFlutterError(
+                UniversalBleErrorCode.FAILED,
+                "Failed to change MTU",
+                status.toString(),
+            ))
+        })
     }
 
     override fun isPaired(deviceId: String, callback: (Result<Boolean>) -> Unit) {
@@ -1415,13 +1464,14 @@ class UniversalBlePlugin : UniversalBlePlatformChannel, BluetoothGattCallback(),
                 false
             }
         }
-        mtuResultFutureList.removeAll {
-            if (it.deviceId == deviceId) {
-                it.result(Result.failure(deviceDisconnectedError))
-                true
-            } else {
-                false
-            }
+        val pendingMtus: List<MtuResultFuture>
+        synchronized(mtuResultFutureList) {
+            pendingMtus = mtuResultFutureList.filter { it.deviceId == deviceId }
+            mtuResultFutureList.removeAll(pendingMtus)
+            negotiatedMtus.keys.removeAll { it.device.address == deviceId }
+        }
+        for (future in pendingMtus) {
+            postMtuResult(future.result, Result.failure(deviceDisconnectedError))
         }
         discoverServicesFutureList.removeAll {
             if (it.deviceId == deviceId) {

--- a/android/src/test/kotlin/com/navideck/universal_ble/MtuCompletionTest.kt
+++ b/android/src/test/kotlin/com/navideck/universal_ble/MtuCompletionTest.kt
@@ -1,0 +1,188 @@
+package com.navideck.universal_ble
+
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.os.Handler
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.mockito.Mockito
+
+internal class MtuCompletionTest {
+    private val address = "AA:BB:CC:DD:EE:FF"
+    private val posted = ConcurrentLinkedQueue<Runnable>()
+    private val plugin = UniversalBlePlugin().also {
+        val handler = Mockito.mock(Handler::class.java)
+        Mockito.doAnswer { call ->
+            posted.add(call.getArgument<Runnable>(0))
+            true
+        }.`when`(handler).post(Mockito.any())
+        val field = UniversalBlePlugin::class.java.getDeclaredField("mainThreadHandler")
+        field.isAccessible = true
+        field.set(it, handler)
+    }
+
+    private fun gatt(id: String = address): BluetoothGatt {
+        val device = Mockito.mock(BluetoothDevice::class.java)
+        Mockito.`when`(device.address).thenReturn(id)
+        return Mockito.mock(BluetoothGatt::class.java).also {
+            Mockito.`when`(it.device).thenReturn(device)
+            Mockito.`when`(it.requestMtu(Mockito.anyInt())).thenReturn(true)
+            it.saveCacheIfNeeded()
+        }
+    }
+
+    private fun drainMain() {
+        while (true) (posted.poll() ?: return).run()
+    }
+
+    @AfterTest
+    fun clearConnections() {
+        connectedGatts().forEach { it.removeCache() }
+    }
+
+    @Test
+    fun binderReplyIsDeliveredOnMainThreadExactlyOnce() {
+        val gatt = gatt()
+        val values = mutableListOf<Result<Long>>()
+        plugin.requestMtu(address, 247L) { values.add(it) }
+        Thread { plugin.onMtuChanged(gatt, 247, BluetoothGatt.GATT_SUCCESS) }.apply { start(); join() }
+        assertTrue(values.isEmpty(), "MTU replies should use the main-looper delivery shared by other BLE completions")
+        drainMain()
+        assertEquals(247L, values.single().getOrThrow())
+        plugin.onMtuChanged(gatt, 247, BluetoothGatt.GATT_SUCCESS)
+        drainMain()
+        assertEquals(1, values.size)
+    }
+
+    @Test
+    fun waiterIsRegisteredBeforeStartingTheNativeRequest() {
+        val gatt = gatt()
+        Mockito.doAnswer {
+            plugin.onMtuChanged(gatt, 247, BluetoothGatt.GATT_SUCCESS)
+            true
+        }.`when`(gatt).requestMtu(247)
+        val values = mutableListOf<Result<Long>>()
+        plugin.requestMtu(address, 247L) { values.add(it) }
+        drainMain()
+        assertEquals(247L, values.single().getOrThrow())
+    }
+
+    @Test
+    fun peerNegotiatedMtuIsReusedWithoutAnotherNativeRequest() {
+        val gatt = gatt()
+        plugin.onMtuChanged(gatt, 247, BluetoothGatt.GATT_SUCCESS)
+        val values = mutableListOf<Result<Long>>()
+        plugin.requestMtu(address, 247L) { values.add(it) }
+        drainMain()
+        assertEquals(247L, values.single().getOrThrow())
+        Mockito.verify(gatt, Mockito.never()).requestMtu(Mockito.anyInt())
+    }
+
+    @Test
+    fun insufficientNegotiatedMtuIsReportedWithoutInventingTheRequestedSize() {
+        val gatt = gatt()
+        val values = mutableListOf<Result<Long>>()
+        plugin.requestMtu(address, 247L) { values.add(it) }
+        plugin.onMtuChanged(gatt, 23, BluetoothGatt.GATT_SUCCESS)
+        drainMain()
+        assertEquals(23L, values.single().getOrThrow())
+    }
+
+    @Test
+    fun onlyAndroid14AndLaterReuseAnInsufficientObservedMtu() {
+        assertTrue(canReuseNegotiatedMtu(23, 247, 34))
+        assertTrue(canReuseNegotiatedMtu(23, 247, 37))
+        assertFalse(canReuseNegotiatedMtu(23, 247, 33))
+        assertTrue(canReuseNegotiatedMtu(247, 247, 21))
+    }
+
+    @Test
+    fun olderAndroidCanRequestAnIncreaseAfterAnEarlierNegotiation() {
+        // The local Android test stub reports SDK_INT=0 (the pre-14 path).
+        val gatt = gatt()
+        plugin.onMtuChanged(gatt, 23, BluetoothGatt.GATT_SUCCESS)
+        val values = mutableListOf<Result<Long>>()
+        plugin.requestMtu(address, 247L) { values.add(it) }
+        drainMain()
+        assertTrue(values.isEmpty())
+        Mockito.verify(gatt).requestMtu(247)
+        plugin.onMtuChanged(gatt, 247, BluetoothGatt.GATT_SUCCESS)
+        drainMain()
+        assertEquals(247L, values.single().getOrThrow())
+    }
+
+    @Test
+    fun rejectedNativeRequestFailsImmediatelyAndCanBeRetried() {
+        val gatt = gatt()
+        Mockito.`when`(gatt.requestMtu(247)).thenReturn(false, true)
+        val values = mutableListOf<Result<Long>>()
+        plugin.requestMtu(address, 247L) { values.add(it) }
+        drainMain()
+        assertTrue(values.single().isFailure)
+        plugin.requestMtu(address, 247L) { values.add(it) }
+        plugin.onMtuChanged(gatt, 247, BluetoothGatt.GATT_SUCCESS)
+        drainMain()
+        assertEquals(2, values.size)
+        assertEquals(247L, values.last().getOrThrow())
+    }
+
+    @Test
+    fun simultaneousRequestsShareOneNegotiation() {
+        val gatt = gatt()
+        val values = mutableListOf<Result<Long>>()
+        plugin.requestMtu(address, 247L) { values.add(it) }
+        plugin.requestMtu(address, 517L) { values.add(it) }
+        plugin.onMtuChanged(gatt, 247, BluetoothGatt.GATT_SUCCESS)
+        drainMain()
+        assertEquals(listOf(247L, 247L), values.map { it.getOrThrow() })
+        Mockito.verify(gatt, Mockito.times(1)).requestMtu(Mockito.anyInt())
+    }
+
+    @Test
+    fun oldGattCallbackCannotCompleteOrPopulateTheReconnectedGatt() {
+        val old = gatt()
+        plugin.onMtuChanged(old, 247, BluetoothGatt.GATT_SUCCESS)
+        plugin.disconnect(address)
+        drainMain()
+        val current = gatt()
+        val values = mutableListOf<Result<Long>>()
+        plugin.requestMtu(address, 247L) { values.add(it) }
+        plugin.onMtuChanged(old, 247, BluetoothGatt.GATT_SUCCESS)
+        drainMain()
+        assertTrue(values.isEmpty())
+        plugin.onMtuChanged(current, 185, BluetoothGatt.GATT_SUCCESS)
+        drainMain()
+        assertEquals(185L, values.single().getOrThrow())
+        Mockito.verify(current).requestMtu(247)
+    }
+
+    @Test
+    fun disconnectFailsPendingMtuAndLateSuccessCannotAcknowledgeIt() {
+        val gatt = gatt()
+        val values = mutableListOf<Result<Long>>()
+        plugin.requestMtu(address, 247L) { values.add(it) }
+        plugin.disconnect(address)
+        plugin.onMtuChanged(gatt, 247, BluetoothGatt.GATT_SUCCESS)
+        drainMain()
+        assertTrue(values.single().isFailure)
+    }
+
+    @Test
+    fun failedMtuStatusDoesNotBecomeACachedValue() {
+        val gatt = gatt()
+        val values = mutableListOf<Result<Long>>()
+        plugin.requestMtu(address, 247L) { values.add(it) }
+        plugin.onMtuChanged(gatt, 247, BluetoothGatt.GATT_FAILURE)
+        drainMain()
+        assertTrue(values.single().isFailure)
+        plugin.requestMtu(address, 247L) { values.add(it) }
+        plugin.onMtuChanged(gatt, 185, BluetoothGatt.GATT_SUCCESS)
+        drainMain()
+        assertEquals(185L, values.last().getOrThrow())
+        Mockito.verify(gatt, Mockito.times(2)).requestMtu(247)
+    }
+}


### PR DESCRIPTION
Android reconnects can report `onMtuChanged(247, GATT_SUCCESS)` while the Dart `requestMtu` future still times out. In the existing implementation, the waiter is registered after the native request, the pending list is accessed from both the platform and Binder threads without synchronization, and an MTU reported before the request is discarded.

This registers the waiter before calling Android, synchronizes pending-request completion, and delivers replies on the main looper consistently with the other BLE completion paths. It also handles native rejection immediately and coalesces requests already pending for the same GATT client.

Negotiated MTUs are retained per GATT client, so a reconnect cannot reuse an old connection's value or consume its late callback. The actual observed MTU is returned, including values smaller than requested. Android 13 and earlier can still request an increase; Android 14+ reuses the observed value because [subsequent MTU requests are ignored](https://developer.android.com/reference/android/bluetooth/BluetoothGatt#requestMtu(int)). Disconnect clears the cached value and fails pending requests.

Validation:

- Android native tests: 23 passed, including 11 MTU cases covering early callbacks, duplicate delivery, already negotiated MTU, native rejection, disconnect and stale reconnect callbacks. Run with Java 17 / Gradle 8.14.3 using the example project.
- Flutter tests: 109 passed.
- Chrome tests: 105 passed.
- Package and HIL analysis: passed with fatal infos enabled.
- Physical regression in a consuming app on a Pixel 6a (Android API 37): three background reconnect/read/disconnect cycles completed at MTU 247 without timeouts, followed by successful foreground recovery. This hardware check used the 2.3.0-based patch before porting it to current `main`; the API 37 MTU path is unchanged.

The native API and generated Pigeon files are unchanged.
